### PR TITLE
feat(op1we): adding op1we (and some other we models) to openmouse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -546,9 +546,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -563,9 +560,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -580,9 +574,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -597,9 +588,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -614,9 +602,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -631,9 +616,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -648,9 +630,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -665,9 +644,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -682,9 +658,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -699,9 +672,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -716,9 +686,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -733,9 +700,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -750,9 +714,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "test": "node --test src/egg-we-protocol.test.ts",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --host",
+    "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "preview": "vite preview --host"
+    "preview": "vite preview"
   },
   "devDependencies": {
     "typescript": "^5.8.3",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc --noEmit && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview --host"
   },
   "devDependencies": {
     "typescript": "^5.8.3",

--- a/src/control.ts
+++ b/src/control.ts
@@ -1394,10 +1394,6 @@ type PulsarToggleSetting = "motionSync" | "angleSnapping" | "rippleControl" | "p
 async function applyPulsarToggle(setting: PulsarToggleSetting, enabled: boolean): Promise<void> {
   const client = activePulsarClient ?? activeEggClient;
   if (!client || settingInProgress) return;
-  if (isEggWeClient(client)) {
-    setText("#read-status", "That sensor toggle is not exposed by this mouse.");
-    return;
-  }
   settingInProgress = true;
   setText("#read-status", `${enabled ? "Enabling" : "Disabling"} ${settingLabel(setting)}…`);
   try {
@@ -1567,19 +1563,13 @@ async function applyEggChange(label: string, change: (client: EggOp1HidClient) =
 }
 
 async function applyPulsarValue(setting: "debounce" | "sleep", value: number): Promise<void> {
-  const client = activePulsarClient
-    ?? (activeEggWeClient && setting === "debounce" ? activeEggWeClient : null);
-  if (!client || settingInProgress) return;
-  if (setting === "sleep" && !activePulsarClient) {
-    setText("#read-status", "Auto sleep is not available on this mouse.");
-    return;
-  }
+  if (!activePulsarClient || settingInProgress) return;
   settingInProgress = true;
   setText("#read-status", `Setting ${setting === "debounce" ? `${value} ms debounce` : "auto sleep"}…`);
   try {
-    if (setting === "debounce") await client.setDebounceTime(value);
-    else if (activePulsarClient) await activePulsarClient.setSleepTimeout(value);
-    showStatus(await client.readStatus());
+    if (setting === "debounce") await activePulsarClient.setDebounceTime(value);
+    else await activePulsarClient.setSleepTimeout(value);
+    showStatus(await activePulsarClient.readStatus());
   } catch (error) {
     setText("#read-status", error instanceof Error ? error.message : "Unable to change that setting.");
   } finally {

--- a/src/control.ts
+++ b/src/control.ts
@@ -857,11 +857,30 @@ function escapeHtml(value: string): string {
   })[character]!);
 }
 
+/**
+ * Collapse Endgame WE cable + receiver into one logical mouse.
+ * Prefer the USB mouse interface when both are present; otherwise use the
+ * receiver as the wireless path to that same mouse.
+ */
+function listLogicalDevices(devices?: HIDDevice[]): HIDDevice[] {
+  const supported = (devices ?? [])
+    .filter((device) => createSupportedClient(device) !== null);
+  const we = supported.filter((device) => EggWeHidClient.isSupported(device));
+  const other = supported.filter((device) => !EggWeHidClient.isSupported(device));
+  if (we.length === 0) return supported;
+
+  const mice = we.filter((device) => !EggWeHidClient.isReceiverDevice(device));
+  const receivers = we.filter((device) => EggWeHidClient.isReceiverDevice(device));
+  if (mice.length > 0) return [...other, ...mice];
+  // Wireless-only: one receiver entry represents the mouse.
+  return [...other, ...receivers.slice(0, 1)];
+}
+
 async function renderDeviceSidebar(devices?: HIDDevice[]): Promise<void> {
   const list = document.querySelector<HTMLElement>("#sidebar-device-list");
   if (!list) return;
-  const supportedDevices = (devices ?? await navigator.hid?.getDevices() ?? [])
-    .filter((device) => createSupportedClient(device) !== null);
+  const all = devices ?? await navigator.hid?.getDevices() ?? [];
+  const supportedDevices = listLogicalDevices(all);
   if (supportedDevices.length === 0) {
     list.innerHTML = `<div class="device-select"><span class="device-dot is-idle"></span><span><strong>No device connected</strong><small>Choose a supported device</small></span></div>`;
     return;
@@ -870,8 +889,14 @@ async function renderDeviceSidebar(devices?: HIDDevice[]): Promise<void> {
     const client = createSupportedClient(device)!;
     const status = deviceStatuses.get(device);
     const selected = device === activeDevice;
-    const name = status?.name ?? device.productName ?? `${deviceBrand(client)} mouse`;
-    const detail = status ? `${status.brand} · Connected` : `${deviceBrand(client)} · Available`;
+    const viaReceiver = client instanceof EggWeHidClient && EggWeHidClient.isReceiverDevice(device);
+    const name = status?.name
+      ?? (viaReceiver ? "Endgame Gear OP1we" : (device.productName ?? `${deviceBrand(client)} mouse`));
+    const detail = status
+      ? `${status.brand} · ${status.connectionType ?? "Connected"}`
+      : viaReceiver
+        ? `${deviceBrand(client)} · Wireless receiver`
+        : `${deviceBrand(client)} · Available`;
     return `<button class="device-select${selected ? " is-selected" : ""}" type="button" data-device-index="${index}" aria-pressed="${selected}">
       <span class="device-dot${selected ? "" : " is-idle"}"></span>
       <span><strong>${escapeHtml(name)}</strong><small>${escapeHtml(detail)}</small></span>
@@ -881,8 +906,7 @@ async function renderDeviceSidebar(devices?: HIDDevice[]): Promise<void> {
 
 async function selectAuthorizedDevice(index: number): Promise<void> {
   if (settingInProgress || refreshInProgress) return;
-  const devices = (await navigator.hid?.getDevices() ?? [])
-    .filter((device) => createSupportedClient(device) !== null);
+  const devices = listLogicalDevices(await navigator.hid?.getDevices() ?? []);
   const device = devices[index];
   if (!device || device === activeDevice) return;
   const client = createSupportedClient(device);
@@ -1017,11 +1041,13 @@ async function requestSupportedClient(): Promise<SupportedClient | null> {
   });
   if (devices.length === 0) return null;
 
-  // Prefer the interface that scores highest for its brand driver (e.g. WE feature 0xa1).
+  // Prefer the interface that scores highest for its brand driver.
+  // For WE: prefer the mouse USB interface over a separate receiver entry.
   const ranked = devices
     .map((device) => ({ device, client: createSupportedClient(device), score: clientSupportScore(device) }))
+    .filter((entry) => entry.client !== null)
     .sort((left, right) => right.score - left.score);
-  const best = ranked.find((entry) => entry.client !== null);
+  const best = ranked[0];
   if (best?.client) return best.client;
 
   const details = devices.map((device) => describeHidDevice(device)).join(" · ");
@@ -1099,7 +1125,11 @@ async function reconnectAuthorizedDevice(): Promise<void> {
     for (const delay of retryDelays) {
       if (delay) await waitForHidChange(delay);
       const devices = await navigator.hid?.getDevices() ?? [];
-      const clients = devices.map(createSupportedClient).filter((candidate): candidate is SupportedClient => candidate !== null);
+      const clients = listLogicalDevices(devices)
+        .map((device) => ({ client: createSupportedClient(device), score: clientSupportScore(device) }))
+        .filter((entry): entry is { client: SupportedClient; score: number } => entry.client !== null)
+        .sort((left, right) => right.score - left.score)
+        .map((entry) => entry.client);
       await renderDeviceSidebar(devices);
       for (const client of clients) {
         try {

--- a/src/control.ts
+++ b/src/control.ts
@@ -589,19 +589,18 @@ function resetDeviceSpecificPanels(): void {
 
 function showStatus(status: MouseStatus): void {
   lastRenderedStatusKey = JSON.stringify(status);
-  const isEgg8k = status.brand === "Endgame Gear" && status.connectionDetail?.includes("WE protocol") !== true
-    && (status.eggCpiStages !== undefined || status.leftSpdtMode !== undefined || activeEggClient !== null);
-  const isEggWe = status.brand === "Endgame Gear" && (
-    status.connectionDetail?.includes("WE protocol") === true || activeEggWeClient !== null
-  );
+  // 8K exposes CPI stages / GX; WE does not.
+  const isEgg8k = status.brand === "Endgame Gear" && Array.isArray(status.eggCpiStages);
+  const isEggWe = status.brand === "Endgame Gear" && !isEgg8k;
   const isEgg = isEgg8k || isEggWe;
+  const weSettingsPending = isEggWe && !EggWeHidClient.settingsMapped;
   const isWired = status.connectionType === "Wired";
   // Always clear device-specific panels first. A status read from the previous
   // mouse may have left these visible when WebHID switches devices.
   resetDeviceSpecificPanels();
   const batterySummary = document.querySelector<HTMLElement>("#battery-summary");
   if (batterySummary) {
-    // WE mice report battery even when cable-connected (charging); 8K is wired-only.
+    // 8K is wired-only (no battery). WE and wireless mice show the battery column.
     const hideBattery = isEgg8k || (isWired && !isEggWe && status.batteryPercent === null);
     batterySummary.hidden = hideBattery;
     batterySummary.style.display = hideBattery ? "none" : "flex";
@@ -620,9 +619,8 @@ function showStatus(status: MouseStatus): void {
   }
   const debounceSettings = document.querySelector<HTMLElement>("#debounce-settings");
   if (debounceSettings) {
-    // Debounce: Pulsar when reported; WE only once settings map is reverse-engineered.
     const showDebounce = status.debounceMs !== null && status.debounceMs !== undefined
-      && (status.brand === "Pulsar" || (isEggWe && EggWeHidClient.settingsMapped));
+      && status.brand === "Pulsar";
     debounceSettings.hidden = !showDebounce;
   }
   const performanceModeSetting = document.querySelector<HTMLElement>("#performance-mode-setting");
@@ -630,7 +628,6 @@ function showStatus(status: MouseStatus): void {
     performanceModeSetting.hidden = isEgg;
     performanceModeSetting.style.display = isEgg ? "none" : "flex";
   }
-  // Motion Sync / angle / ripple card is Pulsar (+ 8K partially via other cards). Hide for WE.
   const processingCard = document.querySelector<HTMLElement>("#motion-sync-toggle")?.closest<HTMLElement>(".setting-card");
   if (processingCard && processingCard.id !== "egg-filter-settings") {
     processingCard.style.display = isEggWe ? "none" : "";
@@ -641,7 +638,11 @@ function showStatus(status: MouseStatus): void {
   setText("#battery-value", battery);
   setText("#battery-detail", batteryDetail(status));
   setText("#firmware-value", status.firmware[0] ?? "—");
-  setText("#firmware-detail", status.firmware.slice(1).join(" · ") || "Firmware reported by mouse");
+  setText("#firmware-detail", status.firmware.length > 1
+    ? status.firmware.slice(1).join(" · ")
+    : status.firmware.length === 1
+      ? "Firmware reported by mouse"
+      : "Not reported");
   setText("#connection-value", status.connectionType ?? "Wireless");
   setText("#connection-detail", status.connectionDetail
     ?? (status.activeProfile ? `2.4 GHz · Profile ${status.activeProfile}` : "2.4 GHz receiver"));
@@ -655,12 +656,14 @@ function showStatus(status: MouseStatus): void {
   }
   const advanced = document.querySelector<HTMLElement>("#pulsar-advanced");
   if (advanced) {
-    const showAdvanced = status.brand === "Pulsar"
-      || isEgg8k
-      || (isEggWe && EggWeHidClient.settingsMapped);
+    const showAdvanced = status.brand === "Pulsar" || isEgg8k;
     advanced.style.display = showAdvanced ? "grid" : "none";
     advanced.classList.toggle("egg-advanced-layout", isEgg8k);
   }
+  // Hide DPI / polling / LOD until WE settings are mapped — same overview-only look as early empty state.
+  const settingsGrid = document.querySelector<HTMLElement>(".settings-grid.device-data");
+  if (settingsGrid) settingsGrid.style.display = weSettingsPending ? "none" : "";
+
   if (status.brand === "Pulsar" || status.brand === "Endgame Gear") {
     const strength = status.signalStrength;
     setText("#signal-output", strength === null || strength === undefined ? "—" : `${strength}/4`);
@@ -678,7 +681,6 @@ function showStatus(status: MouseStatus): void {
     const eggPollingSettings = document.querySelector<HTMLElement>("#egg-polling-settings");
     const eggCpiSettings = document.querySelector<HTMLElement>("#egg-cpi-settings");
     const eggButtonSettings = document.querySelector<HTMLElement>("#egg-button-settings");
-    // 8K-only panels — never show for WE series.
     if (eggFilterSettings) eggFilterSettings.style.display = isEgg8k ? "block" : "none";
     if (eggSpdtSettings) eggSpdtSettings.style.display = isEgg8k ? "block" : "none";
     if (eggPollingSettings) eggPollingSettings.style.display = isEgg8k && interfacePreferences.showExperimental ? "block" : "none";
@@ -710,18 +712,12 @@ function showStatus(status: MouseStatus): void {
     void renderDeviceSidebar();
   }
   setText("#device-status", "Connected");
-  const weSettingsPending = isEggWe && !EggWeHidClient.settingsMapped;
-  setText("#connection-banner", weSettingsPending
-    ? (status.connectionType === "Wireless"
-      ? "OP1we (via receiver). Config HID is idle so the mouse does not freeze. Settings need WE software capture."
-      : "OP1we (USB). Battery approximate if shown; settings need WE software capture.")
-    : "Connected directly through WebHID. Supported settings can be adjusted here.");
+  // Same banner copy as other brands — no RE/debug messaging in the chrome.
+  setText("#connection-banner", "Connected directly through WebHID. Supported settings can be adjusted here.");
   if (weSettingsPending) {
-    setText("#read-status", status.connectionType === "Wireless"
-      ? "Wireless path · no config HID · settings map pending"
-      : (status.batteryPercent === null
-        ? `Connected · ${status.connectionDetail ?? ""}`
-        : `Battery ~${status.batteryPercent}% (approx) · settings map pending`));
+    setText("#read-status", status.batteryPercent === null
+      ? "Connected"
+      : `Battery ${status.batteryPercent}%`);
   } else {
     setText("#read-status", `Current: ${status.dpi.toLocaleString()} DPI · ${status.pollingRateHz.toLocaleString()} Hz`);
   }
@@ -737,27 +733,24 @@ function showStatus(status: MouseStatus): void {
     const unsupportedForEgg8k = isEgg8k && rate < 1000;
     const unsupportedForListed = Array.isArray(supportedRates) && !supportedRates.includes(rate);
     const unsupportedForLogitech = status.brand === "Logitech" && unsupportedForListed;
-    const unsupportedForWe = isEggWe && (weSettingsPending || unsupportedForListed);
-    const hide = unsupportedForEgg8k || unsupportedForLogitech || unsupportedForWe;
-    button.hidden = hide || weSettingsPending;
-    button.disabled = hide || weSettingsPending;
+    const hide = unsupportedForEgg8k || unsupportedForLogitech || weSettingsPending;
+    button.hidden = hide;
+    button.disabled = hide;
   });
   document.querySelectorAll<HTMLButtonElement>("[data-lod]").forEach((button) => {
     const unsupportedForEgg = isEgg && button.dataset.lod === "Low";
-    const disableWe = weSettingsPending || status.liftOffDistance === null;
     button.hidden = unsupportedForEgg || weSettingsPending;
-    button.disabled = unsupportedForEgg || disableWe || (status.brand === "Logitech" && button.dataset.lod === "Low");
+    button.disabled = unsupportedForEgg || weSettingsPending
+      || (status.brand === "Logitech" && button.dataset.lod === "Low");
   });
   document.querySelectorAll<HTMLButtonElement>("[data-dpi]").forEach((button) => {
     button.classList.toggle("selected", Number(button.dataset.dpi) === status.dpi);
-    if (weSettingsPending) {
-      button.disabled = true;
-    }
+    button.disabled = weSettingsPending;
   });
   const customDpi = document.querySelector<HTMLButtonElement>("#custom-dpi");
   if (customDpi) customDpi.disabled = weSettingsPending;
   if (dpiOutputField && weSettingsPending) {
-    dpiOutputField.value = "Pending RE";
+    dpiOutputField.value = "—";
     dpiOutputField.readOnly = true;
   }
   const axisControls = document.querySelector<HTMLElement>("#logitech-axis-controls");

--- a/src/control.ts
+++ b/src/control.ts
@@ -614,9 +614,9 @@ function showStatus(status: MouseStatus): void {
   }
   const debounceSettings = document.querySelector<HTMLElement>("#debounce-settings");
   if (debounceSettings) {
-    // Debounce: WE series + Pulsar. Not exposed on OP1 8K.
-    const showDebounce = isEggWe
-      || (status.brand === "Pulsar" && status.debounceMs !== null && status.debounceMs !== undefined);
+    // Debounce: Pulsar when reported; WE only once settings map is reverse-engineered.
+    const showDebounce = status.debounceMs !== null && status.debounceMs !== undefined
+      && (status.brand === "Pulsar" || (isEggWe && EggWeHidClient.settingsMapped));
     debounceSettings.hidden = !showDebounce;
   }
   const performanceModeSetting = document.querySelector<HTMLElement>("#performance-mode-setting");
@@ -630,8 +630,8 @@ function showStatus(status: MouseStatus): void {
     processingCard.style.display = isEggWe ? "none" : "";
   }
   const battery = status.batteryPercent === null ? "—" : `${status.batteryPercent}%`;
-  const dpiOutput = document.querySelector<HTMLInputElement>("#dpi-output");
-  if (dpiOutput?.readOnly) dpiOutput.value = `${status.dpi.toLocaleString()} DPI`;
+  const dpiOutputField = document.querySelector<HTMLInputElement>("#dpi-output");
+  if (dpiOutputField?.readOnly) dpiOutputField.value = `${status.dpi.toLocaleString()} DPI`;
   setText("#battery-value", battery);
   setText("#battery-detail", batteryDetail(status));
   setText("#firmware-value", status.firmware[0] ?? "—");
@@ -649,7 +649,10 @@ function showStatus(status: MouseStatus): void {
   }
   const advanced = document.querySelector<HTMLElement>("#pulsar-advanced");
   if (advanced) {
-    advanced.style.display = status.brand === "Pulsar" || status.brand === "Endgame Gear" ? "grid" : "none";
+    const showAdvanced = status.brand === "Pulsar"
+      || isEgg8k
+      || (isEggWe && EggWeHidClient.settingsMapped);
+    advanced.style.display = showAdvanced ? "grid" : "none";
     advanced.classList.toggle("egg-advanced-layout", isEgg8k);
   }
   if (status.brand === "Pulsar" || status.brand === "Endgame Gear") {
@@ -701,8 +704,17 @@ function showStatus(status: MouseStatus): void {
     void renderDeviceSidebar();
   }
   setText("#device-status", "Connected");
-  setText("#connection-banner", "Connected directly through WebHID. Supported settings can be adjusted here.");
-  setText("#read-status", `Current: ${status.dpi.toLocaleString()} DPI · ${status.pollingRateHz.toLocaleString()} Hz`);
+  const weSettingsPending = isEggWe && !EggWeHidClient.settingsMapped;
+  setText("#connection-banner", weSettingsPending
+    ? "OP1we connected. Battery uses a known HID command; CPI/polling/LOD need a capture from WE Series software."
+    : "Connected directly through WebHID. Supported settings can be adjusted here.");
+  if (weSettingsPending) {
+    setText("#read-status", status.batteryPercent === null
+      ? `Battery not parsed yet. ${status.connectionDetail ?? ""}`
+      : `Battery ${status.batteryPercent}% · settings map pending reverse-engineering`);
+  } else {
+    setText("#read-status", `Current: ${status.dpi.toLocaleString()} DPI · ${status.pollingRateHz.toLocaleString()} Hz`);
+  }
   const meter = document.querySelector<HTMLElement>("#battery-meter");
   if (meter) meter.style.width = status.batteryPercent === null ? "0%" : `${status.batteryPercent}%`;
   document.querySelectorAll<HTMLElement>(".device-dot, .status-dot").forEach((dot) => dot.classList.remove("is-idle"));
@@ -715,17 +727,29 @@ function showStatus(status: MouseStatus): void {
     const unsupportedForEgg8k = isEgg8k && rate < 1000;
     const unsupportedForListed = Array.isArray(supportedRates) && !supportedRates.includes(rate);
     const unsupportedForLogitech = status.brand === "Logitech" && unsupportedForListed;
-    const unsupportedForWe = isEggWe && unsupportedForListed;
+    const unsupportedForWe = isEggWe && (weSettingsPending || unsupportedForListed);
     const hide = unsupportedForEgg8k || unsupportedForLogitech || unsupportedForWe;
-    button.hidden = hide;
-    button.disabled = hide;
+    button.hidden = hide || weSettingsPending;
+    button.disabled = hide || weSettingsPending;
   });
   document.querySelectorAll<HTMLButtonElement>("[data-lod]").forEach((button) => {
     const unsupportedForEgg = isEgg && button.dataset.lod === "Low";
-    button.hidden = unsupportedForEgg;
-    button.disabled = unsupportedForEgg || (status.brand === "Logitech" && button.dataset.lod === "Low");
+    const disableWe = weSettingsPending || status.liftOffDistance === null;
+    button.hidden = unsupportedForEgg || weSettingsPending;
+    button.disabled = unsupportedForEgg || disableWe || (status.brand === "Logitech" && button.dataset.lod === "Low");
   });
-  document.querySelectorAll<HTMLButtonElement>("[data-dpi]").forEach((button) => button.classList.toggle("selected", Number(button.dataset.dpi) === status.dpi));
+  document.querySelectorAll<HTMLButtonElement>("[data-dpi]").forEach((button) => {
+    button.classList.toggle("selected", Number(button.dataset.dpi) === status.dpi);
+    if (weSettingsPending) {
+      button.disabled = true;
+    }
+  });
+  const customDpi = document.querySelector<HTMLButtonElement>("#custom-dpi");
+  if (customDpi) customDpi.disabled = weSettingsPending;
+  if (dpiOutputField && weSettingsPending) {
+    dpiOutputField.value = "Pending RE";
+    dpiOutputField.readOnly = true;
+  }
   const axisControls = document.querySelector<HTMLElement>("#logitech-axis-controls");
   if (axisControls) axisControls.style.display = status.brand === "Logitech" && status.supportsSeparateDpiAxes ? "block" : "none";
   const dpiX = document.querySelector<HTMLInputElement>("#logitech-dpi-x");
@@ -896,6 +920,17 @@ async function activateClient(client: SupportedClient): Promise<void> {
     dpiOptions = client.getDpiOptions();
     configureDpiControl(status.dpi);
     showStatus(status);
+    // Log battery framing diagnostics for reverse-engineering when % is missing.
+    if (status.batteryPercent === null) {
+      void client.probeBattery().then((report) => {
+        console.info("[OpenMouse WE battery probe]\n" + report);
+        if (activeEggWeClient === client) {
+          setText("#read-status", `Battery probe finished — see DevTools console. ${status.connectionDetail ?? ""}`);
+        }
+      }).catch((error: unknown) => {
+        console.warn("[OpenMouse WE battery probe]", error);
+      });
+    }
   } else if (client instanceof LogitechHidppClient) {
     activeClient = client;
     const status = await client.readStatus();

--- a/src/control.ts
+++ b/src/control.ts
@@ -984,6 +984,38 @@ function handleHidConnect(event: HIDConnectionEvent): void {
     void renderDeviceSidebar();
     return;
   }
+
+  // WE cable + receiver (or multi-interface USB) must not activate twice.
+  if (client instanceof EggWeHidClient) {
+    void (async () => {
+      const all = await navigator.hid?.getDevices() ?? [];
+      await renderDeviceSidebar(all);
+      const preferred = EggWeHidClient.pickDevices(all)[0];
+      if (!preferred) return;
+      // Ignore secondary interface (e.g. receiver while cable is preferred).
+      if (preferred !== event.device && activeDevice === preferred) return;
+      if (preferred !== event.device) {
+        // A better path appeared (cable over receiver) — switch once.
+        const next = createSupportedClient(preferred);
+        if (!next || next.device === activeDevice) return;
+        setText("#device-status", "Switching path");
+        setText("#read-status", "Preferring OP1we USB over receiver.");
+        await activateClient(next);
+        return;
+      }
+      if (activeDevice === preferred) return;
+      setText("#device-status", "New device detected");
+      setText("#read-status", "Reading Endgame Gear OP1we.");
+      await activateClient(new EggWeHidClient(preferred));
+    })().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : "Unable to read the connected mouse.";
+      setText("#device-status", "Connection failed");
+      setText("#read-status", message);
+      void renderDeviceSidebar();
+    });
+    return;
+  }
+
   setText("#device-status", "New device detected");
   setText("#read-status", `Reading ${event.device.productName || "the connected mouse"}.`);
   void activateClient(client).catch((error: unknown) => {
@@ -1004,7 +1036,8 @@ function handleHidDisconnect(event: HIDConnectionEvent): void {
   void (async () => {
     const devices = (await navigator.hid?.getDevices() ?? [])
       .filter((device) => device !== event.device);
-    const replacement = devices
+    const logical = listLogicalDevices(devices);
+    const replacement = logical
       .map(createSupportedClient)
       .find((client): client is SupportedClient => client !== null);
     if (replacement) {

--- a/src/control.ts
+++ b/src/control.ts
@@ -980,11 +980,40 @@ async function requestSupportedClient(): Promise<SupportedClient | null> {
       { vendorId: 0x046d, productId: 0xc54d, usagePage: 0xff00, usage: 0x0001 },
     ],
   });
-  for (const device of devices) {
-    const client = createSupportedClient(device);
-    if (client) return client;
-  }
-  return null;
+  if (devices.length === 0) return null;
+
+  // Prefer the interface that scores highest for its brand driver (e.g. WE feature 0xa1).
+  const ranked = devices
+    .map((device) => ({ device, client: createSupportedClient(device), score: clientSupportScore(device) }))
+    .sort((left, right) => right.score - left.score);
+  const best = ranked.find((entry) => entry.client !== null);
+  if (best?.client) return best.client;
+
+  const details = devices.map((device) => describeHidDevice(device)).join(" · ");
+  throw new Error(
+    `Selected device is not a supported control interface (${details}). `
+    + "Pick the OP1we entry that is not a plain boot mouse, or try the receiver. "
+    + "If this keeps failing, note the VID/PID from this message.",
+  );
+}
+
+function clientSupportScore(device: HIDDevice): number {
+  if (EggOp1HidClient.isSupported(device)) return 10;
+  if (EggWeHidClient.isSupported(device)) return EggWeHidClient.supportScore(device);
+  if (PulsarProHidClient.isSupported(device)) return 8;
+  if (PulsarHidClient.isSupported(device)) return 7;
+  if (LogitechHidppClient.isSupported(device)) return 6;
+  return 0;
+}
+
+function describeHidDevice(device: HIDDevice): string {
+  const name = device.productName || "unknown";
+  const ids = `VID 0x${device.vendorId.toString(16)} PID 0x${device.productId.toString(16)}`;
+  const collections = device.collections.map((collection) => {
+    const features = collection.featureReports.map((report) => `0x${report.reportId.toString(16)}`).join(",") || "none";
+    return `usage 0x${collection.usagePage.toString(16)}:${collection.usage.toString(16)} feat[${features}]`;
+  }).join(" | ") || "no collections";
+  return `${name} (${ids}; ${collections})`;
 }
 
 async function connect(): Promise<void> {
@@ -998,9 +1027,11 @@ async function connect(): Promise<void> {
     const client = await requestSupportedClient();
     if (!client) {
       setText("#device-status", "Not connected");
-      setText("#read-status", "No supported device was selected.");
+      setText("#read-status", "No device was selected in the browser prompt.");
       return;
     }
+    setText("#device-status", "Opening device");
+    setText("#read-status", `Reading ${client.device.productName || "device"}…`);
     await activateClient(client);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unable to read the mouse.";

--- a/src/control.ts
+++ b/src/control.ts
@@ -706,12 +706,14 @@ function showStatus(status: MouseStatus): void {
   setText("#device-status", "Connected");
   const weSettingsPending = isEggWe && !EggWeHidClient.settingsMapped;
   setText("#connection-banner", weSettingsPending
-    ? "OP1we connected. Battery uses a known HID command; CPI/polling/LOD need a capture from WE Series software."
+    ? (status.connectionType === "Wireless"
+      ? "OP1we via receiver — HID polling disabled to avoid freezing the mouse. Battery is approximate; settings need WE software capture."
+      : "OP1we connected over USB. Battery is approximate; CPI/polling/LOD need a capture from WE Series software.")
     : "Connected directly through WebHID. Supported settings can be adjusted here.");
   if (weSettingsPending) {
     setText("#read-status", status.batteryPercent === null
-      ? `Battery not parsed yet. ${status.connectionDetail ?? ""}`
-      : `Battery ${status.batteryPercent}% · settings map pending reverse-engineering`);
+      ? `Battery unread. ${status.connectionDetail ?? ""}`
+      : `Battery ~${status.batteryPercent}% (approx) · no auto-refresh · settings map pending`);
   } else {
     setText("#read-status", `Current: ${status.dpi.toLocaleString()} DPI · ${status.pollingRateHz.toLocaleString()} Hz`);
   }
@@ -939,22 +941,13 @@ async function activateClient(client: SupportedClient): Promise<void> {
     showStatus(status);
   } else if (client instanceof EggWeHidClient) {
     activeEggWeClient = client;
+    // Single gentle status read only — never multi-command probe on connect
+    // (flooding the dongle freezes the OP1we).
     const status = await client.readStatus();
     deviceStatuses.set(client.device, status);
     dpiOptions = client.getDpiOptions();
     configureDpiControl(status.dpi);
     showStatus(status);
-    // Log battery framing diagnostics for reverse-engineering when % is missing.
-    if (status.batteryPercent === null) {
-      void client.probeBattery().then((report) => {
-        console.info("[OpenMouse WE battery probe]\n" + report);
-        if (activeEggWeClient === client) {
-          setText("#read-status", `Battery probe finished — see DevTools console. ${status.connectionDetail ?? ""}`);
-        }
-      }).catch((error: unknown) => {
-        console.warn("[OpenMouse WE battery probe]", error);
-      });
-    }
   } else if (client instanceof LogitechHidppClient) {
     activeClient = client;
     const status = await client.readStatus();
@@ -1542,6 +1535,12 @@ async function applyProSetting(setting: "wheelAcceleration" | "angleTuning" | "p
 
 function startAutomaticRefresh(): void {
   if (refreshTimer !== null) window.clearInterval(refreshTimer);
+  // OP1we over the dongle freezes if we poll feature reports every few seconds.
+  // Read once on connect only; other brands keep a light refresh.
+  if (activeEggWeClient) {
+    refreshTimer = null;
+    return;
+  }
   refreshTimer = window.setInterval(() => {
     void refreshStatus();
   }, 5000);
@@ -1550,6 +1549,8 @@ function startAutomaticRefresh(): void {
 async function refreshStatus(): Promise<void> {
   const client = activeSettingsClient();
   if (!client || refreshInProgress || settingInProgress) return;
+  // Never background-poll WE — wireless path is sensitive to HID chatter.
+  if (client instanceof EggWeHidClient) return;
   refreshInProgress = true;
   try {
     const status = await client.readStatus();

--- a/src/control.ts
+++ b/src/control.ts
@@ -7,7 +7,21 @@ import {
   type EggButtonMapping,
   type EggSpdtMode,
 } from "./egg-op1-hid";
-import { EggWeHidClient } from "./egg-we-hid";
+import {
+  EGG_WE_DISPLAY_NAME,
+  EGG_WE_HID_FILTERS,
+  eggWeAuthorizedPool,
+  eggWeCreate,
+  eggWeFromAuthorized,
+  eggWeIsSupported,
+  eggWeMergeLogicalDevices,
+  eggWeOwnsDevice,
+  eggWePrepare,
+  eggWeResolveConnect,
+  eggWeSupportScore,
+  isEggWeClient,
+  type EggWeHidClient,
+} from "./egg-we-control";
 import { LogitechHidppClient } from "./logitech-hidpp";
 import type { MouseStatus } from "./mouse-types";
 import { PulsarHidClient } from "./pulsar-hid";
@@ -377,7 +391,7 @@ function renderControl(): void {
   document.querySelector<HTMLButtonElement>("#dongle-led-toggle")?.addEventListener("click", () => {
     void toggleDongleLed();
   });
-  for (let debounce = 0; debounce <= 15; debounce += 1) {
+  for (let debounce = 0; debounce <= 20; debounce += 1) {
     document.querySelector<HTMLSelectElement>("#debounce-select")?.add(new Option(`${debounce} ms`, String(debounce)));
   }
   for (let angle = -30; angle <= 30; angle += 1) {
@@ -589,30 +603,40 @@ function resetDeviceSpecificPanels(): void {
 
 function showStatus(status: MouseStatus): void {
   lastRenderedStatusKey = JSON.stringify(status);
-  // 8K exposes CPI stages / GX; WE does not.
-  const isEgg8k = status.brand === "Endgame Gear" && Array.isArray(status.eggCpiStages);
-  const isEggWe = status.brand === "Endgame Gear" && !isEgg8k;
+  // Driver UI hints (e.g. status.ui.family === "egg-we") avoid brand-specific imports.
+  const ui = status.ui;
+  const isEgg8k = activeEggClient !== null
+    || (status.brand === "Endgame Gear" && Array.isArray(status.eggCpiStages));
+  const isEggWe = ui?.family === "egg-we" || activeEggWeClient !== null;
   const isEgg = isEgg8k || isEggWe;
-  const weSettingsPending = isEggWe && !EggWeHidClient.settingsMapped;
+  const settingsPending = ui?.settingsReady === false;
   const isWired = status.connectionType === "Wired";
   // Always clear device-specific panels first. A status read from the previous
   // mouse may have left these visible when WebHID switches devices.
   resetDeviceSpecificPanels();
   const batterySummary = document.querySelector<HTMLElement>("#battery-summary");
   if (batterySummary) {
-    // 8K is wired-only (no battery). WE and wireless mice show the battery column.
-    const hideBattery = isEgg8k || (isWired && !isEggWe && status.batteryPercent === null);
+    // 8K is wired-only (no battery). Drivers may force the column via ui.forceShowBattery.
+    const hideBattery = isEgg8k
+      || (isWired && !ui?.forceShowBattery && status.batteryPercent === null);
     batterySummary.hidden = hideBattery;
     batterySummary.style.display = hideBattery ? "none" : "flex";
   }
   const overview = document.querySelector<HTMLElement>(".device-overview");
   if (overview) {
-    const showBatteryColumn = !isEgg8k && (isEggWe || !isWired || status.batteryPercent !== null);
+    const showBatteryColumn = !isEgg8k
+      && (ui?.forceShowBattery || !isWired || status.batteryPercent !== null);
     overview.style.gridTemplateColumns = showBatteryColumn ? "repeat(3, 1fr)" : "repeat(2, 1fr)";
   }
-  setText("#polling-note", isEgg8k
-    ? "Higher rates update cursor movement more often and increase CPU/USB processing load."
-    : "Higher rates update cursor movement more often, but use more battery.");
+  setText("#polling-note", ui?.pollingNote
+    ?? (isEgg8k
+      ? "Higher rates update cursor movement more often and increase CPU/USB processing load."
+      : "Higher rates update cursor movement more often, but use more battery."));
+  const pollingCard = document.querySelector<HTMLElement>("[data-rate]")?.closest<HTMLElement>(".setting-card");
+  if (pollingCard) {
+    pollingCard.hidden = false;
+    pollingCard.style.display = "";
+  }
   for (const selector of ["#signal-settings", "#sleep-settings"]) {
     const element = document.querySelector<HTMLElement>(selector);
     if (element) element.hidden = isEgg;
@@ -630,7 +654,7 @@ function showStatus(status: MouseStatus): void {
   }
   const processingCard = document.querySelector<HTMLElement>("#motion-sync-toggle")?.closest<HTMLElement>(".setting-card");
   if (processingCard && processingCard.id !== "egg-filter-settings") {
-    processingCard.style.display = isEggWe ? "none" : "";
+    processingCard.style.display = ui?.hideProcessingCard ? "none" : "";
   }
   const battery = status.batteryPercent === null ? "—" : `${status.batteryPercent}%`;
   const dpiOutputField = document.querySelector<HTMLInputElement>("#dpi-output");
@@ -660,9 +684,8 @@ function showStatus(status: MouseStatus): void {
     advanced.style.display = showAdvanced ? "grid" : "none";
     advanced.classList.toggle("egg-advanced-layout", isEgg8k);
   }
-  // Hide DPI / polling / LOD until WE settings are mapped — same overview-only look as early empty state.
   const settingsGrid = document.querySelector<HTMLElement>(".settings-grid.device-data");
-  if (settingsGrid) settingsGrid.style.display = weSettingsPending ? "none" : "";
+  if (settingsGrid) settingsGrid.style.display = settingsPending ? "none" : "";
 
   if (status.brand === "Pulsar" || status.brand === "Endgame Gear") {
     const strength = status.signalStrength;
@@ -714,7 +737,7 @@ function showStatus(status: MouseStatus): void {
   setText("#device-status", "Connected");
   // Same banner copy as other brands — no RE/debug messaging in the chrome.
   setText("#connection-banner", "Connected directly through WebHID. Supported settings can be adjusted here.");
-  if (weSettingsPending) {
+  if (settingsPending) {
     setText("#read-status", status.batteryPercent === null
       ? "Connected"
       : `Battery ${status.batteryPercent}%`);
@@ -732,24 +755,25 @@ function showStatus(status: MouseStatus): void {
     const supportedRates = status.supportedPollingRates;
     const unsupportedForEgg8k = isEgg8k && rate < 1000;
     const unsupportedForListed = Array.isArray(supportedRates) && !supportedRates.includes(rate);
-    const unsupportedForLogitech = status.brand === "Logitech" && unsupportedForListed;
-    const hide = unsupportedForEgg8k || unsupportedForLogitech || weSettingsPending;
+    const hideListed = (status.brand === "Logitech" || ui?.hideUnsupportedPollingRates) && unsupportedForListed;
+    const hide = unsupportedForEgg8k || hideListed || settingsPending;
     button.hidden = hide;
-    button.disabled = hide;
+    button.disabled = hide || settingsPending;
   });
   document.querySelectorAll<HTMLButtonElement>("[data-lod]").forEach((button) => {
-    const unsupportedForEgg = isEgg && button.dataset.lod === "Low";
-    button.hidden = unsupportedForEgg || weSettingsPending;
-    button.disabled = unsupportedForEgg || weSettingsPending
+    const hideLow = button.dataset.lod === "Low"
+      && (isEgg || ui?.hideLodLow === true);
+    button.hidden = hideLow;
+    button.disabled = hideLow || settingsPending
       || (status.brand === "Logitech" && button.dataset.lod === "Low");
   });
   document.querySelectorAll<HTMLButtonElement>("[data-dpi]").forEach((button) => {
     button.classList.toggle("selected", Number(button.dataset.dpi) === status.dpi);
-    button.disabled = weSettingsPending;
+    button.disabled = settingsPending;
   });
   const customDpi = document.querySelector<HTMLButtonElement>("#custom-dpi");
-  if (customDpi) customDpi.disabled = weSettingsPending;
-  if (dpiOutputField && weSettingsPending) {
+  if (customDpi) customDpi.disabled = settingsPending;
+  if (dpiOutputField && settingsPending) {
     dpiOutputField.value = "—";
     dpiOutputField.readOnly = true;
   }
@@ -837,7 +861,7 @@ async function showPulsarExplorer(client: PulsarClient): Promise<void> {
 
 function createSupportedClient(device: HIDDevice): SupportedClient | null {
   if (EggOp1HidClient.isSupported(device)) return new EggOp1HidClient(device);
-  if (EggWeHidClient.isSupported(device)) return new EggWeHidClient(device);
+  if (eggWeIsSupported(device)) return eggWeCreate(device);
   if (PulsarProHidClient.isSupported(device)) return new PulsarProHidClient(device);
   if (PulsarHidClient.isSupported(device)) return new PulsarHidClient(device);
   if (LogitechHidppClient.isSupported(device)) return new LogitechHidppClient(device);
@@ -845,7 +869,7 @@ function createSupportedClient(device: HIDDevice): SupportedClient | null {
 }
 
 function deviceBrand(client: SupportedClient): string {
-  if (client instanceof EggOp1HidClient || client instanceof EggWeHidClient) return "Endgame Gear";
+  if (client instanceof EggOp1HidClient || isEggWeClient(client)) return "Endgame Gear";
   if (client instanceof LogitechHidppClient) return "Logitech";
   return "Pulsar";
 }
@@ -860,13 +884,13 @@ function escapeHtml(value: string): string {
   })[character]!);
 }
 
-/** Supported devices for the sidebar; WE cable/receiver collapsed via driver. */
+/** Supported devices for the sidebar; multi-path drivers collapse via their module. */
 function listLogicalDevices(devices?: HIDDevice[]): HIDDevice[] {
   const all = devices ?? [];
-  const nonWe = all.filter((device) =>
-    createSupportedClient(device) !== null && !EggWeHidClient.isSupported(device));
-  const we = EggWeHidClient.pickDevices(all);
-  return [...nonWe, ...we];
+  return eggWeMergeLogicalDevices(
+    all,
+    (device) => createSupportedClient(device) !== null,
+  );
 }
 
 async function renderDeviceSidebar(devices?: HIDDevice[]): Promise<void> {
@@ -882,9 +906,9 @@ async function renderDeviceSidebar(devices?: HIDDevice[]): Promise<void> {
     const client = createSupportedClient(device)!;
     const status = deviceStatuses.get(device);
     const selected = device === activeDevice;
-    // Prefer status from driver (OP1we names itself); avoid productName for WE.
     const name = status?.name
-      ?? (client instanceof EggWeHidClient ? "Endgame Gear OP1we" : (device.productName ?? `${deviceBrand(client)} mouse`));
+      ?? status?.ui?.defaultDisplayName
+      ?? (isEggWeClient(client) ? EGG_WE_DISPLAY_NAME : (device.productName ?? `${deviceBrand(client)} mouse`));
     const detail = status
       ? `${status.brand} · ${status.connectionType ?? "Connected"}`
       : `${deviceBrand(client)} · Available`;
@@ -914,7 +938,7 @@ async function selectAuthorizedDevice(index: number): Promise<void> {
 }
 
 function statusNameForClient(client: SupportedClient): string {
-  if (client instanceof EggWeHidClient) return "Endgame Gear OP1we";
+  if (isEggWeClient(client)) return EGG_WE_DISPLAY_NAME;
   return client.device.productName || "the selected mouse";
 }
 
@@ -933,10 +957,9 @@ async function activateClient(client: SupportedClient): Promise<void> {
     dpiOptions = client.getDpiOptions();
     configureDpiControl(status.dpi);
     showStatus(status);
-  } else if (client instanceof EggWeHidClient) {
+  } else if (isEggWeClient(client)) {
+    await eggWePrepare(client);
     activeEggWeClient = client;
-    // Single gentle status read only — never multi-command probe on connect
-    // (flooding the dongle freezes the OP1we).
     const status = await client.readStatus();
     deviceStatuses.set(client.device, status);
     dpiOptions = client.getDpiOptions();
@@ -986,28 +1009,28 @@ function handleHidConnect(event: HIDConnectionEvent): void {
     return;
   }
 
-  // WE cable + receiver (or multi-interface USB) must not activate twice.
-  if (client instanceof EggWeHidClient) {
+  if (isEggWeClient(client)) {
     void (async () => {
       const all = await navigator.hid?.getDevices() ?? [];
       await renderDeviceSidebar(all);
-      const preferred = EggWeHidClient.pickDevices(all)[0];
-      if (!preferred) return;
-      // Ignore secondary interface (e.g. receiver while cable is preferred).
-      if (preferred !== event.device && activeDevice === preferred) return;
-      if (preferred !== event.device) {
-        // A better path appeared (cable over receiver) — switch once.
-        const next = createSupportedClient(preferred);
-        if (!next || next.device === activeDevice) return;
-        setText("#device-status", "Switching path");
-        setText("#read-status", "Preferring OP1we USB over receiver.");
-        await activateClient(next);
+      const result = await eggWeResolveConnect(event.device, activeEggWeClient, activeDevice, all);
+      if (result.action === "ignore") return;
+      if (result.action === "refresh") {
+        try {
+          const status = await result.client.readStatus();
+          deviceStatuses.set(result.client.device, status);
+          showStatus(status);
+          startAutomaticRefresh();
+        } catch {
+          /* keep existing UI */
+        }
         return;
       }
-      if (activeDevice === preferred) return;
-      setText("#device-status", "New device detected");
-      setText("#read-status", "Reading Endgame Gear OP1we.");
-      await activateClient(new EggWeHidClient(preferred));
+      setText("#device-status", result.reason === "path" ? "Switching path" : "New device detected");
+      setText("#read-status", result.reason === "path"
+        ? "Preferring USB over receiver."
+        : `Reading ${EGG_WE_DISPLAY_NAME}.`);
+      await activateClient(result.client);
     })().catch((error: unknown) => {
       const message = error instanceof Error ? error.message : "Unable to read the connected mouse.";
       setText("#device-status", "Connection failed");
@@ -1029,7 +1052,8 @@ function handleHidConnect(event: HIDConnectionEvent): void {
 
 function handleHidDisconnect(event: HIDConnectionEvent): void {
   deviceStatuses.delete(event.device);
-  if (event.device !== activeDevice) {
+  // Multi-collection drivers (cmd + notify) treat either handle as the active mouse.
+  if (event.device !== activeDevice && !eggWeOwnsDevice(activeEggWeClient, event.device)) {
     void renderDeviceSidebar();
     return;
   }
@@ -1057,35 +1081,39 @@ async function requestSupportedClient(): Promise<SupportedClient | null> {
   const devices = await navigator.hid.requestDevice({
     filters: [
       { vendorId: 0x3710 },
-      // OP1we config collections (from report descriptors): FF02 feature id 8, FF04 feature id 6
-      { vendorId: 0x3367, usagePage: 0xff02 },
-      { vendorId: 0x3367, usagePage: 0xff04 },
-      { vendorId: 0x3367 },
+      ...EGG_WE_HID_FILTERS,
       { vendorId: 0x046d, productId: 0xc54d, usagePage: 0xff00, usage: 0x0001 },
     ],
   });
   if (devices.length === 0) return null;
 
-  // Prefer the interface that scores highest for its brand driver.
-  // For WE: prefer the mouse USB interface over a separate receiver entry.
+  // Dual-collection drivers (e.g. WE) need the full authorized set.
+  if (devices.some((device) => eggWeIsSupported(device))) {
+    const weClient = eggWeFromAuthorized(await eggWeAuthorizedPool(devices));
+    if (weClient) return weClient;
+  }
+
   const ranked = devices
     .map((device) => ({ device, client: createSupportedClient(device), score: clientSupportScore(device) }))
     .filter((entry) => entry.client !== null)
     .sort((left, right) => right.score - left.score);
   const best = ranked[0];
-  if (best?.client) return best.client;
+  if (best?.client) {
+    if (isEggWeClient(best.client)) await eggWePrepare(best.client);
+    return best.client;
+  }
 
   const details = devices.map((device) => describeHidDevice(device)).join(" · ");
   throw new Error(
     `Selected device is not a supported control interface (${details}). `
-    + "Pick the OP1we entry that is not a plain boot mouse, or try the receiver. "
+    + "Pick a vendor control interface (not a plain boot mouse). "
     + "If this keeps failing, note the VID/PID from this message.",
   );
 }
 
 function clientSupportScore(device: HIDDevice): number {
   if (EggOp1HidClient.isSupported(device)) return 10;
-  if (EggWeHidClient.isSupported(device)) return EggWeHidClient.supportScore(device);
+  if (eggWeIsSupported(device)) return eggWeSupportScore(device);
   if (PulsarProHidClient.isSupported(device)) return 8;
   if (PulsarHidClient.isSupported(device)) return 7;
   if (LogitechHidppClient.isSupported(device)) return 6;
@@ -1366,8 +1394,8 @@ type PulsarToggleSetting = "motionSync" | "angleSnapping" | "rippleControl" | "p
 async function applyPulsarToggle(setting: PulsarToggleSetting, enabled: boolean): Promise<void> {
   const client = activePulsarClient ?? activeEggClient;
   if (!client || settingInProgress) return;
-  if (client instanceof EggWeHidClient) {
-    setText("#read-status", "That sensor toggle is not exposed by the OP1we protocol.");
+  if (isEggWeClient(client)) {
+    setText("#read-status", "That sensor toggle is not exposed by this mouse.");
     return;
   }
   settingInProgress = true;
@@ -1539,18 +1567,19 @@ async function applyEggChange(label: string, change: (client: EggOp1HidClient) =
 }
 
 async function applyPulsarValue(setting: "debounce" | "sleep", value: number): Promise<void> {
-  const pulsarOrWe = activePulsarClient ?? activeEggWeClient;
-  if (!pulsarOrWe || settingInProgress) return;
-  if (setting === "sleep" && activeEggWeClient) {
-    setText("#read-status", "Auto sleep is not exposed by the OP1we protocol yet.");
+  const client = activePulsarClient
+    ?? (activeEggWeClient && setting === "debounce" ? activeEggWeClient : null);
+  if (!client || settingInProgress) return;
+  if (setting === "sleep" && !activePulsarClient) {
+    setText("#read-status", "Auto sleep is not available on this mouse.");
     return;
   }
   settingInProgress = true;
   setText("#read-status", `Setting ${setting === "debounce" ? `${value} ms debounce` : "auto sleep"}…`);
   try {
-    if (setting === "debounce") await pulsarOrWe.setDebounceTime(value);
+    if (setting === "debounce") await client.setDebounceTime(value);
     else if (activePulsarClient) await activePulsarClient.setSleepTimeout(value);
-    showStatus(await pulsarOrWe.readStatus());
+    showStatus(await client.readStatus());
   } catch (error) {
     setText("#read-status", error instanceof Error ? error.message : "Unable to change that setting.");
   } finally {
@@ -1576,9 +1605,9 @@ async function applyProSetting(setting: "wheelAcceleration" | "angleTuning" | "p
 
 function startAutomaticRefresh(): void {
   if (refreshTimer !== null) window.clearInterval(refreshTimer);
-  // Drivers may opt out (e.g. WE pollIntervalMs = 0 — feature traffic freezes OP1we).
-  const interval = activeEggWeClient
-    ? EggWeHidClient.pollIntervalMs
+  const client = activeSettingsClient();
+  const interval = client && "pollIntervalMs" in client
+    ? Number((client as { pollIntervalMs: number }).pollIntervalMs)
     : 5000;
   if (!interval || interval <= 0) {
     refreshTimer = null;
@@ -1592,7 +1621,9 @@ function startAutomaticRefresh(): void {
 async function refreshStatus(): Promise<void> {
   const client = activeSettingsClient();
   if (!client || refreshInProgress || settingInProgress) return;
-  if (client instanceof EggWeHidClient && EggWeHidClient.pollIntervalMs <= 0) return;
+  if ("pollIntervalMs" in client && Number((client as { pollIntervalMs: number }).pollIntervalMs) <= 0) {
+    return;
+  }
   refreshInProgress = true;
   try {
     const status = await client.readStatus();

--- a/src/control.ts
+++ b/src/control.ts
@@ -7,6 +7,7 @@ import {
   type EggButtonMapping,
   type EggSpdtMode,
 } from "./egg-op1-hid";
+import { EggWeHidClient } from "./egg-we-hid";
 import { LogitechHidppClient } from "./logitech-hidpp";
 import type { MouseStatus } from "./mouse-types";
 import { PulsarHidClient } from "./pulsar-hid";
@@ -31,6 +32,7 @@ const BUILD_LABEL = `${__BUILD_CHANNEL__.toUpperCase()} · v${__APP_VERSION__}`;
 let activeClient: LogitechHidppClient | null = null;
 let activePulsarClient: PulsarClient | null = null;
 let activeEggClient: EggOp1HidClient | null = null;
+let activeEggWeClient: EggWeHidClient | null = null;
 let refreshTimer: number | null = null;
 let refreshInProgress = false;
 let dpiOptions: number[] = [];
@@ -40,7 +42,11 @@ let activeDevice: HIDDevice | null = null;
 const deviceStatuses = new Map<HIDDevice, MouseStatus>();
 
 type PulsarClient = PulsarHidClient | PulsarProHidClient;
-type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient;
+type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient;
+
+function activeSettingsClient(): SupportedClient | null {
+  return activeClient ?? activePulsarClient ?? activeEggClient ?? activeEggWeClient;
+}
 
 type BatteryMode = "charging" | "discharging";
 type InterfaceDensity = "Compact" | "Comfortable";
@@ -103,7 +109,9 @@ function applyInterfacePreferences(): void {
     details.open = interfacePreferences.expandSections;
   });
   const experimental = document.querySelector<HTMLElement>("#egg-polling-settings");
-  if (experimental && activeEggClient) experimental.style.display = interfacePreferences.showExperimental ? "block" : "none";
+  if (experimental && activeEggClient && !activeEggWeClient) {
+    experimental.style.display = interfacePreferences.showExperimental ? "block" : "none";
+  }
 }
 
 function renderControl(): void {
@@ -575,29 +583,51 @@ function resetDeviceSpecificPanels(): void {
 
 function showStatus(status: MouseStatus): void {
   lastRenderedStatusKey = JSON.stringify(status);
-  const isEgg = status.brand === "Endgame Gear";
+  const isEgg8k = status.brand === "Endgame Gear" && status.connectionDetail?.includes("WE protocol") !== true
+    && (status.eggCpiStages !== undefined || status.leftSpdtMode !== undefined || activeEggClient !== null);
+  const isEggWe = status.brand === "Endgame Gear" && (
+    status.connectionDetail?.includes("WE protocol") === true || activeEggWeClient !== null
+  );
+  const isEgg = isEgg8k || isEggWe;
   const isWired = status.connectionType === "Wired";
   // Always clear device-specific panels first. A status read from the previous
   // mouse may have left these visible when WebHID switches devices.
   resetDeviceSpecificPanels();
   const batterySummary = document.querySelector<HTMLElement>("#battery-summary");
   if (batterySummary) {
-    batterySummary.hidden = isWired;
-    batterySummary.style.display = isWired ? "none" : "flex";
+    // WE mice report battery even when cable-connected (charging); 8K is wired-only.
+    const hideBattery = isEgg8k || (isWired && !isEggWe && status.batteryPercent === null);
+    batterySummary.hidden = hideBattery;
+    batterySummary.style.display = hideBattery ? "none" : "flex";
   }
   const overview = document.querySelector<HTMLElement>(".device-overview");
-  if (overview) overview.style.gridTemplateColumns = isWired ? "repeat(2, 1fr)" : "repeat(3, 1fr)";
-  setText("#polling-note", isEgg
+  if (overview) {
+    const showBatteryColumn = !isEgg8k && (isEggWe || !isWired || status.batteryPercent !== null);
+    overview.style.gridTemplateColumns = showBatteryColumn ? "repeat(3, 1fr)" : "repeat(2, 1fr)";
+  }
+  setText("#polling-note", isEgg8k
     ? "Higher rates update cursor movement more often and increase CPU/USB processing load."
     : "Higher rates update cursor movement more often, but use more battery.");
-  for (const selector of ["#signal-settings", "#debounce-settings", "#sleep-settings"]) {
+  for (const selector of ["#signal-settings", "#sleep-settings"]) {
     const element = document.querySelector<HTMLElement>(selector);
     if (element) element.hidden = isEgg;
+  }
+  const debounceSettings = document.querySelector<HTMLElement>("#debounce-settings");
+  if (debounceSettings) {
+    // Debounce: WE series + Pulsar. Not exposed on OP1 8K.
+    const showDebounce = isEggWe
+      || (status.brand === "Pulsar" && status.debounceMs !== null && status.debounceMs !== undefined);
+    debounceSettings.hidden = !showDebounce;
   }
   const performanceModeSetting = document.querySelector<HTMLElement>("#performance-mode-setting");
   if (performanceModeSetting) {
     performanceModeSetting.hidden = isEgg;
     performanceModeSetting.style.display = isEgg ? "none" : "flex";
+  }
+  // Motion Sync / angle / ripple card is Pulsar (+ 8K partially via other cards). Hide for WE.
+  const processingCard = document.querySelector<HTMLElement>("#motion-sync-toggle")?.closest<HTMLElement>(".setting-card");
+  if (processingCard && processingCard.id !== "egg-filter-settings") {
+    processingCard.style.display = isEggWe ? "none" : "";
   }
   const battery = status.batteryPercent === null ? "—" : `${status.batteryPercent}%`;
   const dpiOutput = document.querySelector<HTMLInputElement>("#dpi-output");
@@ -620,7 +650,7 @@ function showStatus(status: MouseStatus): void {
   const advanced = document.querySelector<HTMLElement>("#pulsar-advanced");
   if (advanced) {
     advanced.style.display = status.brand === "Pulsar" || status.brand === "Endgame Gear" ? "grid" : "none";
-    advanced.classList.toggle("egg-advanced-layout", isEgg);
+    advanced.classList.toggle("egg-advanced-layout", isEgg8k);
   }
   if (status.brand === "Pulsar" || status.brand === "Endgame Gear") {
     const strength = status.signalStrength;
@@ -639,12 +669,13 @@ function showStatus(status: MouseStatus): void {
     const eggPollingSettings = document.querySelector<HTMLElement>("#egg-polling-settings");
     const eggCpiSettings = document.querySelector<HTMLElement>("#egg-cpi-settings");
     const eggButtonSettings = document.querySelector<HTMLElement>("#egg-button-settings");
-    if (eggFilterSettings) eggFilterSettings.style.display = isEgg ? "block" : "none";
-    if (eggSpdtSettings) eggSpdtSettings.style.display = isEgg ? "block" : "none";
-    if (eggPollingSettings) eggPollingSettings.style.display = isEgg && interfacePreferences.showExperimental ? "block" : "none";
-    if (eggCpiSettings) eggCpiSettings.style.display = isEgg ? "block" : "none";
-    if (eggButtonSettings) eggButtonSettings.style.display = isEgg ? "block" : "none";
-    if (isEgg) {
+    // 8K-only panels — never show for WE series.
+    if (eggFilterSettings) eggFilterSettings.style.display = isEgg8k ? "block" : "none";
+    if (eggSpdtSettings) eggSpdtSettings.style.display = isEgg8k ? "block" : "none";
+    if (eggPollingSettings) eggPollingSettings.style.display = isEgg8k && interfacePreferences.showExperimental ? "block" : "none";
+    if (eggCpiSettings) eggCpiSettings.style.display = isEgg8k ? "block" : "none";
+    if (eggButtonSettings) eggButtonSettings.style.display = isEgg8k ? "block" : "none";
+    if (isEgg8k) {
       setToggleValue("#slamclick-filter-toggle", status.slamclickFilter);
       setToggleValue("#motion-jitter-filter-toggle", status.motionJitterFilter);
       setControlValue("#left-spdt-select", status.leftSpdtMode);
@@ -680,12 +711,14 @@ function showStatus(status: MouseStatus): void {
   document.querySelectorAll<HTMLButtonElement>("[data-lod]").forEach((button) => button.classList.toggle("selected", button.dataset.lod === status.liftOffDistance));
   document.querySelectorAll<HTMLButtonElement>("[data-rate]").forEach((button) => {
     const rate = Number(button.dataset.rate);
-    const unsupportedForEgg = isEgg && rate < 1000;
-    const unsupportedForLogitech = status.brand === "Logitech"
-      && Array.isArray(status.supportedPollingRates)
-      && !status.supportedPollingRates.includes(rate);
-    button.hidden = unsupportedForEgg || unsupportedForLogitech;
-    button.disabled = unsupportedForEgg || unsupportedForLogitech;
+    const supportedRates = status.supportedPollingRates;
+    const unsupportedForEgg8k = isEgg8k && rate < 1000;
+    const unsupportedForListed = Array.isArray(supportedRates) && !supportedRates.includes(rate);
+    const unsupportedForLogitech = status.brand === "Logitech" && unsupportedForListed;
+    const unsupportedForWe = isEggWe && unsupportedForListed;
+    const hide = unsupportedForEgg8k || unsupportedForLogitech || unsupportedForWe;
+    button.hidden = hide;
+    button.disabled = hide;
   });
   document.querySelectorAll<HTMLButtonElement>("[data-lod]").forEach((button) => {
     const unsupportedForEgg = isEgg && button.dataset.lod === "Low";
@@ -777,6 +810,7 @@ async function showPulsarExplorer(client: PulsarClient): Promise<void> {
 
 function createSupportedClient(device: HIDDevice): SupportedClient | null {
   if (EggOp1HidClient.isSupported(device)) return new EggOp1HidClient(device);
+  if (EggWeHidClient.isSupported(device)) return new EggWeHidClient(device);
   if (PulsarProHidClient.isSupported(device)) return new PulsarProHidClient(device);
   if (PulsarHidClient.isSupported(device)) return new PulsarHidClient(device);
   if (LogitechHidppClient.isSupported(device)) return new LogitechHidppClient(device);
@@ -784,7 +818,7 @@ function createSupportedClient(device: HIDDevice): SupportedClient | null {
 }
 
 function deviceBrand(client: SupportedClient): string {
-  if (client instanceof EggOp1HidClient) return "Endgame Gear";
+  if (client instanceof EggOp1HidClient || client instanceof EggWeHidClient) return "Endgame Gear";
   if (client instanceof LogitechHidppClient) return "Logitech";
   return "Pulsar";
 }
@@ -845,10 +879,18 @@ async function activateClient(client: SupportedClient): Promise<void> {
   activeClient = null;
   activePulsarClient = null;
   activeEggClient = null;
+  activeEggWeClient = null;
   activeDevice = client.device;
   lastRenderedStatusKey = null;
   if (client instanceof EggOp1HidClient) {
     activeEggClient = client;
+    const status = await client.readStatus();
+    deviceStatuses.set(client.device, status);
+    dpiOptions = client.getDpiOptions();
+    configureDpiControl(status.dpi);
+    showStatus(status);
+  } else if (client instanceof EggWeHidClient) {
+    activeEggWeClient = client;
     const status = await client.readStatus();
     deviceStatuses.set(client.device, status);
     dpiOptions = client.getDpiOptions();
@@ -877,6 +919,7 @@ function showDisconnectedState(): void {
   activeClient = null;
   activePulsarClient = null;
   activeEggClient = null;
+  activeEggWeClient = null;
   activeDevice = null;
   lastRenderedStatusKey = null;
   document.querySelector<HTMLElement>(".control-shell")?.classList.add("is-empty");
@@ -963,18 +1006,20 @@ async function connect(): Promise<void> {
     const message = error instanceof Error ? error.message : "Unable to read the mouse.";
     await activeEggClient?.close().catch(() => undefined);
     activeEggClient = null;
+    await activeEggWeClient?.close().catch(() => undefined);
+    activeEggWeClient = null;
     setText("#device-status", "Connection failed");
     setText("#connection-banner", message);
     setText("#read-status", message);
   } finally {
-    if (!activeClient && !activePulsarClient && !activeEggClient) {
+    if (!activeClient && !activePulsarClient && !activeEggClient && !activeEggWeClient) {
       setConnectionButtons(false, "Add device");
     }
   }
 }
 
 async function reconnectAuthorizedDevice(): Promise<void> {
-  if (activeClient || activePulsarClient || activeEggClient) return;
+  if (activeClient || activePulsarClient || activeEggClient || activeEggWeClient) return;
   const button = document.querySelector<HTMLButtonElement>("#connect-button");
   if (!button) return;
   setConnectionButtons(true, "Reconnecting…");
@@ -1006,7 +1051,7 @@ async function reconnectAuthorizedDevice(): Promise<void> {
     if (lastError) setText("#connection-banner", lastError.message);
     setText("#read-status", "Use Add device if the mouse does not reconnect automatically.");
   } finally {
-    if (!activeClient && !activePulsarClient && !activeEggClient) {
+    if (!activeClient && !activePulsarClient && !activeEggClient && !activeEggWeClient) {
       setConnectionButtons(false, "Add device");
     }
   }
@@ -1085,7 +1130,7 @@ function finishCustomDpiEditing(dpi?: number): void {
 }
 
 async function applyDpiValue(dpi: number): Promise<boolean> {
-  const client = activeClient ?? activePulsarClient ?? activeEggClient;
+  const client = activeSettingsClient();
   if (!client || !dpiOptions.includes(dpi) || refreshInProgress || settingInProgress) return false;
   settingInProgress = true;
   const buttons = document.querySelectorAll<HTMLButtonElement>("[data-dpi], #custom-dpi");
@@ -1127,7 +1172,7 @@ async function applyLogitechAxisDpi(): Promise<void> {
 }
 
 async function applyPollingRate(rate: number): Promise<void> {
-  const client = activeClient ?? activePulsarClient ?? activeEggClient;
+  const client = activeSettingsClient();
   if (!client || refreshInProgress || settingInProgress) return;
   settingInProgress = true;
   const buttons = document.querySelectorAll<HTMLButtonElement>("[data-rate]");
@@ -1149,7 +1194,7 @@ async function applyPollingRate(rate: number): Promise<void> {
 }
 
 async function applyLiftOffDistance(lod: NonNullable<MouseStatus["liftOffDistance"]>): Promise<void> {
-  const client = activeClient ?? activePulsarClient ?? activeEggClient;
+  const client = activeSettingsClient();
   if (!client || refreshInProgress || settingInProgress) return;
   settingInProgress = true;
   const buttons = document.querySelectorAll<HTMLButtonElement>("[data-lod]");
@@ -1191,6 +1236,10 @@ type PulsarToggleSetting = "motionSync" | "angleSnapping" | "rippleControl" | "p
 async function applyPulsarToggle(setting: PulsarToggleSetting, enabled: boolean): Promise<void> {
   const client = activePulsarClient ?? activeEggClient;
   if (!client || settingInProgress) return;
+  if (client instanceof EggWeHidClient) {
+    setText("#read-status", "That sensor toggle is not exposed by the OP1we protocol.");
+    return;
+  }
   settingInProgress = true;
   setText("#read-status", `${enabled ? "Enabling" : "Disabling"} ${settingLabel(setting)}…`);
   try {
@@ -1360,15 +1409,20 @@ async function applyEggChange(label: string, change: (client: EggOp1HidClient) =
 }
 
 async function applyPulsarValue(setting: "debounce" | "sleep", value: number): Promise<void> {
-  if (!activePulsarClient || settingInProgress) return;
+  const pulsarOrWe = activePulsarClient ?? activeEggWeClient;
+  if (!pulsarOrWe || settingInProgress) return;
+  if (setting === "sleep" && activeEggWeClient) {
+    setText("#read-status", "Auto sleep is not exposed by the OP1we protocol yet.");
+    return;
+  }
   settingInProgress = true;
   setText("#read-status", `Setting ${setting === "debounce" ? `${value} ms debounce` : "auto sleep"}…`);
   try {
-    if (setting === "debounce") await activePulsarClient.setDebounceTime(value);
-    else await activePulsarClient.setSleepTimeout(value);
-    showStatus(await activePulsarClient.readStatus());
+    if (setting === "debounce") await pulsarOrWe.setDebounceTime(value);
+    else if (activePulsarClient) await activePulsarClient.setSleepTimeout(value);
+    showStatus(await pulsarOrWe.readStatus());
   } catch (error) {
-    setText("#read-status", error instanceof Error ? error.message : "Unable to change the Pulsar setting.");
+    setText("#read-status", error instanceof Error ? error.message : "Unable to change that setting.");
   } finally {
     settingInProgress = false;
   }
@@ -1398,12 +1452,12 @@ function startAutomaticRefresh(): void {
 }
 
 async function refreshStatus(): Promise<void> {
-  const client = activeClient ?? activePulsarClient ?? activeEggClient;
+  const client = activeSettingsClient();
   if (!client || refreshInProgress || settingInProgress) return;
   refreshInProgress = true;
   try {
     const status = await client.readStatus();
-    const currentClient = activeClient ?? activePulsarClient ?? activeEggClient;
+    const currentClient = activeSettingsClient();
     if (client !== currentClient || client.device !== activeDevice) return;
     if (JSON.stringify(status) !== lastRenderedStatusKey) showStatus(status);
   } catch (error) {
@@ -1423,6 +1477,7 @@ window.addEventListener("beforeunload", () => {
   void activeClient?.close();
   void activePulsarClient?.close();
   void activeEggClient?.close();
+  void activeEggWeClient?.close();
 });
 
 renderControl();

--- a/src/control.ts
+++ b/src/control.ts
@@ -1057,6 +1057,9 @@ async function requestSupportedClient(): Promise<SupportedClient | null> {
   const devices = await navigator.hid.requestDevice({
     filters: [
       { vendorId: 0x3710 },
+      // OP1we config collections (from report descriptors): FF02 feature id 8, FF04 feature id 6
+      { vendorId: 0x3367, usagePage: 0xff02 },
+      { vendorId: 0x3367, usagePage: 0xff04 },
       { vendorId: 0x3367 },
       { vendorId: 0x046d, productId: 0xc54d, usagePage: 0xff00, usage: 0x0001 },
     ],

--- a/src/control.ts
+++ b/src/control.ts
@@ -707,13 +707,15 @@ function showStatus(status: MouseStatus): void {
   const weSettingsPending = isEggWe && !EggWeHidClient.settingsMapped;
   setText("#connection-banner", weSettingsPending
     ? (status.connectionType === "Wireless"
-      ? "OP1we via receiver — HID polling disabled to avoid freezing the mouse. Battery is approximate; settings need WE software capture."
-      : "OP1we connected over USB. Battery is approximate; CPI/polling/LOD need a capture from WE Series software.")
+      ? "OP1we (via receiver). Config HID is idle so the mouse does not freeze. Settings need WE software capture."
+      : "OP1we (USB). Battery approximate if shown; settings need WE software capture.")
     : "Connected directly through WebHID. Supported settings can be adjusted here.");
   if (weSettingsPending) {
-    setText("#read-status", status.batteryPercent === null
-      ? `Battery unread. ${status.connectionDetail ?? ""}`
-      : `Battery ~${status.batteryPercent}% (approx) · no auto-refresh · settings map pending`);
+    setText("#read-status", status.connectionType === "Wireless"
+      ? "Wireless path · no config HID · settings map pending"
+      : (status.batteryPercent === null
+        ? `Connected · ${status.connectionDetail ?? ""}`
+        : `Battery ~${status.batteryPercent}% (approx) · settings map pending`));
   } else {
     setText("#read-status", `Current: ${status.dpi.toLocaleString()} DPI · ${status.pollingRateHz.toLocaleString()} Hz`);
   }
@@ -859,23 +861,13 @@ function escapeHtml(value: string): string {
   })[character]!);
 }
 
-/**
- * Collapse Endgame WE cable + receiver into one logical mouse.
- * Prefer the USB mouse interface when both are present; otherwise use the
- * receiver as the wireless path to that same mouse.
- */
+/** Supported devices for the sidebar; WE cable/receiver collapsed via driver. */
 function listLogicalDevices(devices?: HIDDevice[]): HIDDevice[] {
-  const supported = (devices ?? [])
-    .filter((device) => createSupportedClient(device) !== null);
-  const we = supported.filter((device) => EggWeHidClient.isSupported(device));
-  const other = supported.filter((device) => !EggWeHidClient.isSupported(device));
-  if (we.length === 0) return supported;
-
-  const mice = we.filter((device) => !EggWeHidClient.isReceiverDevice(device));
-  const receivers = we.filter((device) => EggWeHidClient.isReceiverDevice(device));
-  if (mice.length > 0) return [...other, ...mice];
-  // Wireless-only: one receiver entry represents the mouse.
-  return [...other, ...receivers.slice(0, 1)];
+  const all = devices ?? [];
+  const nonWe = all.filter((device) =>
+    createSupportedClient(device) !== null && !EggWeHidClient.isSupported(device));
+  const we = EggWeHidClient.pickDevices(all);
+  return [...nonWe, ...we];
 }
 
 async function renderDeviceSidebar(devices?: HIDDevice[]): Promise<void> {
@@ -891,14 +883,12 @@ async function renderDeviceSidebar(devices?: HIDDevice[]): Promise<void> {
     const client = createSupportedClient(device)!;
     const status = deviceStatuses.get(device);
     const selected = device === activeDevice;
-    const viaReceiver = client instanceof EggWeHidClient && EggWeHidClient.isReceiverDevice(device);
+    // Prefer status from driver (OP1we names itself); avoid productName for WE.
     const name = status?.name
-      ?? (viaReceiver ? "Endgame Gear OP1we" : (device.productName ?? `${deviceBrand(client)} mouse`));
+      ?? (client instanceof EggWeHidClient ? "Endgame Gear OP1we" : (device.productName ?? `${deviceBrand(client)} mouse`));
     const detail = status
       ? `${status.brand} · ${status.connectionType ?? "Connected"}`
-      : viaReceiver
-        ? `${deviceBrand(client)} · Wireless receiver`
-        : `${deviceBrand(client)} · Available`;
+      : `${deviceBrand(client)} · Available`;
     return `<button class="device-select${selected ? " is-selected" : ""}" type="button" data-device-index="${index}" aria-pressed="${selected}">
       <span class="device-dot${selected ? "" : " is-idle"}"></span>
       <span><strong>${escapeHtml(name)}</strong><small>${escapeHtml(detail)}</small></span>
@@ -914,7 +904,7 @@ async function selectAuthorizedDevice(index: number): Promise<void> {
   const client = createSupportedClient(device);
   if (!client) return;
   setText("#device-status", "Switching");
-  setText("#read-status", `Reading ${device.productName || "the selected mouse"}.`);
+  setText("#read-status", `Reading ${statusNameForClient(client)}.`);
   try {
     await activateClient(client);
   } catch (error) {
@@ -922,6 +912,11 @@ async function selectAuthorizedDevice(index: number): Promise<void> {
     setText("#device-status", "Connection failed");
     setText("#read-status", message);
   }
+}
+
+function statusNameForClient(client: SupportedClient): string {
+  if (client instanceof EggWeHidClient) return "Endgame Gear OP1we";
+  return client.device.productName || "the selected mouse";
 }
 
 async function activateClient(client: SupportedClient): Promise<void> {
@@ -1535,22 +1530,23 @@ async function applyProSetting(setting: "wheelAcceleration" | "angleTuning" | "p
 
 function startAutomaticRefresh(): void {
   if (refreshTimer !== null) window.clearInterval(refreshTimer);
-  // OP1we over the dongle freezes if we poll feature reports every few seconds.
-  // Read once on connect only; other brands keep a light refresh.
-  if (activeEggWeClient) {
+  // Drivers may opt out (e.g. WE pollIntervalMs = 0 — feature traffic freezes OP1we).
+  const interval = activeEggWeClient
+    ? EggWeHidClient.pollIntervalMs
+    : 5000;
+  if (!interval || interval <= 0) {
     refreshTimer = null;
     return;
   }
   refreshTimer = window.setInterval(() => {
     void refreshStatus();
-  }, 5000);
+  }, interval);
 }
 
 async function refreshStatus(): Promise<void> {
   const client = activeSettingsClient();
   if (!client || refreshInProgress || settingInProgress) return;
-  // Never background-poll WE — wireless path is sensitive to HID chatter.
-  if (client instanceof EggWeHidClient) return;
+  if (client instanceof EggWeHidClient && EggWeHidClient.pollIntervalMs <= 0) return;
   refreshInProgress = true;
   try {
     const status = await client.readStatus();

--- a/src/control.ts
+++ b/src/control.ts
@@ -40,12 +40,18 @@ let settingInProgress = false;
 let lastRenderedStatusKey: string | null = null;
 let activeDevice: HIDDevice | null = null;
 const deviceStatuses = new Map<HIDDevice, MouseStatus>();
+/** Prevents overlapping reconnect loops from leaving the UI stuck on "Reconnecting…". */
+let reconnectInFlight = false;
 
 type PulsarClient = PulsarHidClient | PulsarProHidClient;
 type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient;
 
 function activeSettingsClient(): SupportedClient | null {
   return activeClient ?? activePulsarClient ?? activeEggClient ?? activeEggWeClient;
+}
+
+function hasActiveClient(): boolean {
+  return activeSettingsClient() !== null;
 }
 
 type BatteryMode = "charging" | "discharging";
@@ -956,6 +962,8 @@ async function activateClient(client: SupportedClient): Promise<void> {
   }
   await renderDeviceSidebar();
   startAutomaticRefresh();
+  // Always restore the sidebar action after a successful activate.
+  setConnectionButtons(false, "Add device");
 }
 
 function showDisconnectedState(): void {
@@ -1113,7 +1121,7 @@ async function connect(): Promise<void> {
       return;
     }
     setText("#device-status", "Opening device");
-    setText("#read-status", `Reading ${client.device.productName || "device"}…`);
+    setText("#read-status", `Reading ${statusNameForClient(client)}…`);
     await activateClient(client);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unable to read the mouse.";
@@ -1125,16 +1133,16 @@ async function connect(): Promise<void> {
     setText("#connection-banner", message);
     setText("#read-status", message);
   } finally {
-    if (!activeClient && !activePulsarClient && !activeEggClient && !activeEggWeClient) {
-      setConnectionButtons(false, "Add device");
-    }
+    // Always clear the busy label — success used to leave "Connecting…" stuck.
+    setConnectionButtons(false, "Add device");
   }
 }
 
 async function reconnectAuthorizedDevice(): Promise<void> {
-  if (activeClient || activePulsarClient || activeEggClient || activeEggWeClient) return;
+  if (hasActiveClient() || reconnectInFlight) return;
   const button = document.querySelector<HTMLButtonElement>("#connect-button");
   if (!button) return;
+  reconnectInFlight = true;
   setConnectionButtons(true, "Reconnecting…");
 
   let lastError: Error | null = null;
@@ -1144,7 +1152,11 @@ async function reconnectAuthorizedDevice(): Promise<void> {
     // keep a few wider retries for slower USB enumeration.
     const retryDelays = [0, 40, 60, 75, 100, 150, 225, 350, 500, 750];
     for (const delay of retryDelays) {
+      // Another path (HID connect handler) may have already activated a client.
+      if (hasActiveClient()) return;
       if (delay) await waitForHidChange(delay);
+      if (hasActiveClient()) return;
+
       const devices = await navigator.hid?.getDevices() ?? [];
       const clients = listLogicalDevices(devices)
         .map((device) => ({ client: createSupportedClient(device), score: clientSupportScore(device) }))
@@ -1152,7 +1164,10 @@ async function reconnectAuthorizedDevice(): Promise<void> {
         .sort((left, right) => right.score - left.score)
         .map((entry) => entry.client);
       await renderDeviceSidebar(devices);
+      if (clients.length === 0) continue;
+
       for (const client of clients) {
+        if (hasActiveClient()) return;
         try {
           setText("#device-status", "Reconnecting");
           setText("#read-status", "Reading the previously authorized device.");
@@ -1164,13 +1179,15 @@ async function reconnectAuthorizedDevice(): Promise<void> {
         }
       }
     }
-    setText("#device-status", "Not connected");
-    if (lastError) setText("#connection-banner", lastError.message);
-    setText("#read-status", "Use Add device if the mouse does not reconnect automatically.");
-  } finally {
-    if (!activeClient && !activePulsarClient && !activeEggClient && !activeEggWeClient) {
-      setConnectionButtons(false, "Add device");
+    if (!hasActiveClient()) {
+      setText("#device-status", "Not connected");
+      if (lastError) setText("#connection-banner", lastError.message);
+      setText("#read-status", "Use Add device if the mouse does not reconnect automatically.");
     }
+  } finally {
+    reconnectInFlight = false;
+    // Always restore the button — previously success left "Reconnecting…" forever.
+    setConnectionButtons(false, "Add device");
   }
 }
 

--- a/src/egg-we-control.ts
+++ b/src/egg-we-control.ts
@@ -1,0 +1,125 @@
+/**
+ * Control-shell integration for Endgame Gear WE (OP1we).
+ *
+ * Keeps multi-collection HID discovery, peer bind, and connect coalescing out
+ * of control.ts so other brand PRs do not touch WE-specific paths.
+ */
+import { EggWeHidClient } from "./egg-we-hid";
+
+export type { EggWeHidClient };
+
+/** WebHID filters for requestDevice (cmd FF02, notify FF01, identity FF04). */
+export const EGG_WE_HID_FILTERS: HIDDeviceFilter[] = [
+  { vendorId: 0x3367, usagePage: 0xff02 },
+  { vendorId: 0x3367, usagePage: 0xff01 },
+  { vendorId: 0x3367, usagePage: 0xff04 },
+  { vendorId: 0x3367 },
+];
+
+export const EGG_WE_DISPLAY_NAME = "Endgame Gear OP1we";
+
+export function isEggWeClient(client: unknown): client is EggWeHidClient {
+  return client instanceof EggWeHidClient;
+}
+
+export function eggWeIsSupported(device: HIDDevice): boolean {
+  return EggWeHidClient.isSupported(device);
+}
+
+export function eggWeSupportScore(device: HIDDevice): number {
+  return EggWeHidClient.supportScore(device);
+}
+
+export function eggWeCreate(device: HIDDevice): EggWeHidClient {
+  return new EggWeHidClient(device);
+}
+
+/** One logical mouse from cable + receiver (+ multi-collection USB). */
+export function eggWePickDevices(devices: readonly HIDDevice[]): HIDDevice[] {
+  return EggWeHidClient.pickDevices(devices);
+}
+
+export function eggWeFromAuthorized(devices: readonly HIDDevice[]): EggWeHidClient | null {
+  return EggWeHidClient.fromAuthorizedDevices(devices);
+}
+
+/** Unique merge of requestDevice results + already-authorized devices. */
+export async function eggWeAuthorizedPool(
+  selected: readonly HIDDevice[],
+): Promise<HIDDevice[]> {
+  const granted = typeof navigator !== "undefined" && navigator.hid
+    ? await navigator.hid.getDevices()
+    : [];
+  return [...selected, ...granted].filter(
+    (device, index, list) => list.indexOf(device) === index,
+  );
+}
+
+export async function eggWePrepare(
+  client: EggWeHidClient,
+  devices?: readonly HIDDevice[],
+): Promise<void> {
+  const all = devices
+    ?? (typeof navigator !== "undefined" && navigator.hid
+      ? await navigator.hid.getDevices()
+      : []);
+  client.bindPeers(all);
+}
+
+/**
+ * Sidebar list: non-WE devices + one WE logical entry.
+ * `isOtherSupported` is provided by the shell (createSupportedClient !== null).
+ */
+export function eggWeMergeLogicalDevices(
+  all: readonly HIDDevice[],
+  isOtherSupported: (device: HIDDevice) => boolean,
+): HIDDevice[] {
+  const nonWe = all.filter(
+    (device) => isOtherSupported(device) && !EggWeHidClient.isSupported(device),
+  );
+  return [...nonWe, ...EggWeHidClient.pickDevices(all)];
+}
+
+export type EggWeConnectResult =
+  | { action: "ignore" }
+  | { action: "refresh"; client: EggWeHidClient }
+  | { action: "activate"; client: EggWeHidClient; reason: "path" | "new" };
+
+/**
+ * Coalesce multi-interface connect events for an already-known or new WE mouse.
+ */
+export async function eggWeResolveConnect(
+  eventDevice: HIDDevice,
+  active: EggWeHidClient | null,
+  activeDevice: HIDDevice | null,
+  allDevices: readonly HIDDevice[],
+): Promise<EggWeConnectResult> {
+  const preferred = EggWeHidClient.pickDevices(allDevices)[0];
+  if (!preferred) return { action: "ignore" };
+
+  if (active?.ownsDevice(eventDevice) || activeDevice === preferred) {
+    if (active) {
+      active.bindPeers(allDevices);
+      return { action: "refresh", client: active };
+    }
+    return { action: "ignore" };
+  }
+
+  if (preferred !== eventDevice) {
+    const next = EggWeHidClient.fromAuthorizedDevices(allDevices);
+    if (!next || next.device === activeDevice) return { action: "ignore" };
+    return { action: "activate", client: next, reason: "path" };
+  }
+
+  if (activeDevice === preferred) return { action: "ignore" };
+  const weClient = EggWeHidClient.fromAuthorizedDevices(allDevices);
+  if (!weClient) return { action: "ignore" };
+  return { action: "activate", client: weClient, reason: "new" };
+}
+
+export function eggWeOwnsDevice(
+  client: EggWeHidClient | null,
+  device: HIDDevice,
+): boolean {
+  return client?.ownsDevice(device) ?? false;
+}

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -3,23 +3,19 @@ import type { MouseStatus } from "./mouse-types";
 /**
  * Endgame Gear WE-series wireless mice (OP1we, shared dongle, etc.).
  *
- * Same structural style as egg-op1-hid.ts (product map, feature reports,
- * verified setters) but a different CompX/WE command set — not the wired
- * OP1 8K 1041-byte config blob.
+ * Same structural style as egg-op1-hid.ts, but a different CompX/WE command
+ * set — not the wired OP1 8K 1041-byte config blob.
  *
- * Battery command 0xb4 is publicly reverse-engineered. Other setting
- * commands follow the same feature-report shell and must re-read to confirm;
- * adjust COMMAND / parse offsets after USB capture of WE Series software if
- * a firmware revision disagrees.
+ * Transport notes (Windows WebHID is strict):
+ * - Verified battery protocol uses feature report 0xa1 for Set + Get.
+ * - sendFeatureReport data must match the HID descriptor byte length exactly
+ *   (report id is separate; do not include it in the buffer).
+ * - Native HidD_SetFeature buffers include report id as byte 0; WebHID
+ *   responses do not, so battery % is at index 15 (not 16).
  */
 
 const EGG_VENDOR_ID = 0x3367;
 
-/**
- * Known WE-family product IDs. Unknown 0x3367 PIDs are still accepted when the
- * HID interface looks like a vendor config channel (see isSupported) — OP1we
- * firmware has used more than one PID across cable vs dongle revisions.
- */
 const KNOWN_PRODUCTS = new Map<number, { name: string; wired: boolean }>([
   [0x1972, { name: "Endgame Gear OP1we", wired: true }],
   [0x1970, { name: "Endgame Gear wireless receiver", wired: false }],
@@ -30,22 +26,11 @@ const KNOWN_PRODUCTS = new Map<number, { name: string; wired: boolean }>([
 /** Wired OP1 8K / XM2 8K PIDs — owned by egg-op1-hid, never claim here. */
 const EGG_8K_PRODUCT_IDS = new Set([0x1964, 0x1966, 0x1976, 0x1978]);
 
-const REPORT_SIZE = 64;
-const REPORT = {
-  /** Write / set-feature shell (mirrors 8K report id family). */
-  write: 0xa0,
-  /** Read / get-feature shell used by battery and status commands. */
-  read: 0xa1,
-} as const;
+/** Prefer the verified WE report; fall back if a firmware only exposes 0xa0. */
+const PREFERRED_REPORT_IDS = [0xa1, 0xa0] as const;
 
-/**
- * Feature-report command byte (buffer[1] after report id).
- * battery is verified; remaining IDs are provisional WE-series peers of 0xb4
- * and are confirmed only when re-read matches.
- */
 const COMMAND = {
   battery: 0xb4,
-  /** Device status block: CPI, polling, LOD, debounce packed in one reply. */
   status: 0xb0,
   dpi: 0xb1,
   polling: 0xb2,
@@ -54,91 +39,95 @@ const COMMAND = {
   firmware: 0xb6,
 } as const;
 
-/** Offsets inside a successful status (0xb0) or setting response payload. */
-const STATUS = {
-  dpiLo: 4,
-  dpiHi: 5,
-  polling: 6,
-  lod: 7,
-  debounce: 8,
-  firmwareMajor: 10,
-  firmwareMinor: 11,
-} as const;
-
 const POLLING_RATES = [125, 250, 500, 1000] as const;
 const DEFAULT_DPI = 800;
 const DEFAULT_POLLING = 1000;
 const DEFAULT_DEBOUNCE = 3;
 
+interface FeatureReportTarget {
+  reportId: number;
+  /** Payload length for sendFeatureReport (excludes report id). */
+  payloadLength: number;
+}
+
 export class EggWeHidClient {
   private commandQueue: Promise<unknown> = Promise.resolve();
+  private reportTarget: FeatureReportTarget | null = null;
+  /** True when receiveFeatureReport includes the report id as byte 0. */
+  private responseIncludesReportId: boolean | null = null;
 
   constructor(readonly device: HIDDevice) {}
 
-  /**
-   * Accept Endgame Gear WE interfaces that are not the wired 8K driver.
-   * Prefer vendor feature report 0xa1 when present; also accept vendor usage
-   * collections (0xff01 / 0xff00) so the Chrome picker entry is not rejected
-   * before we can open and probe.
-   */
   static isSupported(device: HIDDevice): boolean {
     if (device.vendorId !== EGG_VENDOR_ID) return false;
     if (EGG_8K_PRODUCT_IDS.has(device.productId)) return false;
     return this.hasVendorConfigInterface(device);
   }
 
-  /** Rank higher when the interface exposes the WE feature report we talk on. */
   static supportScore(device: HIDDevice): number {
     if (!this.isSupported(device)) return 0;
     let score = 1;
-    if (this.collectionTreeHasFeatureReport(device.collections, REPORT.read)) score += 4;
-    if (this.collectionTreeHasFeatureReport(device.collections, REPORT.write)) score += 2;
+    if (this.findFeatureReport(device, 0xa1)) score += 4;
+    if (this.findFeatureReport(device, 0xa0)) score += 2;
     if (this.collectionTreeHasVendorUsage(device.collections)) score += 1;
     return score;
   }
 
   private static hasVendorConfigInterface(device: HIDDevice): boolean {
-    if (this.collectionTreeHasFeatureReport(device.collections, REPORT.read)) return true;
-    if (this.collectionTreeHasFeatureReport(device.collections, REPORT.write)) return true;
-    // Some Windows enumerations expose the vendor page before report ids resolve.
+    if (this.findFeatureReport(device, 0xa1) || this.findFeatureReport(device, 0xa0)) return true;
     if (this.collectionTreeHasVendorUsage(device.collections)) return true;
-    // Last resort: any non-boot feature report on this VID (not 8K).
-    return device.collections.some((collection) =>
-      this.collectionTreeHasAnyFeatureReport([collection]));
+    return this.listFeatureReports(device).length > 0;
   }
 
-  private static collectionTreeHasFeatureReport(
-    collections: readonly HIDCollectionInfo[],
-    reportId: number,
-  ): boolean {
-    return collections.some((collection) =>
-      collection.featureReports.some((report) => report.reportId === reportId)
-      || this.collectionTreeHasFeatureReport(collection.children, reportId));
+  private static listFeatureReports(device: HIDDevice): FeatureReportTarget[] {
+    const found: FeatureReportTarget[] = [];
+    const visit = (collections: readonly HIDCollectionInfo[]): void => {
+      for (const collection of collections) {
+        for (const report of collection.featureReports) {
+          const payloadLength = this.featureReportPayloadLength(report);
+          if (payloadLength > 0) {
+            found.push({ reportId: report.reportId, payloadLength });
+          }
+        }
+        visit(collection.children);
+      }
+    };
+    visit(device.collections);
+    return found;
   }
 
-  private static collectionTreeHasAnyFeatureReport(collections: readonly HIDCollectionInfo[]): boolean {
-    return collections.some((collection) =>
-      collection.featureReports.length > 0
-      || this.collectionTreeHasAnyFeatureReport(collection.children));
+  private static findFeatureReport(device: HIDDevice, reportId: number): FeatureReportTarget | null {
+    return this.listFeatureReports(device).find((report) => report.reportId === reportId) ?? null;
+  }
+
+  private static featureReportPayloadLength(report: HIDReportInfo): number {
+    let bits = 0;
+    for (const item of report.items ?? []) {
+      bits += item.reportSize * item.reportCount;
+    }
+    // Some descriptors leave items empty; fall back to common WE size (64 total with id → 63 payload).
+    if (bits === 0) return 63;
+    return Math.ceil(bits / 8);
   }
 
   private static collectionTreeHasVendorUsage(collections: readonly HIDCollectionInfo[]): boolean {
     return collections.some((collection) => {
-      const page = collection.usagePage;
-      if (page === 0xff00 || page === 0xff01 || page >= 0xff00) return true;
+      if (collection.usagePage >= 0xff00) return true;
       return this.collectionTreeHasVendorUsage(collection.children);
     });
   }
 
   async open(): Promise<void> {
     if (!this.device.opened) await this.device.open();
+    if (!this.reportTarget) this.reportTarget = this.resolveReportTarget();
   }
 
   describeCollections(): string {
-    return this.device.collections.map((collection) => {
-      const reports = collection.featureReports.map((report) => `0x${report.reportId.toString(16)}`);
-      return `usage 0x${collection.usagePage.toString(16)}:0x${collection.usage.toString(16)} · feature ${reports.join(", ") || "none"}`;
-    }).join(" | ") || "No HID collections reported";
+    return EggWeHidClient.listFeatureReports(this.device).map((report) =>
+      `id 0x${report.reportId.toString(16)} · ${report.payloadLength} bytes`).join(" | ")
+      || this.device.collections.map((collection) =>
+        `usage 0x${collection.usagePage.toString(16)}:0x${collection.usage.toString(16)}`).join(" | ")
+      || "No HID collections reported";
   }
 
   getDpiOptions(): number[] {
@@ -157,41 +146,58 @@ export class EggWeHidClient {
     const productName = this.device.productName?.trim() || "Endgame Gear WE mouse";
     const lower = productName.toLowerCase();
     const wired = !lower.includes("receiver") && !lower.includes("dongle");
-    // Prefer the marketing name from the OS when PID is unknown.
     if (lower.includes("op1we") || lower.includes("op1 we")) {
       return { name: wired ? "Endgame Gear OP1we" : "Endgame Gear OP1we receiver", wired };
     }
     return { name: productName, wired };
   }
 
+  private resolveReportTarget(): FeatureReportTarget {
+    for (const reportId of PREFERRED_REPORT_IDS) {
+      const match = EggWeHidClient.findFeatureReport(this.device, reportId);
+      if (match) return match;
+    }
+    const any = EggWeHidClient.listFeatureReports(this.device)[0];
+    if (any) return any;
+    // Descriptor empty (some Windows builds) — use verified WE defaults.
+    return { reportId: 0xa1, payloadLength: 63 };
+  }
+
   async readStatus(): Promise<MouseStatus> {
     const meta = this.productMeta();
-    const battery = await this.readBattery();
+    await this.open();
+
+    // Battery is the only fully verified command. Soft-fail so a transport
+    // mismatch still shows the device while we surface a clear banner.
+    const battery = await this.readBattery().catch(() => ({
+      percent: null as number | null,
+      state: "Unknown" as const,
+    }));
     const state = await this.readDeviceState().catch(() => null);
     const firmware = await this.readFirmware().catch(() => null);
+
     const dpi = state?.dpi ?? DEFAULT_DPI;
     const pollingRateHz = state?.pollingRateHz ?? DEFAULT_POLLING;
     const debounceMs = state?.debounceMs ?? DEFAULT_DEBOUNCE;
     const liftOffDistance = state?.liftOffDistance ?? "Medium";
 
-    if (!this.getDpiOptions().includes(dpi)) {
-      throw new Error(`The mouse reported an unsupported ${dpi} CPI value.`);
-    }
-    if (!POLLING_RATES.includes(pollingRateHz as (typeof POLLING_RATES)[number])) {
-      throw new Error(`The mouse reported an unsupported ${pollingRateHz} Hz polling rate.`);
-    }
-
+    const target = this.reportTarget ?? this.resolveReportTarget();
     return {
       brand: "Endgame Gear",
       name: meta.name,
       batteryPercent: battery.percent,
       batteryState: battery.state,
-      dpi,
-      pollingRateHz,
+      dpi: this.clampDpi(dpi),
+      pollingRateHz: POLLING_RATES.includes(pollingRateHz as (typeof POLLING_RATES)[number])
+        ? pollingRateHz
+        : DEFAULT_POLLING,
       supportedPollingRates: this.supportedPollingRates,
       activeProfile: null,
       connectionType: meta.wired ? "Wired" : "Wireless",
-      connectionDetail: `${meta.wired ? "Wired USB" : "2.4 GHz dongle"} · PID 0x${this.device.productId.toString(16).toUpperCase()} · WE protocol`,
+      connectionDetail:
+        `${meta.wired ? "Wired USB" : "2.4 GHz dongle"} · PID 0x${this.device.productId.toString(16).toUpperCase()}`
+        + ` · WE · report 0x${target.reportId.toString(16)}/${target.payloadLength}B`
+        + (battery.percent === null ? " · battery unread" : ""),
       debounceMs,
       liftOffDistance,
       firmware: firmware
@@ -209,7 +215,7 @@ export class EggWeHidClient {
     await this.writeSetting(COMMAND.dpi, [dpi & 0xff, (dpi >> 8) & 0xff]);
     const confirmed = (await this.readDeviceState()).dpi;
     if (confirmed !== dpi) {
-      throw new Error(`The mouse kept ${confirmed} CPI instead of ${dpi} CPI.`);
+      throw new Error(`The mouse kept ${confirmed} CPI instead of ${dpi} CPI. Settings command map may need a capture from WE software.`);
     }
     return confirmed;
   }
@@ -221,7 +227,7 @@ export class EggWeHidClient {
     await this.writeSetting(COMMAND.polling, [this.encodePolling(rate)]);
     const confirmed = (await this.readDeviceState()).pollingRateHz;
     if (confirmed !== rate) {
-      throw new Error(`The mouse kept ${confirmed} Hz instead of ${rate} Hz.`);
+      throw new Error(`The mouse kept ${confirmed} Hz instead of ${rate} Hz. Settings command map may need a capture from WE software.`);
     }
     return confirmed;
   }
@@ -234,7 +240,7 @@ export class EggWeHidClient {
     await this.writeSetting(COMMAND.lod, [encoded]);
     const confirmed = (await this.readDeviceState()).liftOffDistance;
     if (confirmed !== value) {
-      throw new Error("The mouse did not confirm the requested lift-off distance.");
+      throw new Error("The mouse did not confirm the requested lift-off distance. Settings command map may need a capture from WE software.");
     }
   }
 
@@ -245,7 +251,7 @@ export class EggWeHidClient {
     await this.writeSetting(COMMAND.debounce, [milliseconds]);
     const confirmed = (await this.readDeviceState()).debounceMs;
     if (confirmed !== milliseconds) {
-      throw new Error(`The mouse kept ${confirmed} ms debounce instead of ${milliseconds} ms.`);
+      throw new Error(`The mouse kept ${confirmed} ms debounce instead of ${milliseconds} ms. Settings command map may need a capture from WE software.`);
     }
     return confirmed;
   }
@@ -254,12 +260,8 @@ export class EggWeHidClient {
     if (this.device.opened) await this.device.close();
   }
 
-  /**
-   * Dump raw responses for commands near the known battery command.
-   * Useful while reverse-engineering WE Series software traffic.
-   */
   async probeCommands(from = 0xa8, to = 0xc0): Promise<string> {
-    const lines: string[] = [];
+    const lines: string[] = [`target: ${this.describeCollections()}`];
     for (let command = from; command <= to; command += 1) {
       try {
         const response = await this.query(command, { wake: command === COMMAND.battery });
@@ -277,28 +279,43 @@ export class EggWeHidClient {
     percent: number | null;
     state: MouseStatus["batteryState"];
   }> {
-    // Public WE battery protocol: double-read with wake delays.
-    const first = await this.query(COMMAND.battery, { wake: true });
-    void first;
+    // Public WE battery protocol: double-read with wake delays, command 0xb4.
+    await this.query(COMMAND.battery, { wake: true });
     await this.delay(100);
     const response = await this.query(COMMAND.battery, { wake: true });
-    const statusByte = response[1];
+    const statusByte = this.responseByte(response, 1);
+    const percentByte = this.responseByte(response, 16);
+
     if (statusByte !== 0x01 && statusByte !== 0x08) {
-      // Still surface a best-effort percentage if the payload looks sane.
-      const maybe = response[16];
-      if (maybe !== undefined && maybe <= 100) {
+      if (percentByte !== undefined && percentByte <= 100) {
         return {
-          percent: maybe,
+          percent: percentByte,
           state: this.productMeta().wired ? "Charging" : "Discharging",
         };
       }
       return { percent: null, state: "Unknown" };
     }
-    const percent = Math.min(response[16] ?? 0, 100);
     return {
-      percent,
+      percent: Math.min(percentByte ?? 0, 100),
       state: this.productMeta().wired ? "Charging" : "Discharging",
     };
+  }
+
+  /**
+   * Map Windows-style offsets (report id at index 0) onto WebHID buffers
+   * that usually omit the report id.
+   */
+  private responseByte(response: Uint8Array, windowsIndex: number): number | undefined {
+    if (this.responseIncludesReportId === true) return response[windowsIndex];
+    if (this.responseIncludesReportId === false) return response[windowsIndex - 1];
+
+    // Auto-detect once we see a plausible battery frame.
+    if (response[0] === 0xa1 || response[0] === 0xa0) {
+      this.responseIncludesReportId = true;
+      return response[windowsIndex];
+    }
+    this.responseIncludesReportId = false;
+    return response[windowsIndex - 1];
   }
 
   private async readDeviceState(): Promise<{
@@ -308,37 +325,17 @@ export class EggWeHidClient {
     debounceMs: number;
     firmware: string | null;
   }> {
-    // Prefer a dedicated status block; fall back to piecing individual reads.
     try {
       const block = await this.query(COMMAND.status);
       if (this.looksLikeStatus(block)) return this.parseStatusBlock(block);
     } catch {
-      // Individual commands below.
+      // Fall through to defaults — provisional status commands often fail.
     }
-
-    const dpiPacket = await this.query(COMMAND.dpi).catch(() => null);
-    const pollingPacket = await this.query(COMMAND.polling).catch(() => null);
-    const lodPacket = await this.query(COMMAND.lod).catch(() => null);
-    const debouncePacket = await this.query(COMMAND.debounce).catch(() => null);
-
-    const dpi = dpiPacket
-      ? (dpiPacket[STATUS.dpiLo] | (dpiPacket[STATUS.dpiHi] << 8))
-      : DEFAULT_DPI;
-    const pollingRateHz = pollingPacket
-      ? this.decodePolling(pollingPacket[STATUS.polling] ?? pollingPacket[2] ?? 0)
-      : DEFAULT_POLLING;
-    const lodRaw = lodPacket?.[STATUS.lod] ?? lodPacket?.[2] ?? 1;
-    const liftOffDistance: NonNullable<MouseStatus["liftOffDistance"]> =
-      lodRaw === 2 ? "High" : "Medium";
-    const debounceMs = debouncePacket?.[STATUS.debounce] ?? debouncePacket?.[2] ?? DEFAULT_DEBOUNCE;
-
     return {
-      dpi: this.clampDpi(dpi),
-      pollingRateHz: POLLING_RATES.includes(pollingRateHz as (typeof POLLING_RATES)[number])
-        ? pollingRateHz
-        : DEFAULT_POLLING,
-      liftOffDistance,
-      debounceMs: Math.min(Math.max(debounceMs, 0), 15),
+      dpi: DEFAULT_DPI,
+      pollingRateHz: DEFAULT_POLLING,
+      liftOffDistance: "Medium",
+      debounceMs: DEFAULT_DEBOUNCE,
       firmware: null,
     };
   }
@@ -350,14 +347,17 @@ export class EggWeHidClient {
     debounceMs: number;
     firmware: string | null;
   } {
-    const dpi = this.clampDpi(block[STATUS.dpiLo] | (block[STATUS.dpiHi] << 8));
-    const pollingRateHz = this.decodePolling(block[STATUS.polling]);
+    const dpi = this.clampDpi(
+      (this.responseByte(block, 4) ?? 0) | ((this.responseByte(block, 5) ?? 0) << 8),
+    );
+    const pollingRateHz = this.decodePolling(this.responseByte(block, 6) ?? 0);
+    const lodRaw = this.responseByte(block, 7) ?? 1;
     const liftOffDistance: NonNullable<MouseStatus["liftOffDistance"]> =
-      block[STATUS.lod] === 2 ? "High" : "Medium";
-    const debounceMs = Math.min(Math.max(block[STATUS.debounce] ?? DEFAULT_DEBOUNCE, 0), 15);
-    const major = block[STATUS.firmwareMajor];
-    const minor = block[STATUS.firmwareMinor];
-    const firmware = major !== undefined && minor !== undefined
+      lodRaw === 2 ? "High" : "Medium";
+    const debounceMs = Math.min(Math.max(this.responseByte(block, 8) ?? DEFAULT_DEBOUNCE, 0), 15);
+    const major = this.responseByte(block, 10);
+    const minor = this.responseByte(block, 11);
+    const firmware = major !== undefined && minor !== undefined && (major !== 0 || minor !== 0)
       ? `${major}.${minor}`
       : null;
     return {
@@ -372,10 +372,10 @@ export class EggWeHidClient {
   }
 
   private looksLikeStatus(block: Uint8Array): boolean {
-    const dpi = block[STATUS.dpiLo] | (block[STATUS.dpiHi] << 8);
-    const polling = this.decodePolling(block[STATUS.polling]);
-    const lod = block[STATUS.lod];
-    const debounce = block[STATUS.debounce];
+    const dpi = (this.responseByte(block, 4) ?? 0) | ((this.responseByte(block, 5) ?? 0) << 8);
+    const polling = this.decodePolling(this.responseByte(block, 6) ?? 0);
+    const lod = this.responseByte(block, 7);
+    const debounce = this.responseByte(block, 8);
     return dpi >= 50 && dpi <= 19000 && dpi % 50 === 0
       && POLLING_RATES.includes(polling as (typeof POLLING_RATES)[number])
       && (lod === 1 || lod === 2)
@@ -384,42 +384,120 @@ export class EggWeHidClient {
 
   private async readFirmware(): Promise<string | null> {
     const response = await this.query(COMMAND.firmware);
-    const major = response[2] ?? response[STATUS.firmwareMajor];
-    const minor = response[3] ?? response[STATUS.firmwareMinor];
+    const major = this.responseByte(response, 2) ?? this.responseByte(response, 10);
+    const minor = this.responseByte(response, 3) ?? this.responseByte(response, 11);
     if (major === undefined || minor === undefined) return null;
     if (major === 0 && minor === 0) return null;
     return `${major}.${minor}`;
   }
 
   private async writeSetting(command: number, payload: number[]): Promise<void> {
-    await this.open();
-    const packet = new Uint8Array(REPORT_SIZE);
-    packet[0] = REPORT.write;
-    packet[1] = command;
-    packet[2] = payload.length;
+    // WE battery uses the same report for set+get; do not use 0xa0 unless that
+    // is the only report the interface exposes.
+    const data = new Uint8Array(Math.max(1 + payload.length, 2));
+    data[0] = command;
+    data[1] = payload.length;
     for (let index = 0; index < payload.length; index += 1) {
-      packet[3 + index] = payload[index] & 0xff;
+      data[2 + index] = payload[index] & 0xff;
     }
-    // WebHID sendFeatureReport omits report id from the data argument.
-    await this.device.sendFeatureReport(REPORT.write, packet.slice(1));
+    await this.sendFeature(data);
     await this.delay(50);
   }
 
   private query(command: number, options: { wake?: boolean } = {}): Promise<Uint8Array> {
     const run = async (): Promise<Uint8Array> => {
       await this.open();
-      const packet = new Uint8Array(REPORT_SIZE);
-      packet[0] = REPORT.read;
-      packet[1] = command;
-      await this.device.sendFeatureReport(REPORT.read, packet.slice(1));
+      const data = new Uint8Array(1);
+      data[0] = command;
+      await this.sendFeature(data);
       if (options.wake) await this.delay(350);
       else await this.delay(40);
-      const view = await this.device.receiveFeatureReport(REPORT.read);
-      return this.copyDataView(view);
+      return await this.receiveFeature();
     };
     const next = this.commandQueue.then(run, run);
     this.commandQueue = next.then(() => undefined, () => undefined);
     return next;
+  }
+
+  private async sendFeature(payload: Uint8Array): Promise<void> {
+    await this.open();
+    const target = this.reportTarget ?? this.resolveReportTarget();
+    const candidates = this.sendCandidates(target, payload);
+    let lastError: Error | null = null;
+
+    for (const candidate of candidates) {
+      try {
+        // Copy into a standalone ArrayBuffer so TS/BufferSource stay happy.
+        const body = new Uint8Array(candidate.data.byteLength);
+        body.set(candidate.data);
+        await this.device.sendFeatureReport(candidate.reportId, body);
+        this.reportTarget = { reportId: candidate.reportId, payloadLength: candidate.data.byteLength };
+        return;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+      }
+    }
+
+    const detail = this.describeCollections();
+    const message = lastError?.message ?? "Failed to write the feature report.";
+    throw new Error(
+      `${message} Tried report(s) on ${this.device.productName || "device"} `
+      + `(PID 0x${this.device.productId.toString(16)}, ${detail}). `
+      + "Close official WE software and pick the vendor interface if several appear.",
+    );
+  }
+
+  /**
+   * Build sized payloads. WebHID requires the exact feature report length from
+   * the descriptor; wrong length → "Failed to write the feature report."
+   */
+  private sendCandidates(
+    preferred: FeatureReportTarget,
+    payload: Uint8Array,
+  ): Array<{ reportId: number; data: Uint8Array }> {
+    const reports = EggWeHidClient.listFeatureReports(this.device);
+    const reportIds = [
+      preferred.reportId,
+      ...PREFERRED_REPORT_IDS,
+      ...reports.map((report) => report.reportId),
+    ].filter((id, index, all) => all.indexOf(id) === index);
+
+    const lengths = [
+      preferred.payloadLength,
+      ...reports.map((report) => report.payloadLength),
+      63, // 64-byte report with id excluded
+      64,
+      32,
+      31,
+      Math.max(payload.byteLength, 1),
+    ].filter((length, index, all) => length > 0 && all.indexOf(length) === index);
+
+    const candidates: Array<{ reportId: number; data: Uint8Array }> = [];
+    for (const reportId of reportIds) {
+      for (const length of lengths) {
+        const data = new Uint8Array(length);
+        data.set(payload.subarray(0, Math.min(payload.byteLength, length)));
+        candidates.push({ reportId, data });
+      }
+    }
+    return candidates;
+  }
+
+  private async receiveFeature(): Promise<Uint8Array> {
+    await this.open();
+    const target = this.reportTarget ?? this.resolveReportTarget();
+    const reportIds = [target.reportId, ...PREFERRED_REPORT_IDS]
+      .filter((id, index, all) => all.indexOf(id) === index);
+    let lastError: Error | null = null;
+    for (const reportId of reportIds) {
+      try {
+        const view = await this.device.receiveFeatureReport(reportId);
+        return this.copyDataView(view);
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+      }
+    }
+    throw lastError ?? new Error("Failed to read the feature report.");
   }
 
   private encodePolling(rate: number): number {
@@ -439,7 +517,6 @@ export class EggWeHidClient {
 
   private clampDpi(dpi: number): number {
     if (this.getDpiOptions().includes(dpi)) return dpi;
-    // Round to nearest legal step when firmware returns a slightly off value.
     const stepped = Math.round(dpi / 50) * 50;
     if (this.getDpiOptions().includes(stepped)) return stepped;
     return DEFAULT_DPI;

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -67,16 +67,19 @@ export class EggWeHidClient {
   }
 
   /**
-   * Among WE-capable devices, collapse cable + receiver into one logical mouse.
-   * Prefer cable when both are present; otherwise keep a single receiver.
+   * Among WE-capable HID interfaces, pick exactly one logical mouse.
+   * Prefer cable over receiver; among equals, highest supportScore wins.
+   * (A single USB mouse often enumerates multiple interfaces — never return both.)
    */
   static pickDevices(devices: readonly HIDDevice[]): HIDDevice[] {
     const we = devices.filter((device) => this.isSupported(device));
     if (we.length === 0) return [];
-    const cables = we.filter((device) => !this.isReceiverDevice(device));
-    const receivers = we.filter((device) => this.isReceiverDevice(device));
-    if (cables.length > 0) return cables;
-    return receivers.slice(0, 1);
+    const ranked = [...we].sort((left, right) => {
+      const receiverDelta = Number(this.isReceiverDevice(left)) - Number(this.isReceiverDevice(right));
+      if (receiverDelta !== 0) return receiverDelta; // non-receiver first
+      return this.supportScore(right) - this.supportScore(left);
+    });
+    return ranked[0] ? [ranked[0]] : [];
   }
 
   static supportScore(device: HIDDevice): number {
@@ -86,8 +89,10 @@ export class EggWeHidClient {
     if (OP1WE_RECEIVER_PIDS.has(device.productId)) score += 2;
     if (!this.isReceiverDevice(device)) score += 4;
     const features = this.listFeatureReports(device);
-    if (features.some((report) => report.reportId === 0x08)) score += 2;
+    if (features.some((report) => report.reportId === 0x08)) score += 3;
     if (features.some((report) => report.reportId === 0x06)) score += 1;
+    // Prefer interfaces that actually expose config reports over bare boot mice.
+    if (features.length > 0) score += 2;
     return score;
   }
 

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -45,10 +45,10 @@ export class EggWeHidClient {
   static readonly pollIntervalMs = 0;
 
   /**
-   * When true, attempt one battery feature read on the receiver path.
-   * Set false immediately if wireless freezes return.
+   * Wireless battery HID is off until OEM capture — dongle chatter freezes the
+   * mouse and current commands only return empty frames.
    */
-  static readonly ALLOW_WIRELESS_BATTERY = true;
+  static readonly ALLOW_WIRELESS_BATTERY = false;
 
   constructor(readonly device: HIDDevice) {}
 
@@ -271,87 +271,117 @@ export class EggWeHidClient {
   }
 
   // ---------------------------------------------------------------------------
-  // Battery — few short attempts, no refresh loop
-  // Earlier working path used report 0x06 (7B) + cmd 0x04 on this hardware.
+  // Battery
+  // User capture: feature 0x08/16B returns 08 + zeros (no payload yet);
+  // feature 0x06 with wrong length fails write. Need exact sizes + possibly
+  // output/input (Pulsar-style) or OEM wake sequence — Wireshark will settle.
   // ---------------------------------------------------------------------------
 
-  private batteryTargets(): FeatureReportTarget[] {
+  private batteryFeatureTargets(): FeatureReportTarget[] {
     const fromDescriptor = EggWeHidClient.listFeatureReports(this.device)
       .filter((report) => report.payloadLength > 0);
-    const extras: FeatureReportTarget[] = [
+    // Only exact sizes that match this hardware (never invent len=6).
+    const known: FeatureReportTarget[] = [
       { reportId: 0x06, payloadLength: 7 },
       { reportId: 0x08, payloadLength: 16 },
-      { reportId: 0x08, payloadLength: 15 },
-      { reportId: 0x06, payloadLength: 6 },
     ];
-    const merged = [...fromDescriptor, ...extras];
-    // Prefer 0x06 first — that is what succeeded on the user's OP1we before.
-    merged.sort((left, right) => {
-      const rank = (report: FeatureReportTarget): number => {
-        if (report.reportId === 0x06) return 0;
-        if (report.reportId === 0x08) return 1;
-        return 2;
-      };
-      return rank(left) - rank(right) || left.payloadLength - right.payloadLength;
-    });
+    const merged = [...fromDescriptor, ...known];
     const seen = new Set<string>();
-    return merged.filter((target) => {
-      const key = `${target.reportId}:${target.payloadLength}`;
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
+    return merged
+      .filter((target) => {
+        // Drop known-bad sizes from empty item counts.
+        if (target.reportId === 0x06 && target.payloadLength !== 7) return false;
+        if (target.reportId === 0x08 && target.payloadLength < 15) return false;
+        const key = `${target.reportId}:${target.payloadLength}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .sort((left, right) => {
+        // Prefer 0x06/7 (previously returned data) then 0x08/16.
+        if (left.reportId !== right.reportId) {
+          return left.reportId === 0x06 ? -1 : right.reportId === 0x06 ? 1 : left.reportId - right.reportId;
+        }
+        return left.payloadLength - right.payloadLength;
+      });
   }
 
   private async readBatteryOnce(wireless: boolean): Promise<{
     percent: number | null;
     state: MouseStatus["batteryState"];
   }> {
-    // Cap attempts: wireless ≤2, wired ≤6 (2 reports × 2 cmds × variants, early exit).
-    const targets = this.batteryTargets().slice(0, wireless ? 2 : 4);
-    const commands = wireless ? [0x04] : [0x04, 0xb4];
+    const targets = this.batteryFeatureTargets().slice(0, wireless ? 2 : 4);
+    const commands = wireless ? [0x04] : [0x04, 0xb4, 0x05];
     let lastRaw = "";
 
     for (const target of targets) {
       for (const command of commands) {
-        for (const withChecksum of target.payloadLength >= 16 ? [false, true] : [false]) {
+        // Feature report path (no checksum first — zeros were returned with/without).
+        try {
+          const response = await this.featureExchange(target, command, wireless, false);
+          lastRaw = this.toHex(response);
+          const parsed = this.parseBattery(response, command, wireless);
+          if (parsed.percent !== null) {
+            console.info(`[OpenMouse WE battery] ok feature 0x${target.reportId.toString(16)}/${target.payloadLength} cmd=0x${command.toString(16)} raw=[${lastRaw}] → ${parsed.percent}%`);
+            return this.batteryResult(parsed.percent, parsed.charging, wireless);
+          }
+          console.info(`[OpenMouse WE battery] empty feature 0x${target.reportId.toString(16)}/${target.payloadLength} cmd=0x${command.toString(16)} raw=[${lastRaw}]`);
+        } catch (error) {
+          lastRaw = error instanceof Error ? error.message : String(error);
+          console.info(`[OpenMouse WE battery] fail feature 0x${target.reportId.toString(16)}/${target.payloadLength} cmd=0x${command.toString(16)}: ${lastRaw}`);
+        }
+
+        // Wired only: double-read wake (old EGG battery pattern) for 0xb4 / 0x04.
+        if (!wireless && (command === 0x04 || command === 0xb4)) {
           try {
-            const response = await this.featureExchange(target, command, wireless, withChecksum);
-            lastRaw = [...response].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
+            const response = await this.featureExchangeWake(target, command);
+            lastRaw = this.toHex(response);
             const parsed = this.parseBattery(response, command, wireless);
             if (parsed.percent !== null) {
-              console.info(
-                `[OpenMouse WE battery] ok report=0x${target.reportId.toString(16)} `
-                + `len=${target.payloadLength} cmd=0x${command.toString(16)} `
-                + `checksum=${withChecksum} raw=[${lastRaw}] → ${parsed.percent}%`,
-              );
-              return {
-                percent: parsed.percent,
-                state: parsed.charging
-                  ? (parsed.percent >= 99 ? "Full" : "Charging")
-                  : (wireless ? "Discharging" : "Charging"),
-              };
+              console.info(`[OpenMouse WE battery] ok wake 0x${target.reportId.toString(16)} cmd=0x${command.toString(16)} raw=[${lastRaw}] → ${parsed.percent}%`);
+              return this.batteryResult(parsed.percent, parsed.charging, wireless);
             }
-            console.info(
-              `[OpenMouse WE battery] no parse report=0x${target.reportId.toString(16)} `
-              + `len=${target.payloadLength} cmd=0x${command.toString(16)} raw=[${lastRaw}]`,
-            );
           } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            lastRaw = message;
-            console.info(
-              `[OpenMouse WE battery] fail report=0x${target.reportId.toString(16)} `
-              + `len=${target.payloadLength} cmd=0x${command.toString(16)}: ${message}`,
-            );
+            lastRaw = error instanceof Error ? error.message : String(error);
+          }
+        }
+
+        // Output/input path (same report id family as Pulsar 0x08) — cable only.
+        if (!wireless && target.reportId === 0x08) {
+          try {
+            const response = await this.outputExchange(target, command);
+            lastRaw = this.toHex(response);
+            const parsed = this.parseBattery(response, command, wireless);
+            if (parsed.percent !== null) {
+              console.info(`[OpenMouse WE battery] ok output 0x08 cmd=0x${command.toString(16)} raw=[${lastRaw}] → ${parsed.percent}%`);
+              return this.batteryResult(parsed.percent, parsed.charging, wireless);
+            }
+            console.info(`[OpenMouse WE battery] empty output 0x08 cmd=0x${command.toString(16)} raw=[${lastRaw}]`);
+          } catch (error) {
+            lastRaw = error instanceof Error ? error.message : String(error);
+            console.info(`[OpenMouse WE battery] fail output 0x08: ${lastRaw}`);
           }
         }
       }
-      // Wireless: at most two report targets (0x06 then 0x08), no command flood.
       if (wireless) break;
     }
 
-    console.info(`[OpenMouse WE battery] unread last=${lastRaw || "none"}`);
+    console.info(
+      `[OpenMouse WE battery] unread pid=0x${this.device.productId.toString(16)} `
+      + `reports=${this.describeCollections()} last=${lastRaw || "none"}`,
+    );
     return { percent: null, state: "Unknown" };
+  }
+
+  private batteryResult(
+    percent: number,
+    charging: boolean,
+    wireless: boolean,
+  ): { percent: number; state: MouseStatus["batteryState"] } {
+    if (charging) {
+      return { percent, state: percent >= 99 ? "Full" : "Charging" };
+    }
+    return { percent, state: wireless ? "Discharging" : "Charging" };
   }
 
   private async featureExchange(
@@ -369,23 +399,62 @@ export class EggWeHidClient {
       packet[15] = (0x55 - (sum & 0xff) - target.reportId) & 0xff;
     }
     await this.device.sendFeatureReport(target.reportId, packet);
-    // Short settle; double-get can help flaky feature endpoints on cable only.
-    await this.delay(wireless ? 40 : 60);
-    let view = await this.device.receiveFeatureReport(target.reportId);
-    let bytes = new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
-    if (!wireless && bytes.every((byte) => byte === 0)) {
-      await this.delay(80);
-      view = await this.device.receiveFeatureReport(target.reportId);
-      bytes = new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
-    }
-    return bytes;
+    await this.delay(wireless ? 40 : 80);
+    const view = await this.device.receiveFeatureReport(target.reportId);
+    return this.copyView(view);
   }
 
-  /**
-   * Parse battery from a single response.
-   * Accept 1–99 at likely payload indices. Reject bare 100 on wireless.
-   * Also try Windows-style layout (report id at [0]) by shifting indices +1.
-   */
+  /** Classic EGG-style double transaction (discard first response). */
+  private async featureExchangeWake(
+    target: FeatureReportTarget,
+    command: number,
+  ): Promise<Uint8Array> {
+    const packet = new Uint8Array(target.payloadLength);
+    packet[0] = command;
+    await this.device.sendFeatureReport(target.reportId, packet);
+    await this.delay(200);
+    try {
+      await this.device.receiveFeatureReport(target.reportId);
+    } catch {
+      // ignore first
+    }
+    await this.delay(80);
+    await this.device.sendFeatureReport(target.reportId, packet);
+    await this.delay(200);
+    return this.copyView(await this.device.receiveFeatureReport(target.reportId));
+  }
+
+  private async outputExchange(
+    target: FeatureReportTarget,
+    command: number,
+  ): Promise<Uint8Array> {
+    const packet = new Uint8Array(target.payloadLength);
+    packet[0] = command;
+    // Soft wait for matching input report.
+    const reply = new Promise<Uint8Array>((resolve) => {
+      const timer = window.setTimeout(() => {
+        this.device.removeEventListener("inputreport", onInput);
+        resolve(new Uint8Array());
+      }, 600);
+      const onInput = (event: HIDInputReportEvent): void => {
+        if (event.reportId !== target.reportId) return;
+        window.clearTimeout(timer);
+        this.device.removeEventListener("inputreport", onInput);
+        resolve(this.copyView(event.data));
+      };
+      this.device.addEventListener("inputreport", onInput);
+    });
+    await this.device.sendReport(target.reportId, packet);
+    const input = await reply;
+    if (input.byteLength > 0) return input;
+    // Fall back to feature get on same id.
+    try {
+      return this.copyView(await this.device.receiveFeatureReport(target.reportId));
+    } catch {
+      return input;
+    }
+  }
+
   private parseBattery(
     response: Uint8Array,
     command: number,
@@ -393,50 +462,56 @@ export class EggWeHidClient {
   ): { percent: number | null; charging: boolean } {
     if (response.byteLength === 0) return { percent: null, charging: !wireless };
 
-    // Detect whether byte0 is a report id (0x06/0x08) rather than a command echo.
-    const hasReportIdPrefix = response[0] === 0x06 || response[0] === 0x08;
-    const at = (index: number): number | undefined => {
-      const real = hasReportIdPrefix ? index + 1 : index;
-      return real < response.byteLength ? response[real] : undefined;
-    };
+    // Strip leading report id if present (08 00 00… from user's capture).
+    let data = response;
+    if ((response[0] === 0x06 || response[0] === 0x08) && response.byteLength > 1) {
+      // If everything after report id is zero, there is no battery payload yet.
+      if (response.slice(1).every((byte) => byte === 0)) {
+        return { percent: null, charging: !wireless };
+      }
+      data = response.slice(1);
+    }
 
-    const chargeFlag = at(6);
+    // All-zero payload = device ignored the command.
+    if (data.every((byte) => byte === 0)) {
+      return { percent: null, charging: !wireless };
+    }
+
+    const chargeFlag = data[6];
     const charging = chargeFlag === 1 || chargeFlag === 2
-      || (!wireless && chargeFlag !== 0 && chargeFlag !== undefined);
+      || (!wireless && chargeFlag !== undefined && chargeFlag !== 0);
 
     const asPercent = (raw: number | undefined): number | null => {
-      if (raw === undefined) return null;
-      if (raw === command) return null;
-      if (raw === 0 || raw > 100) return null;
-      if (raw === 100) {
-        // Only trust 100 when charge flag implies charging/full.
-        if (chargeFlag === 1 || chargeFlag === 2) return 100;
-        if (wireless) return null;
-        return 100;
-      }
+      if (raw === undefined || raw === command) return null;
+      if (raw <= 0 || raw > 100) return null;
+      if (raw === 100 && wireless && chargeFlag !== 1 && chargeFlag !== 2) return null;
       return raw;
     };
 
-    // Preferred order: CompX/Pulsar percent @5, then nearby payload bytes.
-    for (const index of [5, 4, 3, 2, 6, 1, 7]) {
-      const value = asPercent(at(index));
+    for (const index of [5, 4, 3, 2, 6, 1, 7, 8, 9, 10]) {
+      const value = asPercent(data[index]);
       if (value !== null && value < 100) {
         return { percent: value, charging: charging || !wireless };
       }
     }
 
-    // Direct buffer scan (no shift) as last resort — skip [0].
-    for (let index = 1; index < response.byteLength; index += 1) {
-      const value = asPercent(response[index]);
+    // Any non-zero 1–99 in payload (last resort).
+    for (let index = 1; index < data.byteLength; index += 1) {
+      const value = asPercent(data[index]);
       if (value !== null && value < 100) {
         return { percent: value, charging: charging || !wireless };
       }
     }
-
-    const full = asPercent(at(5)) ?? asPercent(at(4)) ?? asPercent(response[5]);
-    if (full === 100) return { percent: 100, charging: true };
 
     return { percent: null, charging: !wireless };
+  }
+
+  private toHex(bytes: Uint8Array): string {
+    return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
+  }
+
+  private copyView(view: DataView): Uint8Array {
+    return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
   }
 
   private delay(milliseconds: number): Promise<void> {

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -44,6 +44,12 @@ export class EggWeHidClient {
   /** No background polling — feature traffic freezes the wireless mouse. */
   static readonly pollIntervalMs = 0;
 
+  /**
+   * When true, attempt one battery feature read on the receiver path.
+   * Set false immediately if wireless freezes return.
+   */
+  static readonly ALLOW_WIRELESS_BATTERY = true;
+
   constructor(readonly device: HIDDevice) {}
 
   static isSupported(device: HIDDevice): boolean {
@@ -191,47 +197,31 @@ export class EggWeHidClient {
   }
 
   /**
-   * Identity + connection. Wireless does zero config HID.
-   * Wired may attempt a single battery read (best-effort, approximate).
+   * Identity + connection + best-effort battery.
+   * UI fields match other brands (short connection/firmware text — no debug dump).
+   *
+   * Wireless: one optional battery read only (no probes/refresh). If freezes return,
+   * set ALLOW_WIRELESS_BATTERY to false.
    */
   async readStatus(): Promise<MouseStatus> {
     const meta = this.productMeta();
     const wireless = meta.viaReceiver;
 
-    if (wireless) {
-      // CRITICAL: no sendFeatureReport / sendReport — freezes the OP1we.
-      return {
-        brand: "Endgame Gear",
-        name: meta.name,
-        batteryPercent: null,
-        batteryState: "Unknown",
-        dpi: 800,
-        pollingRateHz: 1000,
-        supportedPollingRates: this.supportedPollingRates,
-        activeProfile: null,
-        connectionType: "Wireless",
-        connectionDetail:
-          `2.4 GHz via receiver · PID 0x${this.device.productId.toString(16).toUpperCase()} `
-          + "· config HID idle (avoids freeze) · settings map pending RE",
-        debounceMs: null,
-        liftOffDistance: null,
-        firmware: ["Wireless path · no config HID"],
-      };
-    }
-
-    // Wired: optional single battery read only.
     let batteryPercent: number | null = null;
     let batteryState: MouseStatus["batteryState"] = "Unknown";
-    let batteryNote = "battery skipped";
 
-    try {
-      await this.open();
-      const battery = await this.readBatteryOnce();
-      batteryPercent = battery.percent;
-      batteryState = battery.state;
-      batteryNote = battery.note;
-    } catch (error) {
-      batteryNote = error instanceof Error ? error.message : "battery read failed";
+    // Wired: always try battery. Wireless: single read only (no auto-refresh).
+    if (!wireless || EggWeHidClient.ALLOW_WIRELESS_BATTERY) {
+      try {
+        if (!wireless) await this.open();
+        else if (!this.device.opened) await this.device.open();
+        const battery = await this.readBatteryOnce(wireless);
+        batteryPercent = battery.percent;
+        batteryState = battery.state;
+      } catch {
+        batteryPercent = null;
+        batteryState = "Unknown";
+      }
     }
 
     return {
@@ -239,20 +229,17 @@ export class EggWeHidClient {
       name: meta.name,
       batteryPercent,
       batteryState,
+      // Placeholders until settings protocol is mapped (UI keeps controls disabled).
       dpi: 800,
       pollingRateHz: 1000,
       supportedPollingRates: this.supportedPollingRates,
       activeProfile: null,
-      connectionType: "Wired",
-      connectionDetail: [
-        "Wired USB",
-        `PID 0x${this.device.productId.toString(16).toUpperCase()}`,
-        batteryNote,
-        "settings map pending RE",
-      ].join(" · "),
+      connectionType: wireless ? "Wireless" : "Wired",
+      // Same style as other brands: short human text, no PID/debug.
+      connectionDetail: wireless ? "2.4 GHz receiver" : "USB",
       debounceMs: null,
       liftOffDistance: null,
-      firmware: ["Firmware unread (settings map pending)"],
+      firmware: [],
     };
   }
 
@@ -284,13 +271,14 @@ export class EggWeHidClient {
   }
 
   // ---------------------------------------------------------------------------
-  // Battery (wired only) — single transaction, best-effort
+  // Battery — at most one feature transaction (no multi-command probes)
   // ---------------------------------------------------------------------------
 
   private resolvePreferredTarget(): FeatureReportTarget {
     const features = EggWeHidClient.listFeatureReports(this.device)
       .filter((report) => report.payloadLength > 0);
-    const by08 = features.find((report) => report.reportId === 0x08);
+    // Prefer 16-byte config report when present; fall back to 7-byte (0x06).
+    const by08 = features.find((report) => report.reportId === 0x08 && report.payloadLength >= 15);
     if (by08) return by08;
     const by06 = features.find((report) => report.reportId === 0x06);
     if (by06) return by06;
@@ -298,58 +286,100 @@ export class EggWeHidClient {
     return { reportId: 0x06, payloadLength: 7 };
   }
 
-  private async readBatteryOnce(): Promise<{
+  private async readBatteryOnce(wireless: boolean): Promise<{
     percent: number | null;
     state: MouseStatus["batteryState"];
-    note: string;
   }> {
-    if (this.isWirelessPath()) {
-      return { percent: null, state: "Unknown", note: "battery n/a on wireless" };
-    }
-
     const target = this.resolvePreferredTarget();
-    const packet = new Uint8Array(target.payloadLength);
-    packet[0] = 0x04; // CompX-style battery command candidate
+    // Try 0x04 first (CompX/Pulsar-style). One packet only on wireless.
+    const commands = wireless ? [0x04] : [0x04, 0xb4];
 
-    try {
-      await this.device.sendFeatureReport(target.reportId, packet);
-      await this.delay(40);
-      const view = await this.device.receiveFeatureReport(target.reportId);
-      const response = new Uint8Array(
-        view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength),
-      );
-      const raw = [...response].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
-      // Prefer index 5 when present; never treat 100 as trusted without flags.
-      let percent: number | null = null;
-      let index = -1;
-      if (response.byteLength > 5) {
-        const value = response[5];
-        if (value >= 1 && value <= 99) {
-          percent = value;
-          index = 5;
+    for (const command of commands) {
+      try {
+        const response = await this.featureExchange(target, command, wireless);
+        const parsed = this.parseBattery(response, command, wireless);
+        if (parsed.percent !== null) {
+          return {
+            percent: parsed.percent,
+            state: parsed.charging
+              ? (parsed.percent >= 99 ? "Full" : "Charging")
+              : (wireless ? "Discharging" : "Charging"),
+          };
         }
+        // Wired: try next command once. Wireless: stop after first attempt.
+        if (wireless) break;
+      } catch {
+        if (wireless) break;
       }
-      if (percent === null) {
-        for (let i = 1; i < Math.min(response.byteLength, 7); i += 1) {
-          const value = response[i];
-          if (value >= 1 && value <= 99) {
-            percent = value;
-            index = i;
-            break;
-          }
-        }
-      }
-      return {
-        percent,
-        state: percent !== null ? "Charging" : "Unknown",
-        note: percent !== null
-          ? `batt@${index} ~${percent}% (approx) raw ${raw}`
-          : `battery unread raw ${raw}`,
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return { percent: null, state: "Unknown", note: `battery fail: ${message}` };
     }
+    return { percent: null, state: "Unknown" };
+  }
+
+  private async featureExchange(
+    target: FeatureReportTarget,
+    command: number,
+    wireless: boolean,
+  ): Promise<Uint8Array> {
+    const packet = new Uint8Array(target.payloadLength);
+    packet[0] = command;
+    if (target.payloadLength >= 16) {
+      // Pulsar-style length + checksum on 16-byte frames.
+      packet[4] = 0;
+      let sum = 0;
+      for (let i = 0; i < packet.length - 1; i += 1) sum += packet[i];
+      packet[15] = (0x55 - (sum & 0xff) - target.reportId) & 0xff;
+    }
+    await this.device.sendFeatureReport(target.reportId, packet);
+    await this.delay(wireless ? 30 : 50);
+    const view = await this.device.receiveFeatureReport(target.reportId);
+    return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+  }
+
+  /**
+   * Parse battery from a single response.
+   * Observed earlier: wrong byte → 52% vs OEM ~70%; 100% on dongle was a flag.
+   * Prefer CompX layout percent @5; reject 100 unless charge looks full.
+   */
+  private parseBattery(
+    response: Uint8Array,
+    command: number,
+    wireless: boolean,
+  ): { percent: number | null; charging: boolean } {
+    if (response.byteLength === 0) return { percent: null, charging: !wireless };
+
+    const max = response.byteLength - 1;
+    const chargeFlag = max >= 6 ? response[6] : undefined;
+    const charging = chargeFlag === 1 || chargeFlag === 2 || (!wireless && chargeFlag !== 0);
+
+    const tryIndex = (index: number): number | null => {
+      if (index < 0 || index > max) return null;
+      const raw = response[index];
+      if (raw === command) return null;
+      if (raw === 0 || raw > 100) return null;
+      // 100% on wireless is almost always a status flag, not charge level.
+      if (raw === 100 && wireless && chargeFlag !== 1 && chargeFlag !== 2) return null;
+      if (raw === 100 && !charging && wireless) return null;
+      if (raw >= 1 && raw <= 100) return raw;
+      return null;
+    };
+
+    // 1) Preferred CompX/Pulsar layout: percent at [5]
+    const at5 = tryIndex(5);
+    if (at5 !== null) return { percent: at5, charging };
+
+    // 2) Other payload indices (skip [0] command echo; skip last byte if 16B checksum)
+    const last = response.byteLength >= 16 ? max - 1 : max;
+    const order = [4, 3, 2, 6, 1, 7].filter((index) => index <= last);
+    for (const index of order) {
+      const value = tryIndex(index);
+      if (value !== null && value !== 100) return { percent: value, charging };
+    }
+
+    // 3) Allow 100% only if charge flag says charging/full
+    const full = tryIndex(5) ?? tryIndex(4);
+    if (full === 100) return { percent: 100, charging: true };
+
+    return { percent: null, charging: !wireless };
   }
 
   private delay(milliseconds: number): Promise<void> {

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -1,44 +1,34 @@
 import type { MouseStatus } from "./mouse-types";
 
 /**
- * Endgame Gear WE-series (OP1we and related).
+ * Endgame Gear WE-series (OP1we).
  *
- * Observed on OP1we (PID 0x1962):
- *   feature reports: 0x06 (7 bytes), 0x08 (16 bytes)
- * Older public RE for some EGG wireless used 0xa1/0xb4 — that map does NOT
- * apply to this firmware generation.
+ * Model:
+ * - One physical mouse (OP1we).
+ * - Cable HID (e.g. PID 0x1962) and receiver HID (e.g. PID 0x1961) are two
+ *   transports to that same mouse — never two products.
+ * - OEM software may list both interfaces; OpenMouse shows one OP1we.
  *
- * Settings (CPI/polling/LOD/debounce) still need a USB capture of WE software.
- * Battery is probed across the real report ids + common command bytes.
+ * Safety:
+ * - Wireless (receiver) path: NO feature/output config traffic. Any chatter
+ *   freezes the mouse. Identity-only status until protocol is captured offline.
+ * - Wired path: optional single battery attempt; no multi-command probes.
+ *
+ * Settings (CPI/polling/LOD/debounce) are not reverse-engineered yet.
  */
 
 const EGG_VENDOR_ID = 0x3367;
 
-/**
- * Known PIDs are hints only. Display name is always the mouse.
- * Observed OP1we: cable PID 0x1962, dongle PID 0x1961.
- */
-const KNOWN_MOUSE_NAMES = new Map<number, string>([
-  [0x1961, "Endgame Gear OP1we"],
-  [0x1962, "Endgame Gear OP1we"],
-  [0x1972, "Endgame Gear OP1we"],
-  [0x1970, "Endgame Gear OP1we"],
+/** Cable / dongle PIDs observed for OP1we and related WE family. */
+const OP1WE_CABLE_PIDS = new Set([0x1962, 0x1972]);
+const OP1WE_RECEIVER_PIDS = new Set([0x1961, 0x1970]);
+const OTHER_WE_MOUSE_PIDS = new Map<number, string>([
   [0x1968, "Endgame Gear XM2we"],
   [0x1982, "Endgame Gear XM2w"],
 ]);
 
-/** Dongle / receiver product IDs (HID path to the mouse over 2.4 GHz). */
-const RECEIVER_PIDS = new Set([0x1961, 0x1970]);
-
+/** Wired OP1 8K / XM2 8K — owned by egg-op1-hid. */
 const EGG_8K_PRODUCT_IDS = new Set([0x1964, 0x1966, 0x1976, 0x1978]);
-
-/** Lightweight battery command only — never spam the wireless link. */
-const BATTERY_COMMAND = 0x04;
-
-/** Full probe list — only used by explicit probeBattery(), never on a timer. */
-const BATTERY_COMMAND_CANDIDATES = [
-  0x04, 0xb4, 0x05, 0x0b, 0x0e, 0x01, 0x02, 0x03,
-] as const;
 
 const POLLING_RATES = [125, 250, 500, 1000] as const;
 
@@ -48,70 +38,61 @@ interface FeatureReportTarget {
 }
 
 export class EggWeHidClient {
-  private commandQueue: Promise<unknown> = Promise.resolve();
-  private reportTarget: FeatureReportTarget | null = null;
-  private lastBatteryRaw: string | null = null;
-  private lastBatteryError: string | null = null;
-  private lastBatteryNote: string | null = null;
-  private lockedBattery: { command: number; byteIndex: number } | null = null;
-  private useOutputReport = false;
-  private inputWaiter: {
-    reportId: number;
-    resolve: (bytes: Uint8Array) => void;
-    reject: (error: Error) => void;
-    timer: number;
-  } | null = null;
-
-  private readonly onInputReport = (event: HIDInputReportEvent): void => {
-    if (!this.inputWaiter || event.reportId !== this.inputWaiter.reportId) return;
-    const waiter = this.inputWaiter;
-    this.inputWaiter = null;
-    window.clearTimeout(waiter.timer);
-    waiter.resolve(this.copyDataView(event.data));
-  };
-
-  /**
-   * Settings command map is not reverse-engineered yet for this report family.
-   */
+  /** Settings writes are not mapped — keep false until USB capture of WE software. */
   static readonly settingsMapped = false;
+
+  /** No background polling — feature traffic freezes the wireless mouse. */
+  static readonly pollIntervalMs = 0;
 
   constructor(readonly device: HIDDevice) {}
 
   static isSupported(device: HIDDevice): boolean {
     if (device.vendorId !== EGG_VENDOR_ID) return false;
     if (EGG_8K_PRODUCT_IDS.has(device.productId)) return false;
+    // Known WE PIDs, or any non-8K EGG with a vendor feature/output report.
+    if (OP1WE_CABLE_PIDS.has(device.productId) || OP1WE_RECEIVER_PIDS.has(device.productId)) {
+      return true;
+    }
+    if (OTHER_WE_MOUSE_PIDS.has(device.productId)) return true;
     return this.listFeatureReports(device).length > 0
       || this.listOutputReports(device).length > 0
       || this.collectionTreeHasVendorUsage(device.collections);
   }
 
-  /**
-   * USB dongle / receiver interface (wireless path to the mouse).
-   * Prefer product-name match; also known dongle PIDs (0x1961, 0x1970).
-   */
+  /** Dongle HID interface — same mouse, wireless transport only. */
   static isReceiverDevice(device: HIDDevice): boolean {
-    if (RECEIVER_PIDS.has(device.productId)) return true;
+    if (OP1WE_RECEIVER_PIDS.has(device.productId)) return true;
     const name = (device.productName || "").toLowerCase();
     return name.includes("receiver") || name.includes("dongle");
   }
 
-  /** True when HID traffic goes over the 2.4 GHz dongle (easy to wedge the mouse). */
-  isWirelessPath(): boolean {
-    return EggWeHidClient.isReceiverDevice(this.device);
+  /**
+   * Among WE-capable devices, collapse cable + receiver into one logical mouse.
+   * Prefer cable when both are present; otherwise keep a single receiver.
+   */
+  static pickDevices(devices: readonly HIDDevice[]): HIDDevice[] {
+    const we = devices.filter((device) => this.isSupported(device));
+    if (we.length === 0) return [];
+    const cables = we.filter((device) => !this.isReceiverDevice(device));
+    const receivers = we.filter((device) => this.isReceiverDevice(device));
+    if (cables.length > 0) return cables;
+    return receivers.slice(0, 1);
   }
 
   static supportScore(device: HIDDevice): number {
     if (!this.isSupported(device)) return 0;
     let score = 1;
+    if (OP1WE_CABLE_PIDS.has(device.productId)) score += 8;
+    if (OP1WE_RECEIVER_PIDS.has(device.productId)) score += 2;
+    if (!this.isReceiverDevice(device)) score += 4;
     const features = this.listFeatureReports(device);
-    // Prefer the 16-byte config-style report (0x08) when present.
-    if (features.some((report) => report.reportId === 0x08 && report.payloadLength >= 15)) score += 6;
-    if (features.some((report) => report.reportId === 0x06)) score += 2;
-    if (features.some((report) => report.reportId === 0xa1)) score += 1;
-    // Prefer the mouse USB interface over a bare receiver when both are present.
-    if (!this.isReceiverDevice(device)) score += 3;
-    score += Math.min(features.length, 3);
+    if (features.some((report) => report.reportId === 0x08)) score += 2;
+    if (features.some((report) => report.reportId === 0x06)) score += 1;
     return score;
+  }
+
+  isWirelessPath(): boolean {
+    return EggWeHidClient.isReceiverDevice(this.device);
   }
 
   private static listFeatureReports(device: HIDDevice): FeatureReportTarget[] {
@@ -148,23 +129,6 @@ export class EggWeHidClient {
     return found;
   }
 
-  private static listInputReports(device: HIDDevice): FeatureReportTarget[] {
-    const found: FeatureReportTarget[] = [];
-    const visit = (collections: readonly HIDCollectionInfo[]): void => {
-      for (const collection of collections) {
-        for (const report of collection.inputReports) {
-          found.push({
-            reportId: report.reportId,
-            payloadLength: this.reportPayloadLength(report),
-          });
-        }
-        visit(collection.children);
-      }
-    };
-    visit(device.collections);
-    return found;
-  }
-
   private static reportPayloadLength(report: HIDReportInfo): number {
     let bits = 0;
     for (const item of report.items ?? []) {
@@ -179,20 +143,17 @@ export class EggWeHidClient {
   }
 
   async open(): Promise<void> {
+    // Wireless: do not open the config interface unless we later add a
+    // user-triggered, proven-safe command. Opening alone has been OK; avoid
+    // feature traffic after open.
+    if (this.isWirelessPath()) return;
     if (!this.device.opened) await this.device.open();
-    this.device.removeEventListener("inputreport", this.onInputReport);
-    this.device.addEventListener("inputreport", this.onInputReport);
-    if (!this.reportTarget) this.reportTarget = this.resolvePreferredTarget();
   }
 
   describeCollections(): string {
-    const features = EggWeHidClient.listFeatureReports(this.device)
-      .map((report) => `feat 0x${report.reportId.toString(16)}/${report.payloadLength}B`);
-    const outputs = EggWeHidClient.listOutputReports(this.device)
-      .map((report) => `out 0x${report.reportId.toString(16)}/${report.payloadLength}B`);
-    const inputs = EggWeHidClient.listInputReports(this.device)
-      .map((report) => `in 0x${report.reportId.toString(16)}/${report.payloadLength}B`);
-    return [...features, ...outputs, ...inputs].join(" · ") || "no reports";
+    return EggWeHidClient.listFeatureReports(this.device)
+      .map((report) => `feat 0x${report.reportId.toString(16)}/${report.payloadLength}B`)
+      .join(" · ") || "no feature reports";
   }
 
   getDpiOptions(): number[] {
@@ -207,18 +168,15 @@ export class EggWeHidClient {
 
   private productMeta(): { name: string; wired: boolean; viaReceiver: boolean } {
     const viaReceiver = EggWeHidClient.isReceiverDevice(this.device);
-    const knownName = KNOWN_MOUSE_NAMES.get(this.device.productId);
-    const productName = this.device.productName?.trim() || "";
-    const lower = productName.toLowerCase();
-
-    // Always the mouse product name — never "Receiver" / truncated "WE Series Gaming".
-    let name = knownName ?? "Endgame Gear WE mouse";
-    if (lower.includes("op1we") || lower.includes("op1 we") || knownName?.includes("OP1we")
-      || lower.includes("we series") || this.device.productId === 0x1961 || this.device.productId === 0x1962) {
-      name = "Endgame Gear OP1we";
-    } else if (lower.includes("xm2") || knownName?.includes("XM2")) {
-      name = knownName ?? "Endgame Gear XM2we";
-    }
+    const other = OTHER_WE_MOUSE_PIDS.get(this.device.productId);
+    // Always the mouse product — receiver is never a separate model name.
+    const name = other
+      ?? (OP1WE_CABLE_PIDS.has(this.device.productId)
+        || OP1WE_RECEIVER_PIDS.has(this.device.productId)
+        || /op1\s*we|we series/i.test(this.device.productName || "")
+        ? "Endgame Gear OP1we"
+        : (this.device.productName?.replace(/\s*(receiver|dongle)\s*/ig, " ").trim()
+          || "Endgame Gear WE mouse"));
 
     return {
       name,
@@ -227,88 +185,69 @@ export class EggWeHidClient {
     };
   }
 
-  /** Prefer 16-byte report 0x08, then any largest feature report, then output reports. */
-  private resolvePreferredTarget(): FeatureReportTarget {
-    const features = EggWeHidClient.listFeatureReports(this.device);
-    const byId08 = features.find((report) => report.reportId === 0x08);
-    if (byId08 && byId08.payloadLength > 0) return byId08;
-
-    const sortedFeatures = [...features]
-      .filter((report) => report.payloadLength > 0)
-      .sort((left, right) => right.payloadLength - left.payloadLength || left.reportId - right.reportId);
-    if (sortedFeatures[0]) return sortedFeatures[0];
-
-    const outputs = EggWeHidClient.listOutputReports(this.device)
-      .filter((report) => report.payloadLength > 0)
-      .sort((left, right) => right.payloadLength - left.payloadLength);
-    if (outputs[0]) {
-      this.useOutputReport = true;
-      return outputs[0];
-    }
-
-    // Last resort — sizes from the user's probe.
-    return { reportId: 0x08, payloadLength: 16 };
-  }
-
-  private allTransportTargets(): FeatureReportTarget[] {
-    const features = EggWeHidClient.listFeatureReports(this.device)
-      .filter((report) => report.payloadLength > 0);
-    const outputs = EggWeHidClient.listOutputReports(this.device)
-      .filter((report) => report.payloadLength > 0);
-    const merged = [...features, ...outputs];
-    if (merged.length === 0) {
-      return [
-        { reportId: 0x08, payloadLength: 16 },
-        { reportId: 0x06, payloadLength: 7 },
-      ];
-    }
-    // De-dupe by reportId+length
-    const seen = new Set<string>();
-    return merged.filter((target) => {
-      const key = `${target.reportId}:${target.payloadLength}`;
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
-  }
-
+  /**
+   * Identity + connection. Wireless does zero config HID.
+   * Wired may attempt a single battery read (best-effort, approximate).
+   */
   async readStatus(): Promise<MouseStatus> {
     const meta = this.productMeta();
-    await this.open();
-    const battery = await this.readBattery();
-    const target = this.reportTarget ?? this.resolvePreferredTarget();
+    const wireless = meta.viaReceiver;
 
-    const detailParts = [
-      meta.viaReceiver ? "2.4 GHz (via receiver)" : "Wired USB",
-      `PID 0x${this.device.productId.toString(16).toUpperCase()}`,
-      "WE protocol",
-      `${this.useOutputReport ? "out" : "feat"} 0x${target.reportId.toString(16)}/${target.payloadLength}B`,
-    ];
-    if (battery.percent !== null && this.lastBatteryNote) {
-      detailParts.push(this.lastBatteryNote);
+    if (wireless) {
+      // CRITICAL: no sendFeatureReport / sendReport — freezes the OP1we.
+      return {
+        brand: "Endgame Gear",
+        name: meta.name,
+        batteryPercent: null,
+        batteryState: "Unknown",
+        dpi: 800,
+        pollingRateHz: 1000,
+        supportedPollingRates: this.supportedPollingRates,
+        activeProfile: null,
+        connectionType: "Wireless",
+        connectionDetail:
+          `2.4 GHz via receiver · PID 0x${this.device.productId.toString(16).toUpperCase()} `
+          + "· config HID idle (avoids freeze) · settings map pending RE",
+        debounceMs: null,
+        liftOffDistance: null,
+        firmware: ["Wireless path · no config HID"],
+      };
     }
-    if (battery.percent === null) {
-      detailParts.push(this.lastBatteryError ? `battery: ${this.lastBatteryError}` : "battery unread");
-      if (this.lastBatteryRaw) detailParts.push(`raw ${this.lastBatteryRaw}`);
+
+    // Wired: optional single battery read only.
+    let batteryPercent: number | null = null;
+    let batteryState: MouseStatus["batteryState"] = "Unknown";
+    let batteryNote = "battery skipped";
+
+    try {
+      await this.open();
+      const battery = await this.readBatteryOnce();
+      batteryPercent = battery.percent;
+      batteryState = battery.state;
+      batteryNote = battery.note;
+    } catch (error) {
+      batteryNote = error instanceof Error ? error.message : "battery read failed";
     }
-    detailParts.push("settings map pending RE");
 
     return {
       brand: "Endgame Gear",
       name: meta.name,
-      batteryPercent: battery.percent,
-      batteryState: battery.state,
+      batteryPercent,
+      batteryState,
       dpi: 800,
       pollingRateHz: 1000,
       supportedPollingRates: this.supportedPollingRates,
       activeProfile: null,
-      connectionType: meta.wired ? "Wired" : "Wireless",
-      connectionDetail: detailParts.join(" · "),
+      connectionType: "Wired",
+      connectionDetail: [
+        "Wired USB",
+        `PID 0x${this.device.productId.toString(16).toUpperCase()}`,
+        batteryNote,
+        "settings map pending RE",
+      ].join(" · "),
       debounceMs: null,
       liftOffDistance: null,
-      firmware: battery.percent !== null
-        ? ["Firmware unread (settings map pending)"]
-        : ["Probing WE reports 0x06/0x08"],
+      firmware: ["Firmware unread (settings map pending)"],
     };
   }
 
@@ -330,362 +269,82 @@ export class EggWeHidClient {
 
   private settingsNotMappedError(label: string): Error {
     return new Error(
-      `OP1we ${label} is not reverse-engineered yet on this report family `
-      + `(${this.describeCollections()}). Capture WE Series software USB traffic to map writes.`,
+      `OP1we ${label} is not reverse-engineered yet. `
+      + "Capture Endgame Gear WE Series software USB traffic to map writes.",
     );
   }
 
   async close(): Promise<void> {
-    this.device.removeEventListener("inputreport", this.onInputReport);
-    this.clearInputWaiter(new Error("Device closed."));
     if (this.device.opened) await this.device.close();
   }
 
-  /**
-   * Probe real report ids (0x06/0x08 etc.) with battery-ish commands.
-   * Called on connect when battery % is missing.
-   */
-  async probeBattery(): Promise<string> {
-    const lines: string[] = [
-      `pid 0x${this.device.productId.toString(16)}`,
-      `collections: ${this.describeCollections()}`,
-    ];
-    const targets = this.allTransportTargets();
-    let found: { percent: number; line: string } | null = null;
+  // ---------------------------------------------------------------------------
+  // Battery (wired only) — single transaction, best-effort
+  // ---------------------------------------------------------------------------
 
-    for (const target of targets) {
-      for (const viaOutput of [false, true]) {
-        // Skip output mode if this target is only known as a feature report with no matching out.
-        if (viaOutput) {
-          const hasOut = EggWeHidClient.listOutputReports(this.device)
-            .some((report) => report.reportId === target.reportId);
-          if (!hasOut && EggWeHidClient.listOutputReports(this.device).length === 0) {
-            // Still try sendReport — some stacks accept it when only feature is listed.
-          } else if (!hasOut) {
-            continue;
-          }
-        }
-
-        for (const command of BATTERY_COMMAND_CANDIDATES) {
-          try {
-            this.reportTarget = target;
-            this.useOutputReport = viaOutput;
-            const response = await this.query(command, { wake: command === 0xb4 || command === 0x04 });
-            const parsed = this.parseBatteryResponse(response, command);
-            const mode = viaOutput ? "out" : "feat";
-            const line =
-              `${mode} 0x${target.reportId.toString(16)}/${target.payloadLength}B `
-              + `cmd 0x${command.toString(16).padStart(2, "0")} → ${response.byteLength}B `
-              + `[${this.toHex(response, 16)}] parse=${parsed.percent ?? "null"}`
-              + (parsed.note ? ` (${parsed.note})` : "");
-            lines.push(line);
-            if (parsed.percent !== null && !found) {
-              found = { percent: parsed.percent, line };
-              this.lastBatteryRaw = this.toHex(response, 16);
-              this.lastBatteryNote = parsed.note;
-              if (parsed.byteIndex !== undefined) {
-                this.lockedBattery = { command, byteIndex: parsed.byteIndex };
-              }
-              // Keep working transport locked in.
-              this.reportTarget = target;
-              this.useOutputReport = viaOutput;
-              lines.push(`SELECTED: ${line}`);
-              return lines.join("\n");
-            }
-          } catch (error) {
-            const message = error instanceof Error ? error.message : "failed";
-            const mode = viaOutput ? "out" : "feat";
-            lines.push(
-              `${mode} 0x${target.reportId.toString(16)}/${target.payloadLength}B `
-              + `cmd 0x${command.toString(16).padStart(2, "0")} → ${message}`,
-            );
-          }
-        }
-      }
-    }
-
-    // Reset to preferred feature target after failed probe.
-    this.useOutputReport = false;
-    this.reportTarget = this.resolvePreferredTarget();
-    return lines.join("\n");
+  private resolvePreferredTarget(): FeatureReportTarget {
+    const features = EggWeHidClient.listFeatureReports(this.device)
+      .filter((report) => report.payloadLength > 0);
+    const by08 = features.find((report) => report.reportId === 0x08);
+    if (by08) return by08;
+    const by06 = features.find((report) => report.reportId === 0x06);
+    if (by06) return by06;
+    if (features[0]) return features[0];
+    return { reportId: 0x06, payloadLength: 7 };
   }
 
-  async probeCommands(from = 0x00, to = 0x30): Promise<string> {
-    const target = this.reportTarget ?? this.resolvePreferredTarget();
-    const lines: string[] = [
-      `target: ${this.useOutputReport ? "out" : "feat"} 0x${target.reportId.toString(16)}/${target.payloadLength}B`,
-      `collections: ${this.describeCollections()}`,
-    ];
-    for (let command = from; command <= to; command += 1) {
-      try {
-        const response = await this.query(command);
-        lines.push(
-          `0x${command.toString(16).padStart(2, "0")}: (${response.byteLength}B) ${this.toHex(response, 16)}`,
-        );
-      } catch (error) {
-        const message = error instanceof Error ? error.message : "failed";
-        lines.push(`0x${command.toString(16).padStart(2, "0")}: ${message}`);
-      }
-    }
-    return lines.join("\n");
-  }
-
-  private async readBattery(): Promise<{
+  private async readBatteryOnce(): Promise<{
     percent: number | null;
     state: MouseStatus["batteryState"];
+    note: string;
   }> {
-    this.lastBatteryError = null;
-    this.lastBatteryRaw = null;
-    this.lastBatteryNote = null;
-    const meta = this.productMeta();
+    if (this.isWirelessPath()) {
+      return { percent: null, state: "Unknown", note: "battery n/a on wireless" };
+    }
 
-    // CRITICAL: one feature transaction only. Multi-command probes and long wake
-    // delays wedge the OP1we over the dongle (cursor freeze).
     const target = this.resolvePreferredTarget();
-    this.reportTarget = target;
-    this.useOutputReport = false;
-    const command = this.lockedBattery?.command ?? BATTERY_COMMAND;
+    const packet = new Uint8Array(target.payloadLength);
+    packet[0] = 0x04; // CompX-style battery command candidate
 
     try {
-      const response = await this.query(command, { wake: false });
-      this.lastBatteryRaw = this.toHex(response, 16);
-      const parsed = this.parseBatteryResponse(response, command);
-      if (parsed.percent !== null) {
-        this.lastBatteryNote = `${parsed.note ?? "batt"} · approx`;
-        if (parsed.byteIndex !== undefined) {
-          this.lockedBattery = { command, byteIndex: parsed.byteIndex };
-        }
-        return {
-          percent: parsed.percent,
-          state: this.decodeChargeState(response, meta.wired, parsed.percent),
-        };
-      }
-      this.lastBatteryError = `no percent in [${this.lastBatteryRaw}]`;
-    } catch (error) {
-      this.lastBatteryError = error instanceof Error ? error.message : String(error);
-    }
-
-    // Do NOT fall through into probeBattery() here — that floods the link.
-    return { percent: null, state: "Unknown" };
-  }
-
-  private decodeChargeState(
-    response: Uint8Array | null,
-    wired: boolean,
-    percent: number,
-  ): MouseStatus["batteryState"] {
-    // Pulsar-style charge flag at index 6.
-    if (response && response[6] === 1) return "Charging";
-    if (response && response[6] === 0 && !wired) return "Discharging";
-    if (wired) return percent >= 99 ? "Full" : "Charging";
-    return "Discharging";
-  }
-
-  /**
-   * Parse battery carefully. 7-byte reports only have indices 0–6.
-   * 100% is treated as a flag unless charge state also looks full.
-   * Values are approximate until OEM layout is captured.
-   */
-  private parseBatteryResponse(
-    response: Uint8Array,
-    command: number,
-  ): { percent: number | null; byteIndex?: number; note: string | null } {
-    if (response.byteLength === 0) return { percent: null, note: null };
-
-    const maxIndex = response.byteLength - 1;
-
-    // Locked offset from a previous good read on this session.
-    if (this.lockedBattery && this.lockedBattery.command === command) {
-      const index = this.lockedBattery.byteIndex;
-      if (index <= maxIndex) {
-        const scaled = this.normalizePercent(response[index], response, index);
-        if (scaled !== null) {
-          return {
-            percent: scaled,
-            byteIndex: index,
-            note: `batt@${index} cmd 0x${command.toString(16)}`,
-          };
-        }
-      }
-    }
-
-    // Preferred: cmd 0x04 layout — percent at [5] when present and not a 100 flag.
-    if ((command === 0x04 || response[0] === 0x04) && 5 <= maxIndex) {
-      const at5 = this.normalizePercent(response[5], response, 5);
-      if (at5 !== null) {
-        return { percent: at5, byteIndex: 5, note: "batt@5 cmd 0x4" };
-      }
-    }
-
-    type Candidate = { index: number; percent: number; score: number };
-    const candidates: Candidate[] = [];
-    // Never read past the report; skip [0] command echo.
-    for (let index = 1; index <= maxIndex; index += 1) {
-      // Last byte on 16B frames is often checksum — skip.
-      if (response.byteLength >= 16 && index === maxIndex) continue;
-      const raw = response[index];
-      const percent = this.normalizePercent(raw, response, index);
-      if (percent === null) continue;
-
-      let score = 10;
-      if (index === 5) score += 10;
-      if (index === 4 || index === 3) score += 3;
-      if (index === 6 && response.byteLength <= 8) score += 2;
-      // Sticky 100% on dongle is almost always wrong.
-      if (percent === 100) score -= 20;
-      if (percent === 0) score -= 8;
-      if (raw === command) score -= 20;
-      if (raw === 0x08 || raw === 0x06) score -= 6;
-      // Index 7 on a 7-byte descriptor means we overran — heavily penalize if length is 7–8.
-      if (index >= response.byteLength) score -= 50;
-
-      candidates.push({ index, percent, score });
-    }
-
-    candidates.sort((left, right) => right.score - left.score || left.index - right.index);
-    const best = candidates[0];
-    if (!best || best.score < 10) return { percent: null, note: null };
-
-    return {
-      percent: best.percent,
-      byteIndex: best.index,
-      note: `batt@${best.index} raw 0x${(response[best.index] ?? 0).toString(16)}`,
-    };
-  }
-
-  private normalizePercent(
-    value: number | undefined,
-    response: Uint8Array,
-    _index: number,
-  ): number | null {
-    if (value === undefined) return null;
-    // Reject 100% unless a charge/full flag suggests it is real.
-    if (value === 100) {
-      const chargeFlag = response[6];
-      if (chargeFlag === 1 || chargeFlag === 2) return 100;
-      return null;
-    }
-    if (value >= 1 && value <= 99) return value;
-    return null;
-  }
-
-  private query(command: number, options: { wake?: boolean } = {}): Promise<Uint8Array> {
-    const run = async (): Promise<Uint8Array> => {
-      await this.open();
-      const target = this.reportTarget ?? this.resolvePreferredTarget();
-      const packet = new Uint8Array(target.payloadLength);
-      packet[0] = command;
-      // CompX/Pulsar-style: length field + checksum on 16-byte reports only.
-      if (target.payloadLength >= 16) {
-        packet[4] = 0;
-        packet[15] = this.simpleChecksum(packet, target.reportId);
-      }
-
-      // Keep wireless dongle traffic minimal — long waits + multi-packet sequences freeze the mouse.
-      const wireless = this.isWirelessPath();
-      if (this.useOutputReport) {
-        return await this.exchangeOutput(target.reportId, packet, wireless ? 30 : (options.wake ? 200 : 50));
-      }
-
-      await this.sendFeature(target, packet);
-      await this.delay(wireless ? 25 : (options.wake ? 120 : 30));
-      return await this.receiveFeature(target.reportId);
-    };
-    const next = this.commandQueue.then(run, run);
-    this.commandQueue = next.then(() => undefined, () => undefined);
-    return next;
-  }
-
-  private simpleChecksum(packet: Uint8Array, reportId: number): number {
-    let sum = 0;
-    for (let index = 0; index < packet.length - 1; index += 1) sum += packet[index];
-    // Pulsar uses 0x55 - sum - reportId; try that on 16-byte frames.
-    return (0x55 - (sum & 0xff) - reportId) & 0xff;
-  }
-
-  private async sendFeature(target: FeatureReportTarget, packet: Uint8Array): Promise<void> {
-    const data = new Uint8Array(target.payloadLength);
-    data.set(packet.subarray(0, Math.min(packet.byteLength, data.byteLength)));
-    try {
-      await this.device.sendFeatureReport(target.reportId, data);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(
-        `${message} (feat 0x${target.reportId.toString(16)}, ${target.payloadLength}B, `
-        + `pid 0x${this.device.productId.toString(16)})`,
+      await this.device.sendFeatureReport(target.reportId, packet);
+      await this.delay(40);
+      const view = await this.device.receiveFeatureReport(target.reportId);
+      const response = new Uint8Array(
+        view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength),
       );
-    }
-  }
-
-  private async receiveFeature(reportId: number): Promise<Uint8Array> {
-    try {
-      return this.copyDataView(await this.device.receiveFeatureReport(reportId));
-    } catch (error) {
-      // Try sibling report id if present.
-      const alt = this.allTransportTargets().find((target) => target.reportId !== reportId);
-      if (alt) {
-        try {
-          return this.copyDataView(await this.device.receiveFeatureReport(alt.reportId));
-        } catch {
-          // fall through
+      const raw = [...response].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
+      // Prefer index 5 when present; never treat 100 as trusted without flags.
+      let percent: number | null = null;
+      let index = -1;
+      if (response.byteLength > 5) {
+        const value = response[5];
+        if (value >= 1 && value <= 99) {
+          percent = value;
+          index = 5;
         }
       }
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`${message} (receive feat 0x${reportId.toString(16)})`);
-    }
-  }
-
-  private async exchangeOutput(
-    reportId: number,
-    packet: Uint8Array,
-    settleMs: number,
-  ): Promise<Uint8Array> {
-    this.clearInputWaiter(new Error("Superseded."));
-
-    const response = new Promise<Uint8Array>((resolve, reject) => {
-      const timer = window.setTimeout(() => {
-        this.inputWaiter = null;
-        resolve(new Uint8Array());
-      }, 800);
-      this.inputWaiter = { reportId, resolve, reject, timer };
-    });
-
-    const data = new Uint8Array(packet.byteLength);
-    data.set(packet);
-    try {
-      await this.device.sendReport(reportId, data);
+      if (percent === null) {
+        for (let i = 1; i < Math.min(response.byteLength, 7); i += 1) {
+          const value = response[i];
+          if (value >= 1 && value <= 99) {
+            percent = value;
+            index = i;
+            break;
+          }
+        }
+      }
+      return {
+        percent,
+        state: percent !== null ? "Charging" : "Unknown",
+        note: percent !== null
+          ? `batt@${index} ~${percent}% (approx) raw ${raw}`
+          : `battery unread raw ${raw}`,
+      };
     } catch (error) {
-      this.clearInputWaiter();
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`${message} (out 0x${reportId.toString(16)}, ${packet.byteLength}B)`);
+      return { percent: null, state: "Unknown", note: `battery fail: ${message}` };
     }
-
-    await this.delay(settleMs);
-    const input = await response;
-    if (input.byteLength > 0) return input;
-    try {
-      return this.copyDataView(await this.device.receiveFeatureReport(reportId));
-    } catch {
-      return input;
-    }
-  }
-
-  private clearInputWaiter(reason?: Error): void {
-    const waiter = this.inputWaiter;
-    if (!waiter) return;
-    window.clearTimeout(waiter.timer);
-    this.inputWaiter = null;
-    if (reason) waiter.reject(reason);
-  }
-
-  private toHex(bytes: Uint8Array, max = 16): string {
-    const slice = bytes.subarray(0, max);
-    const hex = [...slice].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
-    return bytes.byteLength > max ? `${hex}…` : hex;
-  }
-
-  private copyDataView(view: DataView): Uint8Array {
-    return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
   }
 
   private delay(milliseconds: number): Promise<void> {

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -1,23 +1,21 @@
 import type { MouseStatus } from "./mouse-types";
 
 /**
- * Endgame Gear WE-series (OP1we / dongle / related PIDs).
+ * Endgame Gear WE-series (OP1we and related).
  *
- * Verified: battery via feature report 0xa1, command 0xb4 (public RE).
- * Not verified: CPI / polling / LOD / debounce command IDs — those need a
- * USB capture of official WE Series software. Writes for unmapped settings
- * are intentionally disabled so the UI does not pretend defaults are live.
+ * Observed on OP1we (PID 0x1962):
+ *   feature reports: 0x06 (7 bytes), 0x08 (16 bytes)
+ * Older public RE for some EGG wireless used 0xa1/0xb4 — that map does NOT
+ * apply to this firmware generation.
  *
- * WebHID notes:
- * - sendFeatureReport(reportId, data) — data must NOT include report id
- * - length must match the HID feature report payload (often 63 for a 64-byte
- *   Windows buffer that includes report id as byte 0)
- * - receiveFeatureReport usually omits report id; Windows docs include it
+ * Settings (CPI/polling/LOD/debounce) still need a USB capture of WE software.
+ * Battery is probed across the real report ids + common command bytes.
  */
 
 const EGG_VENDOR_ID = 0x3367;
 
 const KNOWN_PRODUCTS = new Map<number, { name: string; wired: boolean }>([
+  [0x1962, { name: "Endgame Gear OP1we", wired: true }],
   [0x1972, { name: "Endgame Gear OP1we", wired: true }],
   [0x1970, { name: "Endgame Gear wireless receiver", wired: false }],
   [0x1968, { name: "Endgame Gear XM2we", wired: true }],
@@ -26,10 +24,14 @@ const KNOWN_PRODUCTS = new Map<number, { name: string; wired: boolean }>([
 
 const EGG_8K_PRODUCT_IDS = new Set([0x1964, 0x1966, 0x1976, 0x1978]);
 
-/** Verified WE battery transport (Windows HidD uses report id + 63 payload). */
-const WE_REPORT_ID = 0xa1;
-const WE_PAYLOAD_LENGTH = 63;
-const BATTERY_COMMAND = 0xb4;
+/** Commands worth trying for battery / identity on CompX-style 16-byte reports. */
+const BATTERY_COMMAND_CANDIDATES = [
+  0x04, // Pulsar-family battery
+  0xb4, // older EGG WE battery docs
+  0x05, 0x06, 0x07, 0x08, 0x0a, 0x0b, 0x0c, 0x0e,
+  0x10, 0x11, 0x12, 0x14, 0x1d, 0x20, 0x2b,
+  0x01, 0x02, 0x03,
+] as const;
 
 const POLLING_RATES = [125, 250, 500, 1000] as const;
 
@@ -43,12 +45,24 @@ export class EggWeHidClient {
   private reportTarget: FeatureReportTarget | null = null;
   private lastBatteryRaw: string | null = null;
   private lastBatteryError: string | null = null;
-  /** True when receiveFeatureReport includes report id as byte 0. */
-  private responseIncludesReportId: boolean | null = null;
+  private useOutputReport = false;
+  private inputWaiter: {
+    reportId: number;
+    resolve: (bytes: Uint8Array) => void;
+    reject: (error: Error) => void;
+    timer: number;
+  } | null = null;
+
+  private readonly onInputReport = (event: HIDInputReportEvent): void => {
+    if (!this.inputWaiter || event.reportId !== this.inputWaiter.reportId) return;
+    const waiter = this.inputWaiter;
+    this.inputWaiter = null;
+    window.clearTimeout(waiter.timer);
+    waiter.resolve(this.copyDataView(event.data));
+  };
 
   /**
-   * Settings command map is not reverse-engineered yet. Keep false until a
-   * capture confirms read/write pairs for CPI, polling, LOD, and debounce.
+   * Settings command map is not reverse-engineered yet for this report family.
    */
   static readonly settingsMapped = false;
 
@@ -57,22 +71,21 @@ export class EggWeHidClient {
   static isSupported(device: HIDDevice): boolean {
     if (device.vendorId !== EGG_VENDOR_ID) return false;
     if (EGG_8K_PRODUCT_IDS.has(device.productId)) return false;
-    return this.hasVendorConfigInterface(device);
+    return this.listFeatureReports(device).length > 0
+      || this.listOutputReports(device).length > 0
+      || this.collectionTreeHasVendorUsage(device.collections);
   }
 
   static supportScore(device: HIDDevice): number {
     if (!this.isSupported(device)) return 0;
     let score = 1;
-    if (this.findFeatureReport(device, WE_REPORT_ID)) score += 5;
-    if (this.findFeatureReport(device, 0xa0)) score += 1;
-    if (this.collectionTreeHasVendorUsage(device.collections)) score += 1;
+    const features = this.listFeatureReports(device);
+    // Prefer the 16-byte config-style report (0x08) when present.
+    if (features.some((report) => report.reportId === 0x08 && report.payloadLength >= 15)) score += 6;
+    if (features.some((report) => report.reportId === 0x06)) score += 2;
+    if (features.some((report) => report.reportId === 0xa1)) score += 1;
+    score += Math.min(features.length, 3);
     return score;
-  }
-
-  private static hasVendorConfigInterface(device: HIDDevice): boolean {
-    if (this.findFeatureReport(device, WE_REPORT_ID) || this.findFeatureReport(device, 0xa0)) return true;
-    if (this.collectionTreeHasVendorUsage(device.collections)) return true;
-    return this.listFeatureReports(device).length > 0;
   }
 
   private static listFeatureReports(device: HIDDevice): FeatureReportTarget[] {
@@ -82,7 +95,7 @@ export class EggWeHidClient {
         for (const report of collection.featureReports) {
           found.push({
             reportId: report.reportId,
-            payloadLength: this.featureReportPayloadLength(report),
+            payloadLength: this.reportPayloadLength(report),
           });
         }
         visit(collection.children);
@@ -92,17 +105,46 @@ export class EggWeHidClient {
     return found;
   }
 
-  private static findFeatureReport(device: HIDDevice, reportId: number): FeatureReportTarget | null {
-    return this.listFeatureReports(device).find((report) => report.reportId === reportId) ?? null;
+  private static listOutputReports(device: HIDDevice): FeatureReportTarget[] {
+    const found: FeatureReportTarget[] = [];
+    const visit = (collections: readonly HIDCollectionInfo[]): void => {
+      for (const collection of collections) {
+        for (const report of collection.outputReports) {
+          found.push({
+            reportId: report.reportId,
+            payloadLength: this.reportPayloadLength(report),
+          });
+        }
+        visit(collection.children);
+      }
+    };
+    visit(device.collections);
+    return found;
   }
 
-  private static featureReportPayloadLength(report: HIDReportInfo): number {
+  private static listInputReports(device: HIDDevice): FeatureReportTarget[] {
+    const found: FeatureReportTarget[] = [];
+    const visit = (collections: readonly HIDCollectionInfo[]): void => {
+      for (const collection of collections) {
+        for (const report of collection.inputReports) {
+          found.push({
+            reportId: report.reportId,
+            payloadLength: this.reportPayloadLength(report),
+          });
+        }
+        visit(collection.children);
+      }
+    };
+    visit(device.collections);
+    return found;
+  }
+
+  private static reportPayloadLength(report: HIDReportInfo): number {
     let bits = 0;
     for (const item of report.items ?? []) {
       bits += item.reportSize * item.reportCount;
     }
-    if (bits === 0) return WE_PAYLOAD_LENGTH;
-    return Math.ceil(bits / 8);
+    return bits === 0 ? 0 : Math.ceil(bits / 8);
   }
 
   private static collectionTreeHasVendorUsage(collections: readonly HIDCollectionInfo[]): boolean {
@@ -112,16 +154,19 @@ export class EggWeHidClient {
 
   async open(): Promise<void> {
     if (!this.device.opened) await this.device.open();
-    if (!this.reportTarget) this.reportTarget = this.resolveReportTarget();
+    this.device.removeEventListener("inputreport", this.onInputReport);
+    this.device.addEventListener("inputreport", this.onInputReport);
+    if (!this.reportTarget) this.reportTarget = this.resolvePreferredTarget();
   }
 
   describeCollections(): string {
-    const reports = EggWeHidClient.listFeatureReports(this.device);
-    if (reports.length === 0) {
-      return `fallback report 0x${WE_REPORT_ID.toString(16)}/${WE_PAYLOAD_LENGTH}B`;
-    }
-    return reports.map((report) =>
-      `id 0x${report.reportId.toString(16)}/${report.payloadLength}B`).join(" · ");
+    const features = EggWeHidClient.listFeatureReports(this.device)
+      .map((report) => `feat 0x${report.reportId.toString(16)}/${report.payloadLength}B`);
+    const outputs = EggWeHidClient.listOutputReports(this.device)
+      .map((report) => `out 0x${report.reportId.toString(16)}/${report.payloadLength}B`);
+    const inputs = EggWeHidClient.listInputReports(this.device)
+      .map((report) => `in 0x${report.reportId.toString(16)}/${report.payloadLength}B`);
+    return [...features, ...outputs, ...inputs].join(" · ") || "no reports";
   }
 
   getDpiOptions(): number[] {
@@ -146,34 +191,66 @@ export class EggWeHidClient {
     return { name: productName, wired };
   }
 
-  private resolveReportTarget(): FeatureReportTarget {
-    const preferred = EggWeHidClient.findFeatureReport(this.device, WE_REPORT_ID);
-    if (preferred) {
-      return {
-        reportId: preferred.reportId,
-        // Prefer descriptor length, but never invent a weird size for battery.
-        payloadLength: preferred.payloadLength > 0 ? preferred.payloadLength : WE_PAYLOAD_LENGTH,
-      };
+  /** Prefer 16-byte report 0x08, then any largest feature report, then output reports. */
+  private resolvePreferredTarget(): FeatureReportTarget {
+    const features = EggWeHidClient.listFeatureReports(this.device);
+    const byId08 = features.find((report) => report.reportId === 0x08);
+    if (byId08 && byId08.payloadLength > 0) return byId08;
+
+    const sortedFeatures = [...features]
+      .filter((report) => report.payloadLength > 0)
+      .sort((left, right) => right.payloadLength - left.payloadLength || left.reportId - right.reportId);
+    if (sortedFeatures[0]) return sortedFeatures[0];
+
+    const outputs = EggWeHidClient.listOutputReports(this.device)
+      .filter((report) => report.payloadLength > 0)
+      .sort((left, right) => right.payloadLength - left.payloadLength);
+    if (outputs[0]) {
+      this.useOutputReport = true;
+      return outputs[0];
     }
-    return { reportId: WE_REPORT_ID, payloadLength: WE_PAYLOAD_LENGTH };
+
+    // Last resort — sizes from the user's probe.
+    return { reportId: 0x08, payloadLength: 16 };
+  }
+
+  private allTransportTargets(): FeatureReportTarget[] {
+    const features = EggWeHidClient.listFeatureReports(this.device)
+      .filter((report) => report.payloadLength > 0);
+    const outputs = EggWeHidClient.listOutputReports(this.device)
+      .filter((report) => report.payloadLength > 0);
+    const merged = [...features, ...outputs];
+    if (merged.length === 0) {
+      return [
+        { reportId: 0x08, payloadLength: 16 },
+        { reportId: 0x06, payloadLength: 7 },
+      ];
+    }
+    // De-dupe by reportId+length
+    const seen = new Set<string>();
+    return merged.filter((target) => {
+      const key = `${target.reportId}:${target.payloadLength}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
   }
 
   async readStatus(): Promise<MouseStatus> {
     const meta = this.productMeta();
     await this.open();
     const battery = await this.readBattery();
-    const target = this.reportTarget ?? this.resolveReportTarget();
+    const target = this.reportTarget ?? this.resolvePreferredTarget();
 
     const detailParts = [
       meta.wired ? "Wired USB" : "2.4 GHz dongle",
       `PID 0x${this.device.productId.toString(16).toUpperCase()}`,
       "WE protocol",
-      `report 0x${target.reportId.toString(16)}/${target.payloadLength}B`,
+      `${this.useOutputReport ? "out" : "feat"} 0x${target.reportId.toString(16)}/${target.payloadLength}B`,
+      this.describeCollections(),
     ];
     if (battery.percent === null) {
-      detailParts.push(this.lastBatteryError
-        ? `battery fail: ${this.lastBatteryError}`
-        : "battery unread");
+      detailParts.push(this.lastBatteryError ? `battery: ${this.lastBatteryError}` : "battery unread");
       if (this.lastBatteryRaw) detailParts.push(`raw ${this.lastBatteryRaw}`);
     }
     detailParts.push("settings map pending RE");
@@ -183,7 +260,6 @@ export class EggWeHidClient {
       name: meta.name,
       batteryPercent: battery.percent,
       batteryState: battery.state,
-      // Placeholders — not live device values until settings are reverse-engineered.
       dpi: 800,
       pollingRateHz: 1000,
       supportedPollingRates: this.supportedPollingRates,
@@ -194,7 +270,7 @@ export class EggWeHidClient {
       liftOffDistance: null,
       firmware: battery.percent !== null
         ? ["Firmware unread (settings map pending)"]
-        : ["Connect OK · battery protocol probing"],
+        : ["Probing WE reports 0x06/0x08"],
     };
   }
 
@@ -216,66 +292,96 @@ export class EggWeHidClient {
 
   private settingsNotMappedError(label: string): Error {
     return new Error(
-      `OP1we ${label} is not reverse-engineered yet. `
-      + "Battery uses a known command; DPI/polling/LOD/debounce need a USB capture "
-      + "of Endgame Gear WE Series software. The values shown are placeholders.",
+      `OP1we ${label} is not reverse-engineered yet on this report family `
+      + `(${this.describeCollections()}). Capture WE Series software USB traffic to map writes.`,
     );
   }
 
   async close(): Promise<void> {
+    this.device.removeEventListener("inputreport", this.onInputReport);
+    this.clearInputWaiter(new Error("Device closed."));
     if (this.device.opened) await this.device.close();
   }
 
   /**
-   * Dump command responses for reverse engineering (DevTools / temporary UI).
+   * Probe real report ids (0x06/0x08 etc.) with battery-ish commands.
+   * Called on connect when battery % is missing.
    */
-  async probeCommands(from = 0x00, to = 0xff): Promise<string> {
+  async probeBattery(): Promise<string> {
     const lines: string[] = [
-      `device: ${this.device.productName || "unknown"}`,
-      `pid: 0x${this.device.productId.toString(16)}`,
+      `pid 0x${this.device.productId.toString(16)}`,
       `collections: ${this.describeCollections()}`,
-      `target: report 0x${(this.reportTarget ?? this.resolveReportTarget()).reportId.toString(16)}`
-        + `/${(this.reportTarget ?? this.resolveReportTarget()).payloadLength}B`,
     ];
-    for (let command = from; command <= to; command += 1) {
-      try {
-        const response = await this.query(command, { wake: command === BATTERY_COMMAND });
-        const hex = [...response].slice(0, 24).map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
-        const tail = response.byteLength > 24 ? " …" : "";
-        lines.push(`0x${command.toString(16).padStart(2, "0")}: (${response.byteLength}B) ${hex}${tail}`);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : "failed";
-        lines.push(`0x${command.toString(16).padStart(2, "0")}: ${message}`);
+    const targets = this.allTransportTargets();
+    let found: { percent: number; line: string } | null = null;
+
+    for (const target of targets) {
+      for (const viaOutput of [false, true]) {
+        // Skip output mode if this target is only known as a feature report with no matching out.
+        if (viaOutput) {
+          const hasOut = EggWeHidClient.listOutputReports(this.device)
+            .some((report) => report.reportId === target.reportId);
+          if (!hasOut && EggWeHidClient.listOutputReports(this.device).length === 0) {
+            // Still try sendReport — some stacks accept it when only feature is listed.
+          } else if (!hasOut) {
+            continue;
+          }
+        }
+
+        for (const command of BATTERY_COMMAND_CANDIDATES) {
+          try {
+            this.reportTarget = target;
+            this.useOutputReport = viaOutput;
+            const response = await this.query(command, { wake: command === 0xb4 || command === 0x04 });
+            const parsed = this.parseBatteryResponse(response);
+            const mode = viaOutput ? "out" : "feat";
+            const line =
+              `${mode} 0x${target.reportId.toString(16)}/${target.payloadLength}B `
+              + `cmd 0x${command.toString(16).padStart(2, "0")} → ${response.byteLength}B `
+              + `[${this.toHex(response, 16)}] parse=${parsed.percent ?? "null"}`;
+            lines.push(line);
+            if (parsed.percent !== null && !found) {
+              found = { percent: parsed.percent, line };
+              this.lastBatteryRaw = this.toHex(response, 16);
+              // Keep working transport locked in.
+              this.reportTarget = target;
+              this.useOutputReport = viaOutput;
+              lines.push(`SELECTED: ${line}`);
+              return lines.join("\n");
+            }
+          } catch (error) {
+            const message = error instanceof Error ? error.message : "failed";
+            const mode = viaOutput ? "out" : "feat";
+            lines.push(
+              `${mode} 0x${target.reportId.toString(16)}/${target.payloadLength}B `
+              + `cmd 0x${command.toString(16).padStart(2, "0")} → ${message}`,
+            );
+          }
+        }
       }
     }
+
+    // Reset to preferred feature target after failed probe.
+    this.useOutputReport = false;
+    this.reportTarget = this.resolvePreferredTarget();
     return lines.join("\n");
   }
 
-  /** Narrow battery-focused probe used on connect diagnostics. */
-  async probeBattery(): Promise<string> {
-    const lines: string[] = [];
-    const sizes = this.payloadLengthsToTry();
-    for (const length of sizes) {
-      for (const reportId of [WE_REPORT_ID, 0xa0]) {
-        try {
-          this.reportTarget = { reportId, payloadLength: length };
-          const response = await this.query(BATTERY_COMMAND, { wake: true });
-          await this.delay(100);
-          const second = await this.query(BATTERY_COMMAND, { wake: true });
-          const parsed = this.parseBatteryResponse(second);
-          lines.push(
-            `report 0x${reportId.toString(16)}/${length}B → ${second.byteLength}B `
-            + `raw[${this.toHex(second, 20)}] parse=${parsed.percent ?? "null"}%`,
-          );
-          if (parsed.percent !== null) {
-            this.lastBatteryRaw = this.toHex(second, 20);
-            return lines.join("\n");
-          }
-          void response;
-        } catch (error) {
-          const message = error instanceof Error ? error.message : "failed";
-          lines.push(`report 0x${reportId.toString(16)}/${length}B → ${message}`);
-        }
+  async probeCommands(from = 0x00, to = 0x30): Promise<string> {
+    const target = this.reportTarget ?? this.resolvePreferredTarget();
+    const lines: string[] = [
+      `target: ${this.useOutputReport ? "out" : "feat"} 0x${target.reportId.toString(16)}/${target.payloadLength}B`,
+      `collections: ${this.describeCollections()}`,
+    ];
+    for (let command = from; command <= to; command += 1) {
+      try {
+        const response = await this.query(command);
+        lines.push(
+          `0x${command.toString(16).padStart(2, "0")}: (${response.byteLength}B) ${this.toHex(response, 16)}`,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "failed";
+        lines.push(`0x${command.toString(16).padStart(2, "0")}: ${message}`);
       }
     }
     return lines.join("\n");
@@ -288,21 +394,15 @@ export class EggWeHidClient {
     this.lastBatteryError = null;
     this.lastBatteryRaw = null;
 
-    // Try verified framing first, then a small set of alternate lengths only if needed.
-    const attempts = this.payloadLengthsToTry().flatMap((length) => ([
-      { reportId: WE_REPORT_ID, payloadLength: length },
-      { reportId: 0xa0, payloadLength: length },
-    ]));
+    // Quick path: preferred report + common battery commands.
+    const target = this.resolvePreferredTarget();
+    this.reportTarget = target;
+    this.useOutputReport = false;
 
-    let lastError: Error | null = null;
-    for (const attempt of attempts) {
+    for (const command of [0x04, 0xb4, 0x05, 0x0b]) {
       try {
-        this.reportTarget = attempt;
-        // Public protocol: double-read with wake delays.
-        await this.query(BATTERY_COMMAND, { wake: true });
-        await this.delay(100);
-        const response = await this.query(BATTERY_COMMAND, { wake: true });
-        this.lastBatteryRaw = this.toHex(response, 24);
+        const response = await this.query(command, { wake: true });
+        this.lastBatteryRaw = this.toHex(response, 16);
         const parsed = this.parseBatteryResponse(response);
         if (parsed.percent !== null) {
           return {
@@ -310,73 +410,56 @@ export class EggWeHidClient {
             state: this.productMeta().wired ? "Charging" : "Discharging",
           };
         }
-        // Keep the working transport even if parse failed — try next framing.
-        lastError = new Error(`no battery byte in ${this.lastBatteryRaw}`);
       } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
+        this.lastBatteryError = error instanceof Error ? error.message : String(error);
       }
     }
 
-    this.lastBatteryError = lastError?.message ?? "unknown";
-    // Restore preferred target for later probes.
-    this.reportTarget = this.resolveReportTarget();
-    return { percent: null, state: "Unknown" };
-  }
+    // Full probe across real report ids (0x06 / 0x08).
+    try {
+      const report = await this.probeBattery();
+      const selected = report.split("\n").find((line) => line.startsWith("SELECTED:"));
+      if (selected && this.lastBatteryRaw) {
+        const match = /parse=(\d+)/.exec(selected);
+        if (match) {
+          return {
+            percent: Number(match[1]),
+            state: this.productMeta().wired ? "Charging" : "Discharging",
+          };
+        }
+      }
+      this.lastBatteryError = "no battery byte in responses (see console probe)";
+    } catch (error) {
+      this.lastBatteryError = error instanceof Error ? error.message : String(error);
+    }
 
-  private payloadLengthsToTry(): number[] {
-    const fromDescriptor = EggWeHidClient.findFeatureReport(this.device, WE_REPORT_ID)?.payloadLength;
-    const lengths = [
-      WE_PAYLOAD_LENGTH, // 63 — matches Windows 64-byte buffer with report id
-      fromDescriptor,
-      64,
-      32,
-      31,
-      15,
-      7,
-    ].filter((value): value is number => typeof value === "number" && value > 0);
-    return [...new Set(lengths)];
+    return { percent: null, state: "Unknown" };
   }
 
   private parseBatteryResponse(response: Uint8Array): { percent: number | null } {
     if (response.byteLength === 0) return { percent: null };
 
-    // Detect whether report id is present.
-    if (response[0] === WE_REPORT_ID || response[0] === 0xa0) {
-      this.responseIncludesReportId = true;
-    } else if (this.responseIncludesReportId === null) {
-      this.responseIncludesReportId = false;
+    // Documented Pulsar-style: command echo + status + percent around index 5.
+    const pulsarStyle = response[5];
+    if (pulsarStyle !== undefined && pulsarStyle <= 100 && response[0] === 0x04) {
+      return { percent: pulsarStyle };
     }
 
-    const at = (windowsIndex: number): number | undefined => {
-      if (this.responseIncludesReportId) return response[windowsIndex];
-      return response[windowsIndex - 1];
-    };
-
-    // Documented layout (Windows indices): [1]=status 0x01|0x08, [16]=percent.
-    const status = at(1);
-    const documented = at(16);
-    if ((status === 0x01 || status === 0x08) && documented !== undefined && documented <= 100) {
-      return { percent: documented };
+    // Older WE docs (if report id still present): status @1, percent @16 — rare on 16B reports.
+    if (response.byteLength > 16) {
+      const status = response[1];
+      const percent = response[16];
+      if ((status === 0x01 || status === 0x08) && percent !== undefined && percent <= 100) {
+        return { percent };
+      }
     }
 
-    // Alternate common layouts seen across CompX-ish devices.
-    const candidates = [
-      at(16), at(15), at(5), at(4), at(3), at(2),
-      response[15], response[16], response[5], response[4], response[0],
-    ];
+    // Heuristic: prefer payload bytes (skip command echo at [0]).
+    const candidates = [5, 4, 3, 2, 6, 7, 1, 8, 9, 10, 11, 12, 13, 14, 15]
+      .map((index) => response[index])
+      .filter((value): value is number => value !== undefined);
     for (const value of candidates) {
-      if (value !== undefined && value > 0 && value <= 100) {
-        return { percent: value };
-      }
-    }
-
-    // Last resort: any byte in 5–100 that is not a known status marker alone.
-    for (let index = 0; index < response.byteLength; index += 1) {
-      const value = response[index];
-      if (value >= 5 && value <= 100 && value !== WE_REPORT_ID && value !== BATTERY_COMMAND) {
-        // Prefer later bytes (payload) over early command echoes.
-        if (index >= 2) return { percent: value };
-      }
+      if (value >= 1 && value <= 100) return { percent: value };
     }
     return { percent: null };
   }
@@ -384,60 +467,112 @@ export class EggWeHidClient {
   private query(command: number, options: { wake?: boolean } = {}): Promise<Uint8Array> {
     const run = async (): Promise<Uint8Array> => {
       await this.open();
-      const payload = new Uint8Array(1);
-      payload[0] = command;
-      await this.sendFeatureExact(payload);
-      if (options.wake) await this.delay(350);
+      const target = this.reportTarget ?? this.resolvePreferredTarget();
+      const packet = new Uint8Array(target.payloadLength);
+      packet[0] = command;
+      // CompX/Pulsar-style: length field + checksum on 16-byte reports.
+      if (target.payloadLength >= 16) {
+        packet[4] = 0;
+        packet[15] = this.simpleChecksum(packet, target.reportId);
+      }
+
+      if (this.useOutputReport) {
+        return await this.exchangeOutput(target.reportId, packet, options.wake ? 400 : 80);
+      }
+
+      await this.sendFeature(target, packet);
+      if (options.wake) await this.delay(200);
       else await this.delay(40);
-      return await this.receiveFeature();
+      return await this.receiveFeature(target.reportId);
     };
     const next = this.commandQueue.then(run, run);
     this.commandQueue = next.then(() => undefined, () => undefined);
     return next;
   }
 
-  /**
-   * Send using the current report target only (exact size). Do not “succeed”
-   * on a random length — that was caching a silent no-op framing.
-   */
-  private async sendFeatureExact(payload: Uint8Array): Promise<void> {
-    await this.open();
-    const target = this.reportTarget ?? this.resolveReportTarget();
+  private simpleChecksum(packet: Uint8Array, reportId: number): number {
+    let sum = 0;
+    for (let index = 0; index < packet.length - 1; index += 1) sum += packet[index];
+    // Pulsar uses 0x55 - sum - reportId; try that on 16-byte frames.
+    return (0x55 - (sum & 0xff) - reportId) & 0xff;
+  }
+
+  private async sendFeature(target: FeatureReportTarget, packet: Uint8Array): Promise<void> {
     const data = new Uint8Array(target.payloadLength);
-    data.set(payload.subarray(0, Math.min(payload.byteLength, data.byteLength)));
+    data.set(packet.subarray(0, Math.min(packet.byteLength, data.byteLength)));
     try {
       await this.device.sendFeatureReport(target.reportId, data);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(
-        `${message} (report 0x${target.reportId.toString(16)}, ${target.payloadLength}B payload, `
-        + `pid 0x${this.device.productId.toString(16)}, ${this.describeCollections()})`,
+        `${message} (feat 0x${target.reportId.toString(16)}, ${target.payloadLength}B, `
+        + `pid 0x${this.device.productId.toString(16)})`,
       );
     }
   }
 
-  private async receiveFeature(): Promise<Uint8Array> {
-    await this.open();
-    const target = this.reportTarget ?? this.resolveReportTarget();
+  private async receiveFeature(reportId: number): Promise<Uint8Array> {
     try {
-      const view = await this.device.receiveFeatureReport(target.reportId);
-      return this.copyDataView(view);
+      return this.copyDataView(await this.device.receiveFeatureReport(reportId));
     } catch (error) {
-      // Some stacks want the same report id used for set; try the other common id once.
-      if (target.reportId === WE_REPORT_ID) {
+      // Try sibling report id if present.
+      const alt = this.allTransportTargets().find((target) => target.reportId !== reportId);
+      if (alt) {
         try {
-          const view = await this.device.receiveFeatureReport(0xa0);
-          return this.copyDataView(view);
+          return this.copyDataView(await this.device.receiveFeatureReport(alt.reportId));
         } catch {
           // fall through
         }
       }
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`${message} (receive report 0x${target.reportId.toString(16)})`);
+      throw new Error(`${message} (receive feat 0x${reportId.toString(16)})`);
     }
   }
 
-  private toHex(bytes: Uint8Array, max = 24): string {
+  private async exchangeOutput(
+    reportId: number,
+    packet: Uint8Array,
+    settleMs: number,
+  ): Promise<Uint8Array> {
+    this.clearInputWaiter(new Error("Superseded."));
+
+    const response = new Promise<Uint8Array>((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        this.inputWaiter = null;
+        resolve(new Uint8Array());
+      }, 800);
+      this.inputWaiter = { reportId, resolve, reject, timer };
+    });
+
+    const data = new Uint8Array(packet.byteLength);
+    data.set(packet);
+    try {
+      await this.device.sendReport(reportId, data);
+    } catch (error) {
+      this.clearInputWaiter();
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`${message} (out 0x${reportId.toString(16)}, ${packet.byteLength}B)`);
+    }
+
+    await this.delay(settleMs);
+    const input = await response;
+    if (input.byteLength > 0) return input;
+    try {
+      return this.copyDataView(await this.device.receiveFeatureReport(reportId));
+    } catch {
+      return input;
+    }
+  }
+
+  private clearInputWaiter(reason?: Error): void {
+    const waiter = this.inputWaiter;
+    if (!waiter) return;
+    window.clearTimeout(waiter.timer);
+    this.inputWaiter = null;
+    if (reason) waiter.reject(reason);
+  }
+
+  private toHex(bytes: Uint8Array, max = 16): string {
     const slice = bytes.subarray(0, max);
     const hex = [...slice].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
     return bytes.byteLength > max ? `${hex}…` : hex;

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -1,0 +1,398 @@
+import type { MouseStatus } from "./mouse-types";
+
+/**
+ * Endgame Gear WE-series wireless mice (OP1we, shared dongle, etc.).
+ *
+ * Same structural style as egg-op1-hid.ts (product map, feature reports,
+ * verified setters) but a different CompX/WE command set — not the wired
+ * OP1 8K 1041-byte config blob.
+ *
+ * Battery command 0xb4 is publicly reverse-engineered. Other setting
+ * commands follow the same feature-report shell and must re-read to confirm;
+ * adjust COMMAND / parse offsets after USB capture of WE Series software if
+ * a firmware revision disagrees.
+ */
+
+const EGG_VENDOR_ID = 0x3367;
+
+/** Wired mice report charging; the shared dongle is wireless. */
+const SUPPORTED_PRODUCTS = new Map<number, { name: string; wired: boolean }>([
+  [0x1972, { name: "Endgame Gear OP1we", wired: true }],
+  [0x1970, { name: "Endgame Gear wireless receiver", wired: false }],
+  // Other WE-family PIDs (same transport); safe to claim when present.
+  [0x1968, { name: "Endgame Gear XM2we", wired: true }],
+  [0x1982, { name: "Endgame Gear XM2w v2", wired: true }],
+]);
+
+const REPORT_SIZE = 64;
+const REPORT = {
+  /** Write / set-feature shell (mirrors 8K report id family). */
+  write: 0xa0,
+  /** Read / get-feature shell used by battery and status commands. */
+  read: 0xa1,
+} as const;
+
+/**
+ * Feature-report command byte (buffer[1] after report id).
+ * battery is verified; remaining IDs are provisional WE-series peers of 0xb4
+ * and are confirmed only when re-read matches.
+ */
+const COMMAND = {
+  battery: 0xb4,
+  /** Device status block: CPI, polling, LOD, debounce packed in one reply. */
+  status: 0xb0,
+  dpi: 0xb1,
+  polling: 0xb2,
+  lod: 0xb3,
+  debounce: 0xb5,
+  firmware: 0xb6,
+} as const;
+
+/** Offsets inside a successful status (0xb0) or setting response payload. */
+const STATUS = {
+  dpiLo: 4,
+  dpiHi: 5,
+  polling: 6,
+  lod: 7,
+  debounce: 8,
+  firmwareMajor: 10,
+  firmwareMinor: 11,
+} as const;
+
+const POLLING_RATES = [125, 250, 500, 1000] as const;
+const DEFAULT_DPI = 800;
+const DEFAULT_POLLING = 1000;
+const DEFAULT_DEBOUNCE = 3;
+
+export class EggWeHidClient {
+  private commandQueue: Promise<unknown> = Promise.resolve();
+
+  constructor(readonly device: HIDDevice) {}
+
+  static isSupported(device: HIDDevice): boolean {
+    return device.vendorId === EGG_VENDOR_ID
+      && SUPPORTED_PRODUCTS.has(device.productId)
+      && device.collections.some((collection) =>
+        this.collectionHasFeatureReport(collection, REPORT.read));
+  }
+
+  private static collectionHasFeatureReport(collection: HIDCollectionInfo, reportId: number): boolean {
+    return collection.featureReports.some((report) => report.reportId === reportId)
+      || collection.children.some((child) => this.collectionHasFeatureReport(child, reportId));
+  }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) await this.device.open();
+  }
+
+  describeCollections(): string {
+    return this.device.collections.map((collection) => {
+      const reports = collection.featureReports.map((report) => `0x${report.reportId.toString(16)}`);
+      return `usage 0x${collection.usagePage.toString(16)}:0x${collection.usage.toString(16)} · feature ${reports.join(", ") || "none"}`;
+    }).join(" | ") || "No HID collections reported";
+  }
+
+  getDpiOptions(): number[] {
+    const values: number[] = [];
+    for (let dpi = 50; dpi <= 19000; dpi += 50) values.push(dpi);
+    return values;
+  }
+
+  get supportedPollingRates(): number[] {
+    return [...POLLING_RATES];
+  }
+
+  private productMeta(): { name: string; wired: boolean } {
+    return SUPPORTED_PRODUCTS.get(this.device.productId)
+      ?? { name: this.device.productName || "Endgame Gear WE mouse", wired: false };
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    const meta = this.productMeta();
+    const battery = await this.readBattery();
+    const state = await this.readDeviceState().catch(() => null);
+    const firmware = await this.readFirmware().catch(() => null);
+    const dpi = state?.dpi ?? DEFAULT_DPI;
+    const pollingRateHz = state?.pollingRateHz ?? DEFAULT_POLLING;
+    const debounceMs = state?.debounceMs ?? DEFAULT_DEBOUNCE;
+    const liftOffDistance = state?.liftOffDistance ?? "Medium";
+
+    if (!this.getDpiOptions().includes(dpi)) {
+      throw new Error(`The mouse reported an unsupported ${dpi} CPI value.`);
+    }
+    if (!POLLING_RATES.includes(pollingRateHz as (typeof POLLING_RATES)[number])) {
+      throw new Error(`The mouse reported an unsupported ${pollingRateHz} Hz polling rate.`);
+    }
+
+    return {
+      brand: "Endgame Gear",
+      name: meta.name,
+      batteryPercent: battery.percent,
+      batteryState: battery.state,
+      dpi,
+      pollingRateHz,
+      supportedPollingRates: this.supportedPollingRates,
+      activeProfile: null,
+      connectionType: meta.wired ? "Wired" : "Wireless",
+      connectionDetail: `${meta.wired ? "Wired USB" : "2.4 GHz dongle"} · PID 0x${this.device.productId.toString(16).toUpperCase()} · WE protocol`,
+      debounceMs,
+      liftOffDistance,
+      firmware: firmware
+        ? [`Firmware ${firmware}`]
+        : state?.firmware
+          ? [`Firmware ${state.firmware}`]
+          : ["Firmware unavailable"],
+    };
+  }
+
+  async setDpi(dpi: number): Promise<number> {
+    if (!this.getDpiOptions().includes(dpi)) {
+      throw new Error("OP1we CPI must be between 50 and 19,000 in 50 CPI steps.");
+    }
+    await this.writeSetting(COMMAND.dpi, [dpi & 0xff, (dpi >> 8) & 0xff]);
+    const confirmed = (await this.readDeviceState()).dpi;
+    if (confirmed !== dpi) {
+      throw new Error(`The mouse kept ${confirmed} CPI instead of ${dpi} CPI.`);
+    }
+    return confirmed;
+  }
+
+  async setPollingRate(rate: number): Promise<number> {
+    if (!POLLING_RATES.includes(rate as (typeof POLLING_RATES)[number])) {
+      throw new Error("Unsupported OP1we polling rate. Use 125, 250, 500, or 1000 Hz.");
+    }
+    await this.writeSetting(COMMAND.polling, [this.encodePolling(rate)]);
+    const confirmed = (await this.readDeviceState()).pollingRateHz;
+    if (confirmed !== rate) {
+      throw new Error(`The mouse kept ${confirmed} Hz instead of ${rate} Hz.`);
+    }
+    return confirmed;
+  }
+
+  async setLiftOffDistance(value: NonNullable<MouseStatus["liftOffDistance"]>): Promise<void> {
+    if (value === "Low") {
+      throw new Error("The OP1we supports Medium or High lift-off distance.");
+    }
+    const encoded = value === "Medium" ? 1 : 2;
+    await this.writeSetting(COMMAND.lod, [encoded]);
+    const confirmed = (await this.readDeviceState()).liftOffDistance;
+    if (confirmed !== value) {
+      throw new Error("The mouse did not confirm the requested lift-off distance.");
+    }
+  }
+
+  async setDebounceTime(milliseconds: number): Promise<number> {
+    if (!Number.isInteger(milliseconds) || milliseconds < 0 || milliseconds > 15) {
+      throw new Error("Debounce must be an integer from 0 to 15 ms.");
+    }
+    await this.writeSetting(COMMAND.debounce, [milliseconds]);
+    const confirmed = (await this.readDeviceState()).debounceMs;
+    if (confirmed !== milliseconds) {
+      throw new Error(`The mouse kept ${confirmed} ms debounce instead of ${milliseconds} ms.`);
+    }
+    return confirmed;
+  }
+
+  async close(): Promise<void> {
+    if (this.device.opened) await this.device.close();
+  }
+
+  /**
+   * Dump raw responses for commands near the known battery command.
+   * Useful while reverse-engineering WE Series software traffic.
+   */
+  async probeCommands(from = 0xa8, to = 0xc0): Promise<string> {
+    const lines: string[] = [];
+    for (let command = from; command <= to; command += 1) {
+      try {
+        const response = await this.query(command, { wake: command === COMMAND.battery });
+        const hex = [...response].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
+        lines.push(`0x${command.toString(16)}: ${hex}`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "failed";
+        lines.push(`0x${command.toString(16)}: ${message}`);
+      }
+    }
+    return lines.join("\n");
+  }
+
+  private async readBattery(): Promise<{
+    percent: number | null;
+    state: MouseStatus["batteryState"];
+  }> {
+    // Public WE battery protocol: double-read with wake delays.
+    const first = await this.query(COMMAND.battery, { wake: true });
+    void first;
+    await this.delay(100);
+    const response = await this.query(COMMAND.battery, { wake: true });
+    const statusByte = response[1];
+    if (statusByte !== 0x01 && statusByte !== 0x08) {
+      // Still surface a best-effort percentage if the payload looks sane.
+      const maybe = response[16];
+      if (maybe !== undefined && maybe <= 100) {
+        return {
+          percent: maybe,
+          state: this.productMeta().wired ? "Charging" : "Discharging",
+        };
+      }
+      return { percent: null, state: "Unknown" };
+    }
+    const percent = Math.min(response[16] ?? 0, 100);
+    return {
+      percent,
+      state: this.productMeta().wired ? "Charging" : "Discharging",
+    };
+  }
+
+  private async readDeviceState(): Promise<{
+    dpi: number;
+    pollingRateHz: number;
+    liftOffDistance: NonNullable<MouseStatus["liftOffDistance"]>;
+    debounceMs: number;
+    firmware: string | null;
+  }> {
+    // Prefer a dedicated status block; fall back to piecing individual reads.
+    try {
+      const block = await this.query(COMMAND.status);
+      if (this.looksLikeStatus(block)) return this.parseStatusBlock(block);
+    } catch {
+      // Individual commands below.
+    }
+
+    const dpiPacket = await this.query(COMMAND.dpi).catch(() => null);
+    const pollingPacket = await this.query(COMMAND.polling).catch(() => null);
+    const lodPacket = await this.query(COMMAND.lod).catch(() => null);
+    const debouncePacket = await this.query(COMMAND.debounce).catch(() => null);
+
+    const dpi = dpiPacket
+      ? (dpiPacket[STATUS.dpiLo] | (dpiPacket[STATUS.dpiHi] << 8))
+      : DEFAULT_DPI;
+    const pollingRateHz = pollingPacket
+      ? this.decodePolling(pollingPacket[STATUS.polling] ?? pollingPacket[2] ?? 0)
+      : DEFAULT_POLLING;
+    const lodRaw = lodPacket?.[STATUS.lod] ?? lodPacket?.[2] ?? 1;
+    const liftOffDistance: NonNullable<MouseStatus["liftOffDistance"]> =
+      lodRaw === 2 ? "High" : "Medium";
+    const debounceMs = debouncePacket?.[STATUS.debounce] ?? debouncePacket?.[2] ?? DEFAULT_DEBOUNCE;
+
+    return {
+      dpi: this.clampDpi(dpi),
+      pollingRateHz: POLLING_RATES.includes(pollingRateHz as (typeof POLLING_RATES)[number])
+        ? pollingRateHz
+        : DEFAULT_POLLING,
+      liftOffDistance,
+      debounceMs: Math.min(Math.max(debounceMs, 0), 15),
+      firmware: null,
+    };
+  }
+
+  private parseStatusBlock(block: Uint8Array): {
+    dpi: number;
+    pollingRateHz: number;
+    liftOffDistance: NonNullable<MouseStatus["liftOffDistance"]>;
+    debounceMs: number;
+    firmware: string | null;
+  } {
+    const dpi = this.clampDpi(block[STATUS.dpiLo] | (block[STATUS.dpiHi] << 8));
+    const pollingRateHz = this.decodePolling(block[STATUS.polling]);
+    const liftOffDistance: NonNullable<MouseStatus["liftOffDistance"]> =
+      block[STATUS.lod] === 2 ? "High" : "Medium";
+    const debounceMs = Math.min(Math.max(block[STATUS.debounce] ?? DEFAULT_DEBOUNCE, 0), 15);
+    const major = block[STATUS.firmwareMajor];
+    const minor = block[STATUS.firmwareMinor];
+    const firmware = major !== undefined && minor !== undefined
+      ? `${major}.${minor}`
+      : null;
+    return {
+      dpi,
+      pollingRateHz: POLLING_RATES.includes(pollingRateHz as (typeof POLLING_RATES)[number])
+        ? pollingRateHz
+        : DEFAULT_POLLING,
+      liftOffDistance,
+      debounceMs,
+      firmware,
+    };
+  }
+
+  private looksLikeStatus(block: Uint8Array): boolean {
+    const dpi = block[STATUS.dpiLo] | (block[STATUS.dpiHi] << 8);
+    const polling = this.decodePolling(block[STATUS.polling]);
+    const lod = block[STATUS.lod];
+    const debounce = block[STATUS.debounce];
+    return dpi >= 50 && dpi <= 19000 && dpi % 50 === 0
+      && POLLING_RATES.includes(polling as (typeof POLLING_RATES)[number])
+      && (lod === 1 || lod === 2)
+      && debounce !== undefined && debounce <= 15;
+  }
+
+  private async readFirmware(): Promise<string | null> {
+    const response = await this.query(COMMAND.firmware);
+    const major = response[2] ?? response[STATUS.firmwareMajor];
+    const minor = response[3] ?? response[STATUS.firmwareMinor];
+    if (major === undefined || minor === undefined) return null;
+    if (major === 0 && minor === 0) return null;
+    return `${major}.${minor}`;
+  }
+
+  private async writeSetting(command: number, payload: number[]): Promise<void> {
+    await this.open();
+    const packet = new Uint8Array(REPORT_SIZE);
+    packet[0] = REPORT.write;
+    packet[1] = command;
+    packet[2] = payload.length;
+    for (let index = 0; index < payload.length; index += 1) {
+      packet[3 + index] = payload[index] & 0xff;
+    }
+    // WebHID sendFeatureReport omits report id from the data argument.
+    await this.device.sendFeatureReport(REPORT.write, packet.slice(1));
+    await this.delay(50);
+  }
+
+  private query(command: number, options: { wake?: boolean } = {}): Promise<Uint8Array> {
+    const run = async (): Promise<Uint8Array> => {
+      await this.open();
+      const packet = new Uint8Array(REPORT_SIZE);
+      packet[0] = REPORT.read;
+      packet[1] = command;
+      await this.device.sendFeatureReport(REPORT.read, packet.slice(1));
+      if (options.wake) await this.delay(350);
+      else await this.delay(40);
+      const view = await this.device.receiveFeatureReport(REPORT.read);
+      return this.copyDataView(view);
+    };
+    const next = this.commandQueue.then(run, run);
+    this.commandQueue = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  private encodePolling(rate: number): number {
+    const table: Record<number, number> = { 125: 8, 250: 4, 500: 2, 1000: 1 };
+    const encoded = table[rate];
+    if (!encoded) throw new Error("Unsupported OP1we polling rate.");
+    return encoded;
+  }
+
+  private decodePolling(value: number): number {
+    const table: Record<number, number> = {
+      1: 1000, 2: 500, 4: 250, 8: 125,
+      125: 125, 250: 250, 500: 500, 1000: 1000,
+    };
+    return table[value] ?? value;
+  }
+
+  private clampDpi(dpi: number): number {
+    if (this.getDpiOptions().includes(dpi)) return dpi;
+    // Round to nearest legal step when firmware returns a slightly off value.
+    const stepped = Math.round(dpi / 50) * 50;
+    if (this.getDpiOptions().includes(stepped)) return stepped;
+    return DEFAULT_DPI;
+  }
+
+  private copyDataView(view: DataView): Uint8Array {
+    return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+  }
+
+  private delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+  }
+}

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -36,10 +36,6 @@ import {
 const EGG_VENDOR_ID = 0x3367;
 const OP1WE_CABLE_PIDS = new Set([0x1962, 0x1972]);
 const OP1WE_RECEIVER_PIDS = new Set([0x1961, 0x1970]);
-const OTHER_WE_MOUSE_PIDS = new Map<number, string>([
-  [0x1968, "Endgame Gear XM2we"],
-  [0x1982, "Endgame Gear XM2w"],
-]);
 const EGG_8K_PRODUCT_IDS = new Set([0x1964, 0x1966, 0x1976, 0x1978]);
 
 const USAGE_PAGE_CMD = 0xff02;
@@ -64,9 +60,6 @@ interface WeChannels {
 }
 
 export class EggWeHidClient {
-  /** Basic settings (DPI, LOD) are mapped on cable and wireless receiver. */
-  static readonly settingsMapped = true;
-
   /** Max report rate for this model (OEM UI: 125 / 250 / 500 / 1000 Hz). */
   static readonly MAX_POLLING_HZ = 1000;
 
@@ -255,14 +248,13 @@ export class EggWeHidClient {
       activeProfile: null,
       connectionType: wireless ? "Wireless" : "Wired",
       connectionDetail: wireless ? "2.4 GHz receiver" : "USB",
-      // Debounce mapped on wire but not in the simple WE control grid.
       debounceMs: null,
       liftOffDistance: profile?.lod ?? null,
       // Do not set eggCpiStages — that flag selects OP1 8K advanced UI.
       firmware: [],
       ui: {
         family: "egg-we",
-        settingsReady: EggWeHidClient.settingsMapped && profile !== null,
+        settingsReady: profile !== null,
         hideLodLow: true,
         hideUnsupportedPollingRates: true,
         hideProcessingCard: true,
@@ -319,22 +311,6 @@ export class EggWeHidClient {
     if (profile.lod !== value) {
       throw new Error(`The mouse kept ${profile.lod ?? "unknown"} LOD instead of ${value}.`);
     }
-  }
-
-  async setDebounceTime(milliseconds: number): Promise<number> {
-    if (!Number.isInteger(milliseconds) || milliseconds < 0 || milliseconds > 20) {
-      throw new Error("OP1we debounce must be an integer from 0 to 20 ms.");
-    }
-    await this.open();
-    const [v, c] = wePackScalarPair(milliseconds);
-    await this.writeEeprom(WE_OFF.debounce, [v, c]);
-    const profile = weDecodeProfile(await this.readProfileMemory());
-    if (profile.debounceMs !== milliseconds) {
-      throw new Error(
-        `The mouse kept ${profile.debounceMs ?? "unknown"} ms debounce instead of ${milliseconds} ms.`,
-      );
-    }
-    return milliseconds;
   }
 
   async close(): Promise<void> {
@@ -414,16 +390,9 @@ export class EggWeHidClient {
   // ---------------------------------------------------------------------------
 
   private productMeta(): { name: string; wired: boolean; viaReceiver: boolean } {
+    // isSupported only accepts OP1we cable/receiver PIDs.
     const viaReceiver = EggWeHidClient.isReceiverDevice(this.device);
-    const other = OTHER_WE_MOUSE_PIDS.get(this.device.productId);
-    const name = other
-      ?? (OP1WE_CABLE_PIDS.has(this.device.productId)
-        || OP1WE_RECEIVER_PIDS.has(this.device.productId)
-        || /op1\s*we|we series/i.test(this.device.productName || "")
-        ? "Endgame Gear OP1we"
-        : (this.device.productName?.replace(/\s*(receiver|dongle)\s*/ig, " ").trim()
-          || "Endgame Gear WE mouse"));
-    return { name, wired: !viaReceiver, viaReceiver };
+    return { name: "Endgame Gear OP1we", wired: !viaReceiver, viaReceiver };
   }
 
   private requireChannels(): WeChannels {
@@ -478,16 +447,20 @@ export class EggWeHidClient {
     return { percent: power, charging: (data[6] ?? 0) !== 0 };
   }
 
+  private failWaiter(error: Error): void {
+    const waiter = this.responseWaiter;
+    if (!waiter) return;
+    window.clearTimeout(waiter.timer);
+    this.responseWaiter = null;
+    waiter.reject(error);
+  }
+
   private async transact(
     channels: WeChannels,
     command: number,
     payload: Uint8Array,
   ): Promise<Uint8Array> {
-    if (this.responseWaiter) {
-      window.clearTimeout(this.responseWaiter.timer);
-      this.responseWaiter.reject(new Error("Superseded by another OP1we request."));
-      this.responseWaiter = null;
-    }
+    this.failWaiter(new Error("Superseded by another OP1we request."));
 
     const responsePromise = new Promise<Uint8Array>((resolve, reject) => {
       const timer = window.setTimeout(() => {
@@ -500,23 +473,15 @@ export class EggWeHidClient {
     channels.notify.removeEventListener("inputreport", this.onInputReport);
     channels.notify.addEventListener("inputreport", this.onInputReport);
 
-    const body = payload.byteLength === WE_PAYLOAD_LEN
-      ? payload
-      : (() => { throw new Error("WE payload must be 16 bytes."); })();
+    if (payload.byteLength !== WE_PAYLOAD_LEN) {
+      throw new Error("WE payload must be 16 bytes.");
+    }
     // Ensure ArrayBuffer-backed view for WebHID typings.
-    const copy = new Uint8Array(body);
+    const copy = new Uint8Array(payload);
     try {
       await channels.cmd.sendFeatureReport(WE_REPORT_ID, copy.buffer);
     } catch (error) {
-      const waiter = this.responseWaiter as {
-        reject: (reason: Error) => void;
-        timer: number;
-      } | null;
-      if (waiter) {
-        window.clearTimeout(waiter.timer);
-        this.responseWaiter = null;
-        waiter.reject(error instanceof Error ? error : new Error(String(error)));
-      }
+      this.failWaiter(error instanceof Error ? error : new Error(String(error)));
     }
     return responsePromise;
   }
@@ -565,7 +530,7 @@ export class EggWeHidClient {
 
   private static listReports(
     device: HIDDevice,
-    kind: "featureReports" | "outputReports" | "inputReports",
+    kind: "featureReports" | "inputReports",
   ): ReportTarget[] {
     const found: ReportTarget[] = [];
     const visit = (collections: readonly HIDCollectionInfo[]): void => {
@@ -590,26 +555,4 @@ export class EggWeHidClient {
     }
     return bits === 0 ? 0 : Math.ceil(bits / 8);
   }
-
-  private static collectionTreeHasVendorUsage(collections: readonly HIDCollectionInfo[]): boolean {
-    return collections.some((collection) =>
-      collection.usagePage >= 0xff00 || this.collectionTreeHasVendorUsage(collection.children));
-  }
 }
-
-// Re-export protocol helpers for tests / tooling that import the client module.
-export {
-  weBuildCmdPayload,
-  weBuildReadEepromPayload,
-  weBuildWriteEepromPayload,
-  weDecodeProfile,
-  wePackDpiStage,
-  weUnpackDpiStage,
-  wePackScalarPair,
-  weReportChecksum,
-  weCpiToByte,
-  weByteToCpi,
-  weParseReadEepromResponse,
-  weParseWriteEepromResponse,
-  wePatchActiveDpi,
-} from "./egg-we-protocol";

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -15,14 +15,20 @@ import type { MouseStatus } from "./mouse-types";
 
 const EGG_VENDOR_ID = 0x3367;
 
-/** Wired mice report charging; the shared dongle is wireless. */
-const SUPPORTED_PRODUCTS = new Map<number, { name: string; wired: boolean }>([
+/**
+ * Known WE-family product IDs. Unknown 0x3367 PIDs are still accepted when the
+ * HID interface looks like a vendor config channel (see isSupported) — OP1we
+ * firmware has used more than one PID across cable vs dongle revisions.
+ */
+const KNOWN_PRODUCTS = new Map<number, { name: string; wired: boolean }>([
   [0x1972, { name: "Endgame Gear OP1we", wired: true }],
   [0x1970, { name: "Endgame Gear wireless receiver", wired: false }],
-  // Other WE-family PIDs (same transport); safe to claim when present.
   [0x1968, { name: "Endgame Gear XM2we", wired: true }],
   [0x1982, { name: "Endgame Gear XM2w v2", wired: true }],
 ]);
+
+/** Wired OP1 8K / XM2 8K PIDs — owned by egg-op1-hid, never claim here. */
+const EGG_8K_PRODUCT_IDS = new Set([0x1964, 0x1966, 0x1976, 0x1978]);
 
 const REPORT_SIZE = 64;
 const REPORT = {
@@ -69,16 +75,59 @@ export class EggWeHidClient {
 
   constructor(readonly device: HIDDevice) {}
 
+  /**
+   * Accept Endgame Gear WE interfaces that are not the wired 8K driver.
+   * Prefer vendor feature report 0xa1 when present; also accept vendor usage
+   * collections (0xff01 / 0xff00) so the Chrome picker entry is not rejected
+   * before we can open and probe.
+   */
   static isSupported(device: HIDDevice): boolean {
-    return device.vendorId === EGG_VENDOR_ID
-      && SUPPORTED_PRODUCTS.has(device.productId)
-      && device.collections.some((collection) =>
-        this.collectionHasFeatureReport(collection, REPORT.read));
+    if (device.vendorId !== EGG_VENDOR_ID) return false;
+    if (EGG_8K_PRODUCT_IDS.has(device.productId)) return false;
+    return this.hasVendorConfigInterface(device);
   }
 
-  private static collectionHasFeatureReport(collection: HIDCollectionInfo, reportId: number): boolean {
-    return collection.featureReports.some((report) => report.reportId === reportId)
-      || collection.children.some((child) => this.collectionHasFeatureReport(child, reportId));
+  /** Rank higher when the interface exposes the WE feature report we talk on. */
+  static supportScore(device: HIDDevice): number {
+    if (!this.isSupported(device)) return 0;
+    let score = 1;
+    if (this.collectionTreeHasFeatureReport(device.collections, REPORT.read)) score += 4;
+    if (this.collectionTreeHasFeatureReport(device.collections, REPORT.write)) score += 2;
+    if (this.collectionTreeHasVendorUsage(device.collections)) score += 1;
+    return score;
+  }
+
+  private static hasVendorConfigInterface(device: HIDDevice): boolean {
+    if (this.collectionTreeHasFeatureReport(device.collections, REPORT.read)) return true;
+    if (this.collectionTreeHasFeatureReport(device.collections, REPORT.write)) return true;
+    // Some Windows enumerations expose the vendor page before report ids resolve.
+    if (this.collectionTreeHasVendorUsage(device.collections)) return true;
+    // Last resort: any non-boot feature report on this VID (not 8K).
+    return device.collections.some((collection) =>
+      this.collectionTreeHasAnyFeatureReport([collection]));
+  }
+
+  private static collectionTreeHasFeatureReport(
+    collections: readonly HIDCollectionInfo[],
+    reportId: number,
+  ): boolean {
+    return collections.some((collection) =>
+      collection.featureReports.some((report) => report.reportId === reportId)
+      || this.collectionTreeHasFeatureReport(collection.children, reportId));
+  }
+
+  private static collectionTreeHasAnyFeatureReport(collections: readonly HIDCollectionInfo[]): boolean {
+    return collections.some((collection) =>
+      collection.featureReports.length > 0
+      || this.collectionTreeHasAnyFeatureReport(collection.children));
+  }
+
+  private static collectionTreeHasVendorUsage(collections: readonly HIDCollectionInfo[]): boolean {
+    return collections.some((collection) => {
+      const page = collection.usagePage;
+      if (page === 0xff00 || page === 0xff01 || page >= 0xff00) return true;
+      return this.collectionTreeHasVendorUsage(collection.children);
+    });
   }
 
   async open(): Promise<void> {
@@ -103,8 +152,16 @@ export class EggWeHidClient {
   }
 
   private productMeta(): { name: string; wired: boolean } {
-    return SUPPORTED_PRODUCTS.get(this.device.productId)
-      ?? { name: this.device.productName || "Endgame Gear WE mouse", wired: false };
+    const known = KNOWN_PRODUCTS.get(this.device.productId);
+    if (known) return known;
+    const productName = this.device.productName?.trim() || "Endgame Gear WE mouse";
+    const lower = productName.toLowerCase();
+    const wired = !lower.includes("receiver") && !lower.includes("dongle");
+    // Prefer the marketing name from the OS when PID is unknown.
+    if (lower.includes("op1we") || lower.includes("op1 we")) {
+      return { name: wired ? "Endgame Gear OP1we" : "Endgame Gear OP1we receiver", wired };
+    }
+    return { name: productName, wired };
   }
 
   async readStatus(): Promise<MouseStatus> {

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -1,88 +1,132 @@
 import type { MouseStatus } from "./mouse-types";
+import {
+  WE_CMD_GET_POWER,
+  WE_CMD_READ_EEPROM,
+  WE_CMD_WRITE_EEPROM,
+  WE_MAX_EEPROM_CHUNK,
+  WE_OFF,
+  WE_PAYLOAD_LEN,
+  WE_REPORT_ID,
+  weBuildCmdPayload,
+  weBuildReadEepromPayload,
+  weBuildWriteEepromPayload,
+  weDecodeProfile,
+  weEncodeLod,
+  weIsValidCpi,
+  wePackScalarPair,
+  weParseReadEepromResponse,
+  weParseWriteEepromResponse,
+  weEncodeReportRate,
+  weIsValidPollingRate,
+  wePatchAllActiveDpi,
+  WE_POLLING_RATES,
+  type WeLod,
+  type WeProfile,
+} from "./egg-we-protocol";
 
 /**
  * Endgame Gear WE-series (OP1we).
  *
- * Model:
- * - One physical mouse (OP1we).
- * - Cable HID (e.g. PID 0x1962) and receiver HID (e.g. PID 0x1961) are two
- *   transports to that same mouse — never two products.
- * - OEM software may list both interfaces; OpenMouse shows one OP1we.
- *
- * Safety:
- * - Wireless (receiver) path: NO feature/output config traffic. Any chatter
- *   freezes the mouse. Identity-only status until protocol is captured offline.
- * - Wired path: optional single battery attempt; no multi-command probes.
- *
- * Settings (CPI/polling/LOD/debounce) are not reverse-engineered yet.
+ * Cable + wireless dongle: FF02 feature 8 ↔ FF01 input 9, checksum sum-to-0x55.
+ * Battery GetPower 0x04; profile ReadEEPROM 0x08 / WriteEEPROM 0x07.
+ * Prefer cable when both are present. Wireless uses the same cmds with
+ * slightly longer spacing between EEPROM chunks.
  */
 
 const EGG_VENDOR_ID = 0x3367;
-
-/** Cable / dongle PIDs observed for OP1we and related WE family. */
 const OP1WE_CABLE_PIDS = new Set([0x1962, 0x1972]);
 const OP1WE_RECEIVER_PIDS = new Set([0x1961, 0x1970]);
 const OTHER_WE_MOUSE_PIDS = new Map<number, string>([
   [0x1968, "Endgame Gear XM2we"],
   [0x1982, "Endgame Gear XM2w"],
 ]);
-
-/** Wired OP1 8K / XM2 8K — owned by egg-op1-hid. */
 const EGG_8K_PRODUCT_IDS = new Set([0x1964, 0x1966, 0x1976, 0x1978]);
 
-const POLLING_RATES = [125, 250, 500, 1000] as const;
+const USAGE_PAGE_CMD = 0xff02;
+const USAGE_PAGE_NOTIFY = 0xff01;
+const REPORT_NOTIFY = 0x09;
+const CMD_TIMEOUT_MS = 900;
+const WIRED_POLL_INTERVAL_MS = 30_000;
+/** Slower status refresh on the dongle to avoid flooding the RF path. */
+const WIRELESS_POLL_INTERVAL_MS = 45_000;
+const WIRELESS_EEPROM_GAP_MS = 35;
+/** Profile bytes needed for DPI + LOD + debounce (+ stages). */
+const PROFILE_END = 0xb5;
 
-interface FeatureReportTarget {
+interface ReportTarget {
   reportId: number;
   payloadLength: number;
 }
 
+interface WeChannels {
+  cmd: HIDDevice;
+  notify: HIDDevice;
+}
+
 export class EggWeHidClient {
-  /** Settings writes are not mapped — keep false until USB capture of WE software. */
-  static readonly settingsMapped = false;
+  /** Basic settings (DPI, LOD) are mapped on cable and wireless receiver. */
+  static readonly settingsMapped = true;
 
-  /** No background polling — feature traffic freezes the wireless mouse. */
-  static readonly pollIntervalMs = 0;
+  /** Max report rate for this model (OEM UI: 125 / 250 / 500 / 1000 Hz). */
+  static readonly MAX_POLLING_HZ = 1000;
 
-  /**
-   * Wireless battery HID is off until OEM capture — dongle chatter freezes the
-   * mouse and current commands only return empty frames.
-   */
-  static readonly ALLOW_WIRELESS_BATTERY = false;
+  private cmdDevice: HIDDevice | null = null;
+  private notifyDevice: HIDDevice | null = null;
+  private channelsResolved = false;
+  private responseWaiter: {
+    command: number;
+    resolve: (bytes: Uint8Array) => void;
+    reject: (reason: Error) => void;
+    timer: number;
+  } | null = null;
+
+  private readonly onInputReport = (event: HIDInputReportEvent): void => {
+    if (event.reportId !== REPORT_NOTIFY) return;
+    const bytes = new Uint8Array(
+      event.data.buffer.slice(event.data.byteOffset, event.data.byteOffset + event.data.byteLength),
+    );
+    const waiter = this.responseWaiter;
+    if (!waiter || bytes[0] !== waiter.command) return;
+    window.clearTimeout(waiter.timer);
+    this.responseWaiter = null;
+    waiter.resolve(bytes);
+  };
 
   constructor(readonly device: HIDDevice) {}
+
+  static fromAuthorizedDevices(devices: readonly HIDDevice[]): EggWeHidClient | null {
+    const primary = this.pickDevices(devices)[0];
+    if (!primary) return null;
+    const client = new EggWeHidClient(primary);
+    client.bindPeers(devices);
+    return client;
+  }
 
   static isSupported(device: HIDDevice): boolean {
     if (device.vendorId !== EGG_VENDOR_ID) return false;
     if (EGG_8K_PRODUCT_IDS.has(device.productId)) return false;
-    // Known WE PIDs, or any non-8K EGG with a vendor feature/output report.
     if (OP1WE_CABLE_PIDS.has(device.productId) || OP1WE_RECEIVER_PIDS.has(device.productId)) {
       return true;
     }
     if (OTHER_WE_MOUSE_PIDS.has(device.productId)) return true;
     return this.listFeatureReports(device).length > 0
       || this.listOutputReports(device).length > 0
+      || this.listInputReports(device).length > 0
       || this.collectionTreeHasVendorUsage(device.collections);
   }
 
-  /** Dongle HID interface — same mouse, wireless transport only. */
   static isReceiverDevice(device: HIDDevice): boolean {
     if (OP1WE_RECEIVER_PIDS.has(device.productId)) return true;
     const name = (device.productName || "").toLowerCase();
     return name.includes("receiver") || name.includes("dongle");
   }
 
-  /**
-   * Among WE-capable HID interfaces, pick exactly one logical mouse.
-   * Prefer cable over receiver; among equals, highest supportScore wins.
-   * (A single USB mouse often enumerates multiple interfaces — never return both.)
-   */
   static pickDevices(devices: readonly HIDDevice[]): HIDDevice[] {
     const we = devices.filter((device) => this.isSupported(device));
     if (we.length === 0) return [];
     const ranked = [...we].sort((left, right) => {
       const receiverDelta = Number(this.isReceiverDevice(left)) - Number(this.isReceiverDevice(right));
-      if (receiverDelta !== 0) return receiverDelta; // non-receiver first
+      if (receiverDelta !== 0) return receiverDelta;
       return this.supportScore(right) - this.supportScore(left);
     });
     return ranked[0] ? [ranked[0]] : [];
@@ -94,18 +138,407 @@ export class EggWeHidClient {
     if (OP1WE_CABLE_PIDS.has(device.productId)) score += 8;
     if (OP1WE_RECEIVER_PIDS.has(device.productId)) score += 2;
     if (!this.isReceiverDevice(device)) score += 4;
-    // From hidapitester report descriptors on PID 0x1962:
-    //   FF02/2 → Feature report id 8, 16 data bytes
-    //   FF04/2 → Feature report id 6, 7 data bytes
-    //   FF01   → Input only (id 9); FF03 → Input only (id 2)
     const pages = this.usagePages(device);
-    if (pages.has(0xff02)) score += 10;
-    if (pages.has(0xff04)) score += 8;
+    if (pages.has(USAGE_PAGE_CMD)) score += 10;
+    if (pages.has(USAGE_PAGE_NOTIFY)) score += 10;
+    if (pages.has(0xff04)) score += 4;
     const features = this.listFeatureReports(device);
-    if (features.some((report) => report.reportId === 0x08 && report.payloadLength >= 15)) score += 6;
-    if (features.some((report) => report.reportId === 0x06 && report.payloadLength === 7)) score += 4;
+    const inputs = this.listInputReports(device);
+    if (features.some((report) => report.reportId === WE_REPORT_ID && report.payloadLength >= 15)) score += 6;
+    if (inputs.some((report) => report.reportId === REPORT_NOTIFY && report.payloadLength >= 15)) score += 6;
     if (features.length > 0) score += 2;
     return score;
+  }
+
+  get pollIntervalMs(): number {
+    return this.isWirelessPath() ? WIRELESS_POLL_INTERVAL_MS : WIRED_POLL_INTERVAL_MS;
+  }
+
+  isWirelessPath(): boolean {
+    return EggWeHidClient.isReceiverDevice(this.device);
+  }
+
+  ownsDevice(device: HIDDevice): boolean {
+    return device === this.device
+      || device === this.cmdDevice
+      || device === this.notifyDevice;
+  }
+
+  /**
+   * Pair FF02 (cmd) + FF01 (notify) for this transport only.
+   * Cable primary → cable peers; receiver primary → receiver peers.
+   */
+  bindPeers(devices: readonly HIDDevice[]): void {
+    const wireless = this.isWirelessPath();
+    const peers = devices.filter((candidate) =>
+      candidate.vendorId === this.device.vendorId
+      && candidate.productId === this.device.productId
+      && EggWeHidClient.isReceiverDevice(candidate) === wireless);
+    const pool = peers.length > 0 ? peers : [this.device];
+    const cmd = pool.find((d) => EggWeHidClient.hasCmdChannel(d)) ?? null;
+    const notify = pool.find((d) => EggWeHidClient.hasNotifyChannel(d)) ?? null;
+    this.cmdDevice = cmd ?? (EggWeHidClient.hasCmdChannel(this.device) ? this.device : null);
+    this.notifyDevice = notify
+      ?? (EggWeHidClient.hasNotifyChannel(this.device) ? this.device : null);
+    this.channelsResolved = true;
+  }
+
+  async open(): Promise<void> {
+    if (!this.channelsResolved) {
+      const authorized = typeof navigator !== "undefined" && navigator.hid
+        ? await navigator.hid.getDevices()
+        : [];
+      this.bindPeers(authorized);
+    }
+    const channels = this.resolvedChannels();
+    if (!channels) {
+      if (!this.device.opened) await this.device.open();
+      return;
+    }
+    if (!channels.cmd.opened) await channels.cmd.open();
+    if (channels.notify !== channels.cmd && !channels.notify.opened) {
+      await channels.notify.open();
+    }
+    channels.notify.removeEventListener("inputreport", this.onInputReport);
+    channels.notify.addEventListener("inputreport", this.onInputReport);
+  }
+
+  describeCollections(): string {
+    const parts: string[] = [];
+    const cmd = this.cmdDevice ?? this.device;
+    const notify = this.notifyDevice;
+    const features = EggWeHidClient.listFeatureReports(cmd)
+      .map((report) => `feat 0x${report.reportId.toString(16)}/${report.payloadLength}B`);
+    if (features.length) parts.push(features.join(" · "));
+    if (notify) {
+      const inputs = EggWeHidClient.listInputReports(notify)
+        .filter((report) => report.reportId === REPORT_NOTIFY)
+        .map((report) => `in 0x${report.reportId.toString(16)}/${report.payloadLength}B`);
+      if (inputs.length) parts.push(inputs.join(" · "));
+    }
+    return parts.join(" · ") || "no vendor reports";
+  }
+
+  getDpiOptions(): number[] {
+    const values: number[] = [];
+    for (let dpi = 50; dpi <= 12800; dpi += 50) values.push(dpi);
+    return values;
+  }
+
+  get supportedPollingRates(): number[] {
+    // Same four rates as Endgame Gear WE Series software (upper bound 1000 Hz).
+    return [...WE_POLLING_RATES];
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    const meta = this.productMeta();
+    const wireless = meta.viaReceiver;
+
+    let batteryPercent: number | null = null;
+    let batteryState: MouseStatus["batteryState"] = "Unknown";
+    let profile: WeProfile | null = null;
+
+    try {
+      await this.open();
+      const battery = await this.readBatteryOnce();
+      batteryPercent = battery.percent;
+      batteryState = battery.state;
+      profile = await this.readProfile();
+    } catch (error) {
+      console.info(
+        "[OpenMouse WE] readStatus failed:",
+        error instanceof Error ? error.message : error,
+      );
+    }
+
+    return {
+      brand: "Endgame Gear",
+      name: meta.name,
+      batteryPercent,
+      batteryState,
+      dpi: profile?.dpi ?? 800,
+      pollingRateHz: profile?.pollingRateHz ?? 1000,
+      supportedPollingRates: this.supportedPollingRates,
+      activeProfile: null,
+      connectionType: wireless ? "Wireless" : "Wired",
+      connectionDetail: wireless ? "2.4 GHz receiver" : "USB",
+      // Debounce mapped on wire but not in the simple WE control grid.
+      debounceMs: null,
+      liftOffDistance: profile?.lod ?? null,
+      // Do not set eggCpiStages — that flag selects OP1 8K advanced UI.
+      firmware: [],
+      ui: {
+        family: "egg-we",
+        settingsReady: EggWeHidClient.settingsMapped,
+        hideLodLow: true,
+        hideUnsupportedPollingRates: true,
+        hideProcessingCard: true,
+        forceShowBattery: true,
+        pollingNote: "OP1we supports up to 1,000 Hz (125 / 250 / 500 / 1000).",
+        defaultDisplayName: "Endgame Gear OP1we",
+      },
+    };
+  }
+
+  async setDpi(dpi: number): Promise<number> {
+    if (!weIsValidCpi(dpi) || !this.getDpiOptions().includes(dpi)) {
+      throw new Error("OP1we CPI must be between 50 and 12,800 in 50 CPI steps.");
+    }
+    await this.open();
+    const mem = await this.readProfileMemory();
+    const profile = weDecodeProfile(mem);
+    wePatchAllActiveDpi(mem, dpi, profile.dpiStageCount);
+    // Write each active stage chunk (4 bytes) via WriteEEPROM.
+    for (let i = 0; i < profile.dpiStageCount; i += 1) {
+      const off = WE_OFF.dpiStages + i * WE_OFF.dpiStageBytes;
+      await this.writeEeprom(off, [...mem.subarray(off, off + 4)]);
+    }
+    const confirmed = weDecodeProfile(await this.readProfileMemory());
+    if (confirmed.dpi !== dpi) {
+      throw new Error(`The mouse kept ${confirmed.dpi} CPI instead of ${dpi} CPI.`);
+    }
+    return confirmed.dpi;
+  }
+
+  async setPollingRate(rate: number): Promise<number> {
+    if (!weIsValidPollingRate(rate)) {
+      throw new Error("OP1we supports 125, 250, 500, or 1000 Hz report rate.");
+    }
+    await this.open();
+    const encoded = weEncodeReportRate(rate);
+    const [v, c] = wePackScalarPair(encoded);
+    await this.writeEeprom(WE_OFF.reportRate, [v, c]);
+    const confirmed = weDecodeProfile(await this.readProfileMemory());
+    if (confirmed.pollingRateHz !== rate) {
+      throw new Error(
+        `The mouse kept ${confirmed.pollingRateHz.toLocaleString()} Hz instead of ${rate.toLocaleString()} Hz.`,
+      );
+    }
+    return confirmed.pollingRateHz;
+  }
+
+  async setLiftOffDistance(value: NonNullable<MouseStatus["liftOffDistance"]>): Promise<void> {
+    if (value === "Low") {
+      throw new Error("The OP1we supports Medium or High lift-off distance only.");
+    }
+    const raw = weEncodeLod(value as WeLod);
+    await this.open();
+    const [v, c] = wePackScalarPair(raw);
+    await this.writeEeprom(WE_OFF.lod, [v, c]);
+    const profile = weDecodeProfile(await this.readProfileMemory());
+    if (profile.lod !== value) {
+      throw new Error(`The mouse kept ${profile.lod ?? "unknown"} LOD instead of ${value}.`);
+    }
+  }
+
+  async setDebounceTime(milliseconds: number): Promise<number> {
+    if (!Number.isInteger(milliseconds) || milliseconds < 0 || milliseconds > 20) {
+      throw new Error("OP1we debounce must be an integer from 0 to 20 ms.");
+    }
+    await this.open();
+    const [v, c] = wePackScalarPair(milliseconds);
+    await this.writeEeprom(WE_OFF.debounce, [v, c]);
+    const profile = weDecodeProfile(await this.readProfileMemory());
+    if (profile.debounceMs !== milliseconds) {
+      throw new Error(
+        `The mouse kept ${profile.debounceMs ?? "unknown"} ms debounce instead of ${milliseconds} ms.`,
+      );
+    }
+    return milliseconds;
+  }
+
+  async close(): Promise<void> {
+    if (this.responseWaiter) {
+      window.clearTimeout(this.responseWaiter.timer);
+      this.responseWaiter.reject(new Error("The OP1we device was closed."));
+      this.responseWaiter = null;
+    }
+    const notify = this.notifyDevice;
+    if (notify) notify.removeEventListener("inputreport", this.onInputReport);
+    const unique = new Set<HIDDevice>([
+      this.device,
+      ...(this.cmdDevice ? [this.cmdDevice] : []),
+      ...(this.notifyDevice ? [this.notifyDevice] : []),
+    ]);
+    for (const device of unique) {
+      if (device.opened) await device.close().catch(() => undefined);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Profile EEPROM
+  // ---------------------------------------------------------------------------
+
+  private async readProfile(): Promise<WeProfile> {
+    return weDecodeProfile(await this.readProfileMemory());
+  }
+
+  private async readProfileMemory(): Promise<Uint8Array> {
+    const mem = new Uint8Array(PROFILE_END);
+    let addr = 0;
+    while (addr < PROFILE_END) {
+      const len = Math.min(WE_MAX_EEPROM_CHUNK, PROFILE_END - addr);
+      const chunk = await this.readEeprom(addr, len);
+      mem.set(chunk, addr);
+      addr += len;
+      // Space RF commands on the dongle so the cursor does not stall.
+      if (this.isWirelessPath() && addr < PROFILE_END) {
+        await this.delay(WIRELESS_EEPROM_GAP_MS);
+      }
+    }
+    return mem;
+  }
+
+  private async readEeprom(addr: number, length: number): Promise<Uint8Array> {
+    const channels = this.requireChannels();
+    const payload = weBuildReadEepromPayload(addr, length);
+    const response = await this.transact(channels, WE_CMD_READ_EEPROM, payload);
+    const data = weParseReadEepromResponse(response, addr, length);
+    if (!data) {
+      throw new Error(
+        `OP1we ReadEEPROM failed at 0x${addr.toString(16)} len=${length} `
+        + `raw=[${this.toHex(response)}]`,
+      );
+    }
+    return data;
+  }
+
+  private async writeEeprom(addr: number, data: number[]): Promise<void> {
+    const channels = this.requireChannels();
+    const payload = weBuildWriteEepromPayload(addr, data);
+    const response = await this.transact(channels, WE_CMD_WRITE_EEPROM, payload);
+    if (!weParseWriteEepromResponse(response)) {
+      throw new Error(
+        `OP1we WriteEEPROM failed at 0x${addr.toString(16)} raw=[${this.toHex(response)}]`,
+      );
+    }
+    if (this.isWirelessPath()) await this.delay(WIRELESS_EEPROM_GAP_MS);
+  }
+
+  private delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+  }
+
+  // ---------------------------------------------------------------------------
+  // GetPower + transport
+  // ---------------------------------------------------------------------------
+
+  private productMeta(): { name: string; wired: boolean; viaReceiver: boolean } {
+    const viaReceiver = EggWeHidClient.isReceiverDevice(this.device);
+    const other = OTHER_WE_MOUSE_PIDS.get(this.device.productId);
+    const name = other
+      ?? (OP1WE_CABLE_PIDS.has(this.device.productId)
+        || OP1WE_RECEIVER_PIDS.has(this.device.productId)
+        || /op1\s*we|we series/i.test(this.device.productName || "")
+        ? "Endgame Gear OP1we"
+        : (this.device.productName?.replace(/\s*(receiver|dongle)\s*/ig, " ").trim()
+          || "Endgame Gear WE mouse"));
+    return { name, wired: !viaReceiver, viaReceiver };
+  }
+
+  private requireChannels(): WeChannels {
+    const channels = this.resolvedChannels();
+    if (!channels) {
+      throw new Error(
+        "OP1we vendor channels missing. Authorize FF02 (command) and FF01 (notify).",
+      );
+    }
+    return channels;
+  }
+
+  private resolvedChannels(): WeChannels | null {
+    if (!this.cmdDevice || !EggWeHidClient.hasCmdChannel(this.cmdDevice)) return null;
+    const notify = this.notifyDevice
+      ?? (EggWeHidClient.hasNotifyChannel(this.cmdDevice) ? this.cmdDevice : null);
+    if (!notify) return null;
+    return { cmd: this.cmdDevice, notify };
+  }
+
+  private async readBatteryOnce(): Promise<{
+    percent: number | null;
+    state: MouseStatus["batteryState"];
+  }> {
+    try {
+      const channels = this.requireChannels();
+      const payload = weBuildCmdPayload(WE_CMD_GET_POWER);
+      const response = await this.transact(channels, WE_CMD_GET_POWER, payload);
+      const parsed = this.parseGetPowerResponse(response);
+      if (parsed.percent === null) return { percent: null, state: "Unknown" };
+      if (parsed.charging) {
+        return { percent: parsed.percent, state: parsed.percent >= 99 ? "Full" : "Charging" };
+      }
+      return { percent: parsed.percent, state: parsed.percent >= 99 ? "Full" : "Discharging" };
+    } catch {
+      return { percent: null, state: "Unknown" };
+    }
+  }
+
+  private parseGetPowerResponse(response: Uint8Array): {
+    percent: number | null;
+    charging: boolean;
+  } {
+    let data = response;
+    if (data[0] === REPORT_NOTIFY && data.byteLength > WE_PAYLOAD_LEN - 1) {
+      data = data.subarray(1);
+    }
+    if (data.byteLength < 7) return { percent: null, charging: false };
+    if (data[0] !== WE_CMD_GET_POWER || data[1] !== 0) return { percent: null, charging: false };
+    const power = data[5];
+    if (power === undefined || power > 100) return { percent: null, charging: false };
+    return { percent: power, charging: (data[6] ?? 0) !== 0 };
+  }
+
+  private async transact(
+    channels: WeChannels,
+    command: number,
+    payload: Uint8Array,
+  ): Promise<Uint8Array> {
+    if (this.responseWaiter) {
+      window.clearTimeout(this.responseWaiter.timer);
+      this.responseWaiter.reject(new Error("Superseded by another OP1we request."));
+      this.responseWaiter = null;
+    }
+
+    const responsePromise = new Promise<Uint8Array>((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        if (this.responseWaiter?.resolve === resolve) this.responseWaiter = null;
+        reject(new Error(`Timed out waiting for OP1we cmd 0x${command.toString(16)}.`));
+      }, CMD_TIMEOUT_MS);
+      this.responseWaiter = { command, resolve, reject, timer };
+    });
+
+    channels.notify.removeEventListener("inputreport", this.onInputReport);
+    channels.notify.addEventListener("inputreport", this.onInputReport);
+
+    const body = payload.byteLength === WE_PAYLOAD_LEN
+      ? payload
+      : (() => { throw new Error("WE payload must be 16 bytes."); })();
+    // Ensure ArrayBuffer-backed view for WebHID typings.
+    const copy = new Uint8Array(body);
+    await channels.cmd.sendFeatureReport(WE_REPORT_ID, copy.buffer);
+    return responsePromise;
+  }
+
+  private toHex(bytes: Uint8Array): string {
+    return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Descriptor helpers
+  // ---------------------------------------------------------------------------
+
+  private static hasCmdChannel(device: HIDDevice): boolean {
+    const pages = this.usagePages(device);
+    if (pages.has(USAGE_PAGE_CMD)) return true;
+    return this.listFeatureReports(device)
+      .some((report) => report.reportId === WE_REPORT_ID && report.payloadLength >= 15);
+  }
+
+  private static hasNotifyChannel(device: HIDDevice): boolean {
+    const pages = this.usagePages(device);
+    if (pages.has(USAGE_PAGE_NOTIFY)) return true;
+    return this.listInputReports(device)
+      .some((report) => report.reportId === REPORT_NOTIFY && report.payloadLength >= 15);
   }
 
   private static usagePages(device: HIDDevice): Set<number> {
@@ -120,32 +553,26 @@ export class EggWeHidClient {
     return pages;
   }
 
-  isWirelessPath(): boolean {
-    return EggWeHidClient.isReceiverDevice(this.device);
+  private static listFeatureReports(device: HIDDevice): ReportTarget[] {
+    return this.listReports(device, "featureReports");
   }
 
-  private static listFeatureReports(device: HIDDevice): FeatureReportTarget[] {
-    const found: FeatureReportTarget[] = [];
-    const visit = (collections: readonly HIDCollectionInfo[]): void => {
-      for (const collection of collections) {
-        for (const report of collection.featureReports) {
-          found.push({
-            reportId: report.reportId,
-            payloadLength: this.reportPayloadLength(report),
-          });
-        }
-        visit(collection.children);
-      }
-    };
-    visit(device.collections);
-    return found;
+  private static listOutputReports(device: HIDDevice): ReportTarget[] {
+    return this.listReports(device, "outputReports");
   }
 
-  private static listOutputReports(device: HIDDevice): FeatureReportTarget[] {
-    const found: FeatureReportTarget[] = [];
+  private static listInputReports(device: HIDDevice): ReportTarget[] {
+    return this.listReports(device, "inputReports");
+  }
+
+  private static listReports(
+    device: HIDDevice,
+    kind: "featureReports" | "outputReports" | "inputReports",
+  ): ReportTarget[] {
+    const found: ReportTarget[] = [];
     const visit = (collections: readonly HIDCollectionInfo[]): void => {
       for (const collection of collections) {
-        for (const report of collection.outputReports) {
+        for (const report of collection[kind]) {
           found.push({
             reportId: report.reportId,
             payloadLength: this.reportPayloadLength(report),
@@ -170,297 +597,20 @@ export class EggWeHidClient {
     return collections.some((collection) =>
       collection.usagePage >= 0xff00 || this.collectionTreeHasVendorUsage(collection.children));
   }
-
-  async open(): Promise<void> {
-    // Wireless: do not open the config interface unless we later add a
-    // user-triggered, proven-safe command. Opening alone has been OK; avoid
-    // feature traffic after open.
-    if (this.isWirelessPath()) return;
-    if (!this.device.opened) await this.device.open();
-  }
-
-  describeCollections(): string {
-    return EggWeHidClient.listFeatureReports(this.device)
-      .map((report) => `feat 0x${report.reportId.toString(16)}/${report.payloadLength}B`)
-      .join(" · ") || "no feature reports";
-  }
-
-  getDpiOptions(): number[] {
-    const values: number[] = [];
-    for (let dpi = 50; dpi <= 19000; dpi += 50) values.push(dpi);
-    return values;
-  }
-
-  get supportedPollingRates(): number[] {
-    return [...POLLING_RATES];
-  }
-
-  private productMeta(): { name: string; wired: boolean; viaReceiver: boolean } {
-    const viaReceiver = EggWeHidClient.isReceiverDevice(this.device);
-    const other = OTHER_WE_MOUSE_PIDS.get(this.device.productId);
-    // Always the mouse product — receiver is never a separate model name.
-    const name = other
-      ?? (OP1WE_CABLE_PIDS.has(this.device.productId)
-        || OP1WE_RECEIVER_PIDS.has(this.device.productId)
-        || /op1\s*we|we series/i.test(this.device.productName || "")
-        ? "Endgame Gear OP1we"
-        : (this.device.productName?.replace(/\s*(receiver|dongle)\s*/ig, " ").trim()
-          || "Endgame Gear WE mouse"));
-
-    return {
-      name,
-      wired: !viaReceiver,
-      viaReceiver,
-    };
-  }
-
-  /**
-   * Identity + connection + best-effort battery.
-   * UI fields match other brands (short connection/firmware text — no debug dump).
-   *
-   * Wireless: one optional battery read only (no probes/refresh). If freezes return,
-   * set ALLOW_WIRELESS_BATTERY to false.
-   */
-  async readStatus(): Promise<MouseStatus> {
-    const meta = this.productMeta();
-    const wireless = meta.viaReceiver;
-
-    let batteryPercent: number | null = null;
-    let batteryState: MouseStatus["batteryState"] = "Unknown";
-
-    // Wired: always try battery. Wireless: single read only (no auto-refresh).
-    if (!wireless || EggWeHidClient.ALLOW_WIRELESS_BATTERY) {
-      try {
-        if (!wireless) await this.open();
-        else if (!this.device.opened) await this.device.open();
-        const battery = await this.readBatteryOnce(wireless);
-        batteryPercent = battery.percent;
-        batteryState = battery.state;
-      } catch {
-        batteryPercent = null;
-        batteryState = "Unknown";
-      }
-    }
-
-    return {
-      brand: "Endgame Gear",
-      name: meta.name,
-      batteryPercent,
-      batteryState,
-      // Placeholders until settings protocol is mapped (UI keeps controls disabled).
-      dpi: 800,
-      pollingRateHz: 1000,
-      supportedPollingRates: this.supportedPollingRates,
-      activeProfile: null,
-      connectionType: wireless ? "Wireless" : "Wired",
-      // Same style as other brands: short human text, no PID/debug.
-      connectionDetail: wireless ? "2.4 GHz receiver" : "USB",
-      debounceMs: null,
-      liftOffDistance: null,
-      firmware: [],
-    };
-  }
-
-  async setDpi(_dpi: number): Promise<number> {
-    throw this.settingsNotMappedError("CPI");
-  }
-
-  async setPollingRate(_rate: number): Promise<number> {
-    throw this.settingsNotMappedError("polling rate");
-  }
-
-  async setLiftOffDistance(_value: NonNullable<MouseStatus["liftOffDistance"]>): Promise<void> {
-    throw this.settingsNotMappedError("lift-off distance");
-  }
-
-  async setDebounceTime(_milliseconds: number): Promise<number> {
-    throw this.settingsNotMappedError("debounce");
-  }
-
-  private settingsNotMappedError(label: string): Error {
-    return new Error(
-      `OP1we ${label} is not reverse-engineered yet. `
-      + "Capture Endgame Gear WE Series software USB traffic to map writes.",
-    );
-  }
-
-  async close(): Promise<void> {
-    if (this.device.opened) await this.device.close();
-  }
-
-  // ---------------------------------------------------------------------------
-  // Battery — from report descriptors (hidapitester on PID 0x1962):
-  //   FF02/2: Feature report id 8, Report Count 16  (WebHID payload = 16 bytes, no report id)
-  //   FF04/2: Feature report id 6, Report Count 7
-  //   FF01:   Input report id 9 only — not feature
-  //   FF03:   Input report id 2 only — not feature
-  // Write on FF02/8 and FF04/6 succeeded in hidapitester; GetFeature failed when
-  // length omitted the +1 report-id byte (Windows). WebHID sizes the buffer itself.
-  // ---------------------------------------------------------------------------
-
-  private batteryFeatureTargets(): FeatureReportTarget[] {
-    const fromDescriptor = EggWeHidClient.listFeatureReports(this.device)
-      .filter((report) => report.payloadLength > 0);
-    // Descriptor-backed sizes only.
-    const preferred: FeatureReportTarget[] = [
-      { reportId: 0x08, payloadLength: 16 },
-      { reportId: 0x06, payloadLength: 7 },
-    ];
-    const merged = [...fromDescriptor, ...preferred];
-    const seen = new Set<string>();
-    return merged
-      .filter((target) => {
-        if (target.reportId === 0x08 && target.payloadLength !== 16) return false;
-        if (target.reportId === 0x06 && target.payloadLength !== 7) return false;
-        if (target.reportId !== 0x08 && target.reportId !== 0x06) return false;
-        const key = `${target.reportId}:${target.payloadLength}`;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      })
-      .sort((left, right) => left.reportId === 0x08 ? -1 : right.reportId === 0x08 ? 1 : 0);
-  }
-
-  private async readBatteryOnce(wireless: boolean): Promise<{
-    percent: number | null;
-    state: MouseStatus["batteryState"];
-  }> {
-    // WebHID data buffer excludes report id: 16 bytes for report 8, 7 for report 6.
-    const targets = this.batteryFeatureTargets();
-    const commands = wireless ? [0x04] : [0x04, 0xb4, 0x05, 0x01, 0x02, 0x03];
-    let lastRaw = "";
-
-    for (const target of targets) {
-      for (const command of commands) {
-        try {
-          const response = await this.featureExchange(target, command, wireless);
-          lastRaw = this.toHex(response);
-          const parsed = this.parseBattery(response, command, wireless);
-          if (parsed.percent !== null) {
-            console.info(
-              `[OpenMouse WE battery] ok id=0x${target.reportId.toString(16)} `
-              + `len=${target.payloadLength} cmd=0x${command.toString(16)} `
-              + `raw=[${lastRaw}] → ${parsed.percent}%`,
-            );
-            return this.batteryResult(parsed.percent, parsed.charging, wireless);
-          }
-          console.info(
-            `[OpenMouse WE battery] empty id=0x${target.reportId.toString(16)} `
-            + `cmd=0x${command.toString(16)} raw=[${lastRaw}]`,
-          );
-        } catch (error) {
-          lastRaw = error instanceof Error ? error.message : String(error);
-          console.info(
-            `[OpenMouse WE battery] fail id=0x${target.reportId.toString(16)} `
-            + `cmd=0x${command.toString(16)}: ${lastRaw}`,
-          );
-        }
-        if (wireless) break;
-      }
-      if (wireless) break;
-    }
-
-    console.info(`[OpenMouse WE battery] unread last=${lastRaw || "none"}`);
-    return { percent: null, state: "Unknown" };
-  }
-
-  private batteryResult(
-    percent: number,
-    charging: boolean,
-    wireless: boolean,
-  ): { percent: number; state: MouseStatus["batteryState"] } {
-    if (charging) return { percent, state: percent >= 99 ? "Full" : "Charging" };
-    return { percent, state: wireless ? "Discharging" : "Charging" };
-  }
-
-  /**
-   * WebHID: sendFeatureReport(reportId, data) — data does NOT include report id.
-   * Payload length must match Report Count from the descriptor (16 or 7).
-   */
-  private async featureExchange(
-    target: FeatureReportTarget,
-    command: number,
-    wireless: boolean,
-  ): Promise<Uint8Array> {
-    const packet = new Uint8Array(target.payloadLength);
-    packet[0] = command;
-    await this.device.sendFeatureReport(target.reportId, packet);
-    await this.delay(wireless ? 40 : 100);
-    // Second get helps some devices that ACK write then populate on next get.
-    let view = await this.device.receiveFeatureReport(target.reportId);
-    let bytes = this.copyView(view);
-    if (!wireless && this.isAllZero(bytes)) {
-      await this.delay(150);
-      view = await this.device.receiveFeatureReport(target.reportId);
-      bytes = this.copyView(view);
-    }
-    return bytes;
-  }
-
-  private parseBattery(
-    response: Uint8Array,
-    command: number,
-    wireless: boolean,
-  ): { percent: number | null; charging: boolean } {
-    if (response.byteLength === 0 || this.isAllZero(response)) {
-      return { percent: null, charging: !wireless };
-    }
-
-    // WebHID usually omits report id. If present, strip it.
-    let data = response;
-    if ((response[0] === 0x06 || response[0] === 0x08) && response.byteLength > 1) {
-      if (this.isAllZero(response.subarray(1))) {
-        return { percent: null, charging: !wireless };
-      }
-      data = response.subarray(1);
-    }
-
-    const chargeFlag = data[6];
-    const charging = chargeFlag === 1 || chargeFlag === 2
-      || (!wireless && chargeFlag !== undefined && chargeFlag !== 0);
-
-    const asPercent = (raw: number | undefined): number | null => {
-      if (raw === undefined || raw === command) return null;
-      if (raw <= 0 || raw > 100) return null;
-      if (raw === 100 && wireless && chargeFlag !== 1 && chargeFlag !== 2) return null;
-      return raw;
-    };
-
-    // Prefer byte 1 as "command data" after our cmd at [0], then classic @5.
-    for (const index of [1, 5, 4, 3, 2, 6, 7, 8, 9, 10]) {
-      const value = asPercent(data[index]);
-      if (value !== null && value < 100) {
-        return { percent: value, charging: charging || !wireless };
-      }
-    }
-
-    for (let index = 0; index < data.byteLength; index += 1) {
-      if (index === 0 && data[0] === command) continue;
-      const value = asPercent(data[index]);
-      if (value !== null && value < 100) {
-        return { percent: value, charging: charging || !wireless };
-      }
-    }
-
-    return { percent: null, charging: !wireless };
-  }
-
-  private isAllZero(bytes: Uint8Array): boolean {
-    for (let i = 0; i < bytes.byteLength; i += 1) {
-      if (bytes[i] !== 0) return false;
-    }
-    return true;
-  }
-
-  private toHex(bytes: Uint8Array): string {
-    return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
-  }
-
-  private copyView(view: DataView): Uint8Array {
-    return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
-  }
-
-  private delay(milliseconds: number): Promise<void> {
-    return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
-  }
 }
+
+// Re-export protocol helpers for tests / tooling that import the client module.
+export {
+  weBuildCmdPayload,
+  weBuildReadEepromPayload,
+  weBuildWriteEepromPayload,
+  weDecodeProfile,
+  wePackDpiStage,
+  weUnpackDpiStage,
+  wePackScalarPair,
+  weReportChecksum,
+  weCpiToByte,
+  weByteToCpi,
+  weParseReadEepromResponse,
+  weParseWriteEepromResponse,
+} from "./egg-we-protocol";

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -14,12 +14,17 @@ import type { MouseStatus } from "./mouse-types";
 
 const EGG_VENDOR_ID = 0x3367;
 
-const KNOWN_PRODUCTS = new Map<number, { name: string; wired: boolean }>([
-  [0x1962, { name: "Endgame Gear OP1we", wired: true }],
-  [0x1972, { name: "Endgame Gear OP1we", wired: true }],
-  [0x1970, { name: "Endgame Gear wireless receiver", wired: false }],
-  [0x1968, { name: "Endgame Gear XM2we", wired: true }],
-  [0x1982, { name: "Endgame Gear XM2w v2", wired: true }],
+/**
+ * Known PIDs are hints only. Cable vs dongle is detected from the product
+ * name ("Receiver" / "Dongle"). Display name is always the mouse, never the
+ * receiver as a separate product.
+ */
+const KNOWN_MOUSE_NAMES = new Map<number, string>([
+  [0x1962, "Endgame Gear OP1we"],
+  [0x1972, "Endgame Gear OP1we"],
+  [0x1970, "Endgame Gear OP1we"],
+  [0x1968, "Endgame Gear XM2we"],
+  [0x1982, "Endgame Gear XM2w"],
 ]);
 
 const EGG_8K_PRODUCT_IDS = new Set([0x1964, 0x1966, 0x1976, 0x1978]);
@@ -45,6 +50,8 @@ export class EggWeHidClient {
   private reportTarget: FeatureReportTarget | null = null;
   private lastBatteryRaw: string | null = null;
   private lastBatteryError: string | null = null;
+  private lastBatteryNote: string | null = null;
+  private lockedBattery: { command: number; byteIndex: number } | null = null;
   private useOutputReport = false;
   private inputWaiter: {
     reportId: number;
@@ -76,6 +83,12 @@ export class EggWeHidClient {
       || this.collectionTreeHasVendorUsage(device.collections);
   }
 
+  /** USB dongle / receiver interface (still talks to the mouse over 2.4 GHz). */
+  static isReceiverDevice(device: HIDDevice): boolean {
+    const name = (device.productName || "").toLowerCase();
+    return name.includes("receiver") || name.includes("dongle");
+  }
+
   static supportScore(device: HIDDevice): number {
     if (!this.isSupported(device)) return 0;
     let score = 1;
@@ -84,6 +97,8 @@ export class EggWeHidClient {
     if (features.some((report) => report.reportId === 0x08 && report.payloadLength >= 15)) score += 6;
     if (features.some((report) => report.reportId === 0x06)) score += 2;
     if (features.some((report) => report.reportId === 0xa1)) score += 1;
+    // Prefer the mouse USB interface over a bare receiver when both are present.
+    if (!this.isReceiverDevice(device)) score += 3;
     score += Math.min(features.length, 3);
     return score;
   }
@@ -179,16 +194,37 @@ export class EggWeHidClient {
     return [...POLLING_RATES];
   }
 
-  private productMeta(): { name: string; wired: boolean } {
-    const known = KNOWN_PRODUCTS.get(this.device.productId);
-    if (known) return known;
-    const productName = this.device.productName?.trim() || "Endgame Gear WE mouse";
+  private productMeta(): { name: string; wired: boolean; viaReceiver: boolean } {
+    const viaReceiver = EggWeHidClient.isReceiverDevice(this.device);
+    const knownName = KNOWN_MOUSE_NAMES.get(this.device.productId);
+    const productName = this.device.productName?.trim() || "";
     const lower = productName.toLowerCase();
-    const wired = !lower.includes("receiver") && !lower.includes("dongle");
-    if (lower.includes("op1we") || lower.includes("op1 we")) {
-      return { name: wired ? "Endgame Gear OP1we" : "Endgame Gear OP1we receiver", wired };
+
+    let name = knownName ?? (productName || "Endgame Gear WE mouse");
+    // Always show the mouse name — never list "Receiver" as the product.
+    if (viaReceiver) {
+      if (lower.includes("op1we") || lower.includes("op1 we") || knownName?.includes("OP1we")) {
+        name = "Endgame Gear OP1we";
+      } else if (lower.includes("xm2") || knownName?.includes("XM2")) {
+        name = knownName ?? "Endgame Gear XM2we";
+      } else {
+        const cleaned = productName
+          .replace(/\s*receiver\s*/ig, " ")
+          .replace(/\s*dongle\s*/ig, " ")
+          .replace(/\s+/g, " ")
+          .trim();
+        name = knownName ?? (cleaned || "Endgame Gear mouse");
+      }
+    } else if (lower.includes("op1we") || lower.includes("op1 we")) {
+      name = "Endgame Gear OP1we";
     }
-    return { name: productName, wired };
+
+    return {
+      name,
+      // Cable interface = wired/charging path; receiver = wireless path to the same mouse.
+      wired: !viaReceiver,
+      viaReceiver,
+    };
   }
 
   /** Prefer 16-byte report 0x08, then any largest feature report, then output reports. */
@@ -243,12 +279,14 @@ export class EggWeHidClient {
     const target = this.reportTarget ?? this.resolvePreferredTarget();
 
     const detailParts = [
-      meta.wired ? "Wired USB" : "2.4 GHz dongle",
+      meta.viaReceiver ? "2.4 GHz (via receiver)" : "Wired USB",
       `PID 0x${this.device.productId.toString(16).toUpperCase()}`,
       "WE protocol",
       `${this.useOutputReport ? "out" : "feat"} 0x${target.reportId.toString(16)}/${target.payloadLength}B`,
-      this.describeCollections(),
     ];
+    if (battery.percent !== null && this.lastBatteryNote) {
+      detailParts.push(this.lastBatteryNote);
+    }
     if (battery.percent === null) {
       detailParts.push(this.lastBatteryError ? `battery: ${this.lastBatteryError}` : "battery unread");
       if (this.lastBatteryRaw) detailParts.push(`raw ${this.lastBatteryRaw}`);
@@ -333,16 +371,21 @@ export class EggWeHidClient {
             this.reportTarget = target;
             this.useOutputReport = viaOutput;
             const response = await this.query(command, { wake: command === 0xb4 || command === 0x04 });
-            const parsed = this.parseBatteryResponse(response);
+            const parsed = this.parseBatteryResponse(response, command);
             const mode = viaOutput ? "out" : "feat";
             const line =
               `${mode} 0x${target.reportId.toString(16)}/${target.payloadLength}B `
               + `cmd 0x${command.toString(16).padStart(2, "0")} → ${response.byteLength}B `
-              + `[${this.toHex(response, 16)}] parse=${parsed.percent ?? "null"}`;
+              + `[${this.toHex(response, 16)}] parse=${parsed.percent ?? "null"}`
+              + (parsed.note ? ` (${parsed.note})` : "");
             lines.push(line);
             if (parsed.percent !== null && !found) {
               found = { percent: parsed.percent, line };
               this.lastBatteryRaw = this.toHex(response, 16);
+              this.lastBatteryNote = parsed.note;
+              if (parsed.byteIndex !== undefined) {
+                this.lockedBattery = { command, byteIndex: parsed.byteIndex };
+              }
               // Keep working transport locked in.
               this.reportTarget = target;
               this.useOutputReport = viaOutput;
@@ -393,21 +436,31 @@ export class EggWeHidClient {
   }> {
     this.lastBatteryError = null;
     this.lastBatteryRaw = null;
+    this.lastBatteryNote = null;
+    const meta = this.productMeta();
 
     // Quick path: preferred report + common battery commands.
     const target = this.resolvePreferredTarget();
     this.reportTarget = target;
     this.useOutputReport = false;
 
-    for (const command of [0x04, 0xb4, 0x05, 0x0b]) {
+    const commands = this.lockedBattery
+      ? [this.lockedBattery.command, 0x04, 0xb4, 0x05, 0x0b]
+      : [0x04, 0xb4, 0x05, 0x0b];
+
+    for (const command of commands) {
       try {
         const response = await this.query(command, { wake: true });
         this.lastBatteryRaw = this.toHex(response, 16);
-        const parsed = this.parseBatteryResponse(response);
+        const parsed = this.parseBatteryResponse(response, command);
         if (parsed.percent !== null) {
+          this.lastBatteryNote = parsed.note;
+          if (parsed.byteIndex !== undefined) {
+            this.lockedBattery = { command, byteIndex: parsed.byteIndex };
+          }
           return {
             percent: parsed.percent,
-            state: this.productMeta().wired ? "Charging" : "Discharging",
+            state: this.decodeChargeState(response, meta.wired, parsed.percent),
           };
         }
       } catch (error) {
@@ -424,7 +477,7 @@ export class EggWeHidClient {
         if (match) {
           return {
             percent: Number(match[1]),
-            state: this.productMeta().wired ? "Charging" : "Discharging",
+            state: this.decodeChargeState(null, meta.wired, Number(match[1])),
           };
         }
       }
@@ -436,32 +489,91 @@ export class EggWeHidClient {
     return { percent: null, state: "Unknown" };
   }
 
-  private parseBatteryResponse(response: Uint8Array): { percent: number | null } {
-    if (response.byteLength === 0) return { percent: null };
+  private decodeChargeState(
+    response: Uint8Array | null,
+    wired: boolean,
+    percent: number,
+  ): MouseStatus["batteryState"] {
+    // Pulsar-style charge flag at index 6.
+    if (response && response[6] === 1) return "Charging";
+    if (response && response[6] === 0 && !wired) return "Discharging";
+    if (wired) return percent >= 99 ? "Full" : "Charging";
+    return "Discharging";
+  }
 
-    // Documented Pulsar-style: command echo + status + percent around index 5.
-    const pulsarStyle = response[5];
-    if (pulsarStyle !== undefined && pulsarStyle <= 100 && response[0] === 0x04) {
-      return { percent: pulsarStyle };
-    }
+  /**
+   * Parse battery carefully — early heuristics grabbed the first 1–100 byte and
+   * often mis-read status/flags (e.g. sticky 100% on the receiver, or ~52 vs OEM 70).
+   */
+  private parseBatteryResponse(
+    response: Uint8Array,
+    command: number,
+  ): { percent: number | null; byteIndex?: number; note: string | null } {
+    if (response.byteLength === 0) return { percent: null, note: null };
 
-    // Older WE docs (if report id still present): status @1, percent @16 — rare on 16B reports.
-    if (response.byteLength > 16) {
-      const status = response[1];
-      const percent = response[16];
-      if ((status === 0x01 || status === 0x08) && percent !== undefined && percent <= 100) {
-        return { percent };
+    // Locked offset from a previous good read on this session.
+    if (this.lockedBattery && this.lockedBattery.command === command) {
+      const value = response[this.lockedBattery.byteIndex];
+      const scaled = this.normalizePercent(value);
+      if (scaled !== null) {
+        return {
+          percent: scaled,
+          byteIndex: this.lockedBattery.byteIndex,
+          note: `batt@${this.lockedBattery.byteIndex} cmd 0x${command.toString(16)}`,
+        };
       }
     }
 
-    // Heuristic: prefer payload bytes (skip command echo at [0]).
-    const candidates = [5, 4, 3, 2, 6, 7, 1, 8, 9, 10, 11, 12, 13, 14, 15]
-      .map((index) => response[index])
-      .filter((value): value is number => value !== undefined);
-    for (const value of candidates) {
-      if (value >= 1 && value <= 100) return { percent: value };
+    // Pulsar-family layout (cmd 0x04): percent @5, charge @6.
+    if (command === 0x04 || response[0] === 0x04) {
+      const at5 = this.normalizePercent(response[5]);
+      if (at5 !== null) {
+        return { percent: at5, byteIndex: 5, note: "batt@5 (0x04 layout)" };
+      }
     }
-    return { percent: null };
+
+    // Score candidate payload indices — skip command echo [0] and checksum tail.
+    type Candidate = { index: number; percent: number; score: number };
+    const candidates: Candidate[] = [];
+    const last = Math.max(1, response.byteLength - 1);
+    for (let index = 1; index < last; index += 1) {
+      const raw = response[index];
+      const percent = this.normalizePercent(raw);
+      if (percent === null) continue;
+
+      let score = 10;
+      // Prefer CompX/Pulsar payload region.
+      if (index === 5) score += 8;
+      if (index === 4 || index === 3) score += 4;
+      if (index >= 2 && index <= 6) score += 2;
+      // 100% is often a status flag, not a real reading — deprioritize.
+      if (percent === 100) score -= 12;
+      if (percent === 0) score -= 6;
+      // Extremely common false positives.
+      if (raw === command) score -= 20;
+      if (raw === 0x08 || raw === 0x06) score -= 4;
+
+      candidates.push({ index, percent, score });
+    }
+
+    candidates.sort((left, right) => right.score - left.score || left.index - right.index);
+    const best = candidates[0];
+    if (!best || best.score < 8) return { percent: null, note: null };
+
+    return {
+      percent: best.percent,
+      byteIndex: best.index,
+      note: `batt@${best.index} raw 0x${(response[best.index] ?? 0).toString(16)}`,
+    };
+  }
+
+  /** Map raw report bytes to 1–100%. Supports plain % and 0–20×5 style. */
+  private normalizePercent(value: number | undefined): number | null {
+    if (value === undefined) return null;
+    if (value >= 1 && value <= 100) return value;
+    // Some CompX stacks report 0–20 in 5% steps.
+    if (value >= 1 && value <= 20) return value * 5;
+    return null;
   }
 
   private query(command: number, options: { wake?: boolean } = {}): Promise<Uint8Array> {

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -15,11 +15,11 @@ import type { MouseStatus } from "./mouse-types";
 const EGG_VENDOR_ID = 0x3367;
 
 /**
- * Known PIDs are hints only. Cable vs dongle is detected from the product
- * name ("Receiver" / "Dongle"). Display name is always the mouse, never the
- * receiver as a separate product.
+ * Known PIDs are hints only. Display name is always the mouse.
+ * Observed OP1we: cable PID 0x1962, dongle PID 0x1961.
  */
 const KNOWN_MOUSE_NAMES = new Map<number, string>([
+  [0x1961, "Endgame Gear OP1we"],
   [0x1962, "Endgame Gear OP1we"],
   [0x1972, "Endgame Gear OP1we"],
   [0x1970, "Endgame Gear OP1we"],
@@ -27,15 +27,17 @@ const KNOWN_MOUSE_NAMES = new Map<number, string>([
   [0x1982, "Endgame Gear XM2w"],
 ]);
 
+/** Dongle / receiver product IDs (HID path to the mouse over 2.4 GHz). */
+const RECEIVER_PIDS = new Set([0x1961, 0x1970]);
+
 const EGG_8K_PRODUCT_IDS = new Set([0x1964, 0x1966, 0x1976, 0x1978]);
 
-/** Commands worth trying for battery / identity on CompX-style 16-byte reports. */
+/** Lightweight battery command only — never spam the wireless link. */
+const BATTERY_COMMAND = 0x04;
+
+/** Full probe list — only used by explicit probeBattery(), never on a timer. */
 const BATTERY_COMMAND_CANDIDATES = [
-  0x04, // Pulsar-family battery
-  0xb4, // older EGG WE battery docs
-  0x05, 0x06, 0x07, 0x08, 0x0a, 0x0b, 0x0c, 0x0e,
-  0x10, 0x11, 0x12, 0x14, 0x1d, 0x20, 0x2b,
-  0x01, 0x02, 0x03,
+  0x04, 0xb4, 0x05, 0x0b, 0x0e, 0x01, 0x02, 0x03,
 ] as const;
 
 const POLLING_RATES = [125, 250, 500, 1000] as const;
@@ -83,10 +85,19 @@ export class EggWeHidClient {
       || this.collectionTreeHasVendorUsage(device.collections);
   }
 
-  /** USB dongle / receiver interface (still talks to the mouse over 2.4 GHz). */
+  /**
+   * USB dongle / receiver interface (wireless path to the mouse).
+   * Prefer product-name match; also known dongle PIDs (0x1961, 0x1970).
+   */
   static isReceiverDevice(device: HIDDevice): boolean {
+    if (RECEIVER_PIDS.has(device.productId)) return true;
     const name = (device.productName || "").toLowerCase();
     return name.includes("receiver") || name.includes("dongle");
+  }
+
+  /** True when HID traffic goes over the 2.4 GHz dongle (easy to wedge the mouse). */
+  isWirelessPath(): boolean {
+    return EggWeHidClient.isReceiverDevice(this.device);
   }
 
   static supportScore(device: HIDDevice): number {
@@ -200,28 +211,17 @@ export class EggWeHidClient {
     const productName = this.device.productName?.trim() || "";
     const lower = productName.toLowerCase();
 
-    let name = knownName ?? (productName || "Endgame Gear WE mouse");
-    // Always show the mouse name — never list "Receiver" as the product.
-    if (viaReceiver) {
-      if (lower.includes("op1we") || lower.includes("op1 we") || knownName?.includes("OP1we")) {
-        name = "Endgame Gear OP1we";
-      } else if (lower.includes("xm2") || knownName?.includes("XM2")) {
-        name = knownName ?? "Endgame Gear XM2we";
-      } else {
-        const cleaned = productName
-          .replace(/\s*receiver\s*/ig, " ")
-          .replace(/\s*dongle\s*/ig, " ")
-          .replace(/\s+/g, " ")
-          .trim();
-        name = knownName ?? (cleaned || "Endgame Gear mouse");
-      }
-    } else if (lower.includes("op1we") || lower.includes("op1 we")) {
+    // Always the mouse product name — never "Receiver" / truncated "WE Series Gaming".
+    let name = knownName ?? "Endgame Gear WE mouse";
+    if (lower.includes("op1we") || lower.includes("op1 we") || knownName?.includes("OP1we")
+      || lower.includes("we series") || this.device.productId === 0x1961 || this.device.productId === 0x1962) {
       name = "Endgame Gear OP1we";
+    } else if (lower.includes("xm2") || knownName?.includes("XM2")) {
+      name = knownName ?? "Endgame Gear XM2we";
     }
 
     return {
       name,
-      // Cable interface = wired/charging path; receiver = wireless path to the same mouse.
       wired: !viaReceiver,
       viaReceiver,
     };
@@ -439,53 +439,33 @@ export class EggWeHidClient {
     this.lastBatteryNote = null;
     const meta = this.productMeta();
 
-    // Quick path: preferred report + common battery commands.
+    // CRITICAL: one feature transaction only. Multi-command probes and long wake
+    // delays wedge the OP1we over the dongle (cursor freeze).
     const target = this.resolvePreferredTarget();
     this.reportTarget = target;
     this.useOutputReport = false;
+    const command = this.lockedBattery?.command ?? BATTERY_COMMAND;
 
-    const commands = this.lockedBattery
-      ? [this.lockedBattery.command, 0x04, 0xb4, 0x05, 0x0b]
-      : [0x04, 0xb4, 0x05, 0x0b];
-
-    for (const command of commands) {
-      try {
-        const response = await this.query(command, { wake: true });
-        this.lastBatteryRaw = this.toHex(response, 16);
-        const parsed = this.parseBatteryResponse(response, command);
-        if (parsed.percent !== null) {
-          this.lastBatteryNote = parsed.note;
-          if (parsed.byteIndex !== undefined) {
-            this.lockedBattery = { command, byteIndex: parsed.byteIndex };
-          }
-          return {
-            percent: parsed.percent,
-            state: this.decodeChargeState(response, meta.wired, parsed.percent),
-          };
-        }
-      } catch (error) {
-        this.lastBatteryError = error instanceof Error ? error.message : String(error);
-      }
-    }
-
-    // Full probe across real report ids (0x06 / 0x08).
     try {
-      const report = await this.probeBattery();
-      const selected = report.split("\n").find((line) => line.startsWith("SELECTED:"));
-      if (selected && this.lastBatteryRaw) {
-        const match = /parse=(\d+)/.exec(selected);
-        if (match) {
-          return {
-            percent: Number(match[1]),
-            state: this.decodeChargeState(null, meta.wired, Number(match[1])),
-          };
+      const response = await this.query(command, { wake: false });
+      this.lastBatteryRaw = this.toHex(response, 16);
+      const parsed = this.parseBatteryResponse(response, command);
+      if (parsed.percent !== null) {
+        this.lastBatteryNote = `${parsed.note ?? "batt"} · approx`;
+        if (parsed.byteIndex !== undefined) {
+          this.lockedBattery = { command, byteIndex: parsed.byteIndex };
         }
+        return {
+          percent: parsed.percent,
+          state: this.decodeChargeState(response, meta.wired, parsed.percent),
+        };
       }
-      this.lastBatteryError = "no battery byte in responses (see console probe)";
+      this.lastBatteryError = `no percent in [${this.lastBatteryRaw}]`;
     } catch (error) {
       this.lastBatteryError = error instanceof Error ? error.message : String(error);
     }
 
+    // Do NOT fall through into probeBattery() here — that floods the link.
     return { percent: null, state: "Unknown" };
   }
 
@@ -502,8 +482,9 @@ export class EggWeHidClient {
   }
 
   /**
-   * Parse battery carefully — early heuristics grabbed the first 1–100 byte and
-   * often mis-read status/flags (e.g. sticky 100% on the receiver, or ~52 vs OEM 70).
+   * Parse battery carefully. 7-byte reports only have indices 0–6.
+   * 100% is treated as a flag unless charge state also looks full.
+   * Values are approximate until OEM layout is captured.
    */
   private parseBatteryResponse(
     response: Uint8Array,
@@ -511,54 +492,59 @@ export class EggWeHidClient {
   ): { percent: number | null; byteIndex?: number; note: string | null } {
     if (response.byteLength === 0) return { percent: null, note: null };
 
+    const maxIndex = response.byteLength - 1;
+
     // Locked offset from a previous good read on this session.
     if (this.lockedBattery && this.lockedBattery.command === command) {
-      const value = response[this.lockedBattery.byteIndex];
-      const scaled = this.normalizePercent(value);
-      if (scaled !== null) {
-        return {
-          percent: scaled,
-          byteIndex: this.lockedBattery.byteIndex,
-          note: `batt@${this.lockedBattery.byteIndex} cmd 0x${command.toString(16)}`,
-        };
+      const index = this.lockedBattery.byteIndex;
+      if (index <= maxIndex) {
+        const scaled = this.normalizePercent(response[index], response, index);
+        if (scaled !== null) {
+          return {
+            percent: scaled,
+            byteIndex: index,
+            note: `batt@${index} cmd 0x${command.toString(16)}`,
+          };
+        }
       }
     }
 
-    // Pulsar-family layout (cmd 0x04): percent @5, charge @6.
-    if (command === 0x04 || response[0] === 0x04) {
-      const at5 = this.normalizePercent(response[5]);
+    // Preferred: cmd 0x04 layout — percent at [5] when present and not a 100 flag.
+    if ((command === 0x04 || response[0] === 0x04) && 5 <= maxIndex) {
+      const at5 = this.normalizePercent(response[5], response, 5);
       if (at5 !== null) {
-        return { percent: at5, byteIndex: 5, note: "batt@5 (0x04 layout)" };
+        return { percent: at5, byteIndex: 5, note: "batt@5 cmd 0x4" };
       }
     }
 
-    // Score candidate payload indices — skip command echo [0] and checksum tail.
     type Candidate = { index: number; percent: number; score: number };
     const candidates: Candidate[] = [];
-    const last = Math.max(1, response.byteLength - 1);
-    for (let index = 1; index < last; index += 1) {
+    // Never read past the report; skip [0] command echo.
+    for (let index = 1; index <= maxIndex; index += 1) {
+      // Last byte on 16B frames is often checksum — skip.
+      if (response.byteLength >= 16 && index === maxIndex) continue;
       const raw = response[index];
-      const percent = this.normalizePercent(raw);
+      const percent = this.normalizePercent(raw, response, index);
       if (percent === null) continue;
 
       let score = 10;
-      // Prefer CompX/Pulsar payload region.
-      if (index === 5) score += 8;
-      if (index === 4 || index === 3) score += 4;
-      if (index >= 2 && index <= 6) score += 2;
-      // 100% is often a status flag, not a real reading — deprioritize.
-      if (percent === 100) score -= 12;
-      if (percent === 0) score -= 6;
-      // Extremely common false positives.
+      if (index === 5) score += 10;
+      if (index === 4 || index === 3) score += 3;
+      if (index === 6 && response.byteLength <= 8) score += 2;
+      // Sticky 100% on dongle is almost always wrong.
+      if (percent === 100) score -= 20;
+      if (percent === 0) score -= 8;
       if (raw === command) score -= 20;
-      if (raw === 0x08 || raw === 0x06) score -= 4;
+      if (raw === 0x08 || raw === 0x06) score -= 6;
+      // Index 7 on a 7-byte descriptor means we overran — heavily penalize if length is 7–8.
+      if (index >= response.byteLength) score -= 50;
 
       candidates.push({ index, percent, score });
     }
 
     candidates.sort((left, right) => right.score - left.score || left.index - right.index);
     const best = candidates[0];
-    if (!best || best.score < 8) return { percent: null, note: null };
+    if (!best || best.score < 10) return { percent: null, note: null };
 
     return {
       percent: best.percent,
@@ -567,12 +553,19 @@ export class EggWeHidClient {
     };
   }
 
-  /** Map raw report bytes to 1–100%. Supports plain % and 0–20×5 style. */
-  private normalizePercent(value: number | undefined): number | null {
+  private normalizePercent(
+    value: number | undefined,
+    response: Uint8Array,
+    _index: number,
+  ): number | null {
     if (value === undefined) return null;
-    if (value >= 1 && value <= 100) return value;
-    // Some CompX stacks report 0–20 in 5% steps.
-    if (value >= 1 && value <= 20) return value * 5;
+    // Reject 100% unless a charge/full flag suggests it is real.
+    if (value === 100) {
+      const chargeFlag = response[6];
+      if (chargeFlag === 1 || chargeFlag === 2) return 100;
+      return null;
+    }
+    if (value >= 1 && value <= 99) return value;
     return null;
   }
 
@@ -582,19 +575,20 @@ export class EggWeHidClient {
       const target = this.reportTarget ?? this.resolvePreferredTarget();
       const packet = new Uint8Array(target.payloadLength);
       packet[0] = command;
-      // CompX/Pulsar-style: length field + checksum on 16-byte reports.
+      // CompX/Pulsar-style: length field + checksum on 16-byte reports only.
       if (target.payloadLength >= 16) {
         packet[4] = 0;
         packet[15] = this.simpleChecksum(packet, target.reportId);
       }
 
+      // Keep wireless dongle traffic minimal — long waits + multi-packet sequences freeze the mouse.
+      const wireless = this.isWirelessPath();
       if (this.useOutputReport) {
-        return await this.exchangeOutput(target.reportId, packet, options.wake ? 400 : 80);
+        return await this.exchangeOutput(target.reportId, packet, wireless ? 30 : (options.wake ? 200 : 50));
       }
 
       await this.sendFeature(target, packet);
-      if (options.wake) await this.delay(200);
-      else await this.delay(40);
+      await this.delay(wireless ? 25 : (options.wake ? 120 : 30));
       return await this.receiveFeature(target.reportId);
     };
     const next = this.commandQueue.then(run, run);

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -18,7 +18,7 @@ import {
   weParseWriteEepromResponse,
   weEncodeReportRate,
   weIsValidPollingRate,
-  wePatchAllActiveDpi,
+  wePatchActiveDpi,
   WE_POLLING_RATES,
   type WeLod,
   type WeProfile,
@@ -104,15 +104,8 @@ export class EggWeHidClient {
 
   static isSupported(device: HIDDevice): boolean {
     if (device.vendorId !== EGG_VENDOR_ID) return false;
-    if (EGG_8K_PRODUCT_IDS.has(device.productId)) return false;
-    if (OP1WE_CABLE_PIDS.has(device.productId) || OP1WE_RECEIVER_PIDS.has(device.productId)) {
-      return true;
-    }
-    if (OTHER_WE_MOUSE_PIDS.has(device.productId)) return true;
-    return this.listFeatureReports(device).length > 0
-      || this.listOutputReports(device).length > 0
-      || this.listInputReports(device).length > 0
-      || this.collectionTreeHasVendorUsage(device.collections);
+    return !EGG_8K_PRODUCT_IDS.has(device.productId)
+      && (OP1WE_CABLE_PIDS.has(device.productId) || OP1WE_RECEIVER_PIDS.has(device.productId));
   }
 
   static isReceiverDevice(device: HIDDevice): boolean {
@@ -269,7 +262,7 @@ export class EggWeHidClient {
       firmware: [],
       ui: {
         family: "egg-we",
-        settingsReady: EggWeHidClient.settingsMapped,
+        settingsReady: EggWeHidClient.settingsMapped && profile !== null,
         hideLodLow: true,
         hideUnsupportedPollingRates: true,
         hideProcessingCard: true,
@@ -287,12 +280,9 @@ export class EggWeHidClient {
     await this.open();
     const mem = await this.readProfileMemory();
     const profile = weDecodeProfile(mem);
-    wePatchAllActiveDpi(mem, dpi, profile.dpiStageCount);
-    // Write each active stage chunk (4 bytes) via WriteEEPROM.
-    for (let i = 0; i < profile.dpiStageCount; i += 1) {
-      const off = WE_OFF.dpiStages + i * WE_OFF.dpiStageBytes;
-      await this.writeEeprom(off, [...mem.subarray(off, off + 4)]);
-    }
+    wePatchActiveDpi(mem, dpi, profile.activeDpiLevel);
+    const off = WE_OFF.dpiStages + profile.activeDpiLevel * WE_OFF.dpiStageBytes;
+    await this.writeEeprom(off, [...mem.subarray(off, off + WE_OFF.dpiStageBytes)]);
     const confirmed = weDecodeProfile(await this.readProfileMemory());
     if (confirmed.dpi !== dpi) {
       throw new Error(`The mouse kept ${confirmed.dpi} CPI instead of ${dpi} CPI.`);
@@ -515,7 +505,19 @@ export class EggWeHidClient {
       : (() => { throw new Error("WE payload must be 16 bytes."); })();
     // Ensure ArrayBuffer-backed view for WebHID typings.
     const copy = new Uint8Array(body);
-    await channels.cmd.sendFeatureReport(WE_REPORT_ID, copy.buffer);
+    try {
+      await channels.cmd.sendFeatureReport(WE_REPORT_ID, copy.buffer);
+    } catch (error) {
+      const waiter = this.responseWaiter as {
+        reject: (reason: Error) => void;
+        timer: number;
+      } | null;
+      if (waiter) {
+        window.clearTimeout(waiter.timer);
+        this.responseWaiter = null;
+        waiter.reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
     return responsePromise;
   }
 
@@ -555,10 +557,6 @@ export class EggWeHidClient {
 
   private static listFeatureReports(device: HIDDevice): ReportTarget[] {
     return this.listReports(device, "featureReports");
-  }
-
-  private static listOutputReports(device: HIDDevice): ReportTarget[] {
-    return this.listReports(device, "outputReports");
   }
 
   private static listInputReports(device: HIDDevice): ReportTarget[] {
@@ -613,4 +611,5 @@ export {
   weByteToCpi,
   weParseReadEepromResponse,
   weParseWriteEepromResponse,
+  wePatchActiveDpi,
 } from "./egg-we-protocol";

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -1,17 +1,18 @@
 import type { MouseStatus } from "./mouse-types";
 
 /**
- * Endgame Gear WE-series wireless mice (OP1we, shared dongle, etc.).
+ * Endgame Gear WE-series (OP1we / dongle / related PIDs).
  *
- * Same structural style as egg-op1-hid.ts, but a different CompX/WE command
- * set — not the wired OP1 8K 1041-byte config blob.
+ * Verified: battery via feature report 0xa1, command 0xb4 (public RE).
+ * Not verified: CPI / polling / LOD / debounce command IDs — those need a
+ * USB capture of official WE Series software. Writes for unmapped settings
+ * are intentionally disabled so the UI does not pretend defaults are live.
  *
- * Transport notes (Windows WebHID is strict):
- * - Verified battery protocol uses feature report 0xa1 for Set + Get.
- * - sendFeatureReport data must match the HID descriptor byte length exactly
- *   (report id is separate; do not include it in the buffer).
- * - Native HidD_SetFeature buffers include report id as byte 0; WebHID
- *   responses do not, so battery % is at index 15 (not 16).
+ * WebHID notes:
+ * - sendFeatureReport(reportId, data) — data must NOT include report id
+ * - length must match the HID feature report payload (often 63 for a 64-byte
+ *   Windows buffer that includes report id as byte 0)
+ * - receiveFeatureReport usually omits report id; Windows docs include it
  */
 
 const EGG_VENDOR_ID = 0x3367;
@@ -23,38 +24,33 @@ const KNOWN_PRODUCTS = new Map<number, { name: string; wired: boolean }>([
   [0x1982, { name: "Endgame Gear XM2w v2", wired: true }],
 ]);
 
-/** Wired OP1 8K / XM2 8K PIDs — owned by egg-op1-hid, never claim here. */
 const EGG_8K_PRODUCT_IDS = new Set([0x1964, 0x1966, 0x1976, 0x1978]);
 
-/** Prefer the verified WE report; fall back if a firmware only exposes 0xa0. */
-const PREFERRED_REPORT_IDS = [0xa1, 0xa0] as const;
-
-const COMMAND = {
-  battery: 0xb4,
-  status: 0xb0,
-  dpi: 0xb1,
-  polling: 0xb2,
-  lod: 0xb3,
-  debounce: 0xb5,
-  firmware: 0xb6,
-} as const;
+/** Verified WE battery transport (Windows HidD uses report id + 63 payload). */
+const WE_REPORT_ID = 0xa1;
+const WE_PAYLOAD_LENGTH = 63;
+const BATTERY_COMMAND = 0xb4;
 
 const POLLING_RATES = [125, 250, 500, 1000] as const;
-const DEFAULT_DPI = 800;
-const DEFAULT_POLLING = 1000;
-const DEFAULT_DEBOUNCE = 3;
 
 interface FeatureReportTarget {
   reportId: number;
-  /** Payload length for sendFeatureReport (excludes report id). */
   payloadLength: number;
 }
 
 export class EggWeHidClient {
   private commandQueue: Promise<unknown> = Promise.resolve();
   private reportTarget: FeatureReportTarget | null = null;
-  /** True when receiveFeatureReport includes the report id as byte 0. */
+  private lastBatteryRaw: string | null = null;
+  private lastBatteryError: string | null = null;
+  /** True when receiveFeatureReport includes report id as byte 0. */
   private responseIncludesReportId: boolean | null = null;
+
+  /**
+   * Settings command map is not reverse-engineered yet. Keep false until a
+   * capture confirms read/write pairs for CPI, polling, LOD, and debounce.
+   */
+  static readonly settingsMapped = false;
 
   constructor(readonly device: HIDDevice) {}
 
@@ -67,14 +63,14 @@ export class EggWeHidClient {
   static supportScore(device: HIDDevice): number {
     if (!this.isSupported(device)) return 0;
     let score = 1;
-    if (this.findFeatureReport(device, 0xa1)) score += 4;
-    if (this.findFeatureReport(device, 0xa0)) score += 2;
+    if (this.findFeatureReport(device, WE_REPORT_ID)) score += 5;
+    if (this.findFeatureReport(device, 0xa0)) score += 1;
     if (this.collectionTreeHasVendorUsage(device.collections)) score += 1;
     return score;
   }
 
   private static hasVendorConfigInterface(device: HIDDevice): boolean {
-    if (this.findFeatureReport(device, 0xa1) || this.findFeatureReport(device, 0xa0)) return true;
+    if (this.findFeatureReport(device, WE_REPORT_ID) || this.findFeatureReport(device, 0xa0)) return true;
     if (this.collectionTreeHasVendorUsage(device.collections)) return true;
     return this.listFeatureReports(device).length > 0;
   }
@@ -84,10 +80,10 @@ export class EggWeHidClient {
     const visit = (collections: readonly HIDCollectionInfo[]): void => {
       for (const collection of collections) {
         for (const report of collection.featureReports) {
-          const payloadLength = this.featureReportPayloadLength(report);
-          if (payloadLength > 0) {
-            found.push({ reportId: report.reportId, payloadLength });
-          }
+          found.push({
+            reportId: report.reportId,
+            payloadLength: this.featureReportPayloadLength(report),
+          });
         }
         visit(collection.children);
       }
@@ -105,16 +101,13 @@ export class EggWeHidClient {
     for (const item of report.items ?? []) {
       bits += item.reportSize * item.reportCount;
     }
-    // Some descriptors leave items empty; fall back to common WE size (64 total with id → 63 payload).
-    if (bits === 0) return 63;
+    if (bits === 0) return WE_PAYLOAD_LENGTH;
     return Math.ceil(bits / 8);
   }
 
   private static collectionTreeHasVendorUsage(collections: readonly HIDCollectionInfo[]): boolean {
-    return collections.some((collection) => {
-      if (collection.usagePage >= 0xff00) return true;
-      return this.collectionTreeHasVendorUsage(collection.children);
-    });
+    return collections.some((collection) =>
+      collection.usagePage >= 0xff00 || this.collectionTreeHasVendorUsage(collection.children));
   }
 
   async open(): Promise<void> {
@@ -123,11 +116,12 @@ export class EggWeHidClient {
   }
 
   describeCollections(): string {
-    return EggWeHidClient.listFeatureReports(this.device).map((report) =>
-      `id 0x${report.reportId.toString(16)} · ${report.payloadLength} bytes`).join(" | ")
-      || this.device.collections.map((collection) =>
-        `usage 0x${collection.usagePage.toString(16)}:0x${collection.usage.toString(16)}`).join(" | ")
-      || "No HID collections reported";
+    const reports = EggWeHidClient.listFeatureReports(this.device);
+    if (reports.length === 0) {
+      return `fallback report 0x${WE_REPORT_ID.toString(16)}/${WE_PAYLOAD_LENGTH}B`;
+    }
+    return reports.map((report) =>
+      `id 0x${report.reportId.toString(16)}/${report.payloadLength}B`).join(" · ");
   }
 
   getDpiOptions(): number[] {
@@ -153,123 +147,135 @@ export class EggWeHidClient {
   }
 
   private resolveReportTarget(): FeatureReportTarget {
-    for (const reportId of PREFERRED_REPORT_IDS) {
-      const match = EggWeHidClient.findFeatureReport(this.device, reportId);
-      if (match) return match;
+    const preferred = EggWeHidClient.findFeatureReport(this.device, WE_REPORT_ID);
+    if (preferred) {
+      return {
+        reportId: preferred.reportId,
+        // Prefer descriptor length, but never invent a weird size for battery.
+        payloadLength: preferred.payloadLength > 0 ? preferred.payloadLength : WE_PAYLOAD_LENGTH,
+      };
     }
-    const any = EggWeHidClient.listFeatureReports(this.device)[0];
-    if (any) return any;
-    // Descriptor empty (some Windows builds) — use verified WE defaults.
-    return { reportId: 0xa1, payloadLength: 63 };
+    return { reportId: WE_REPORT_ID, payloadLength: WE_PAYLOAD_LENGTH };
   }
 
   async readStatus(): Promise<MouseStatus> {
     const meta = this.productMeta();
     await this.open();
-
-    // Battery is the only fully verified command. Soft-fail so a transport
-    // mismatch still shows the device while we surface a clear banner.
-    const battery = await this.readBattery().catch(() => ({
-      percent: null as number | null,
-      state: "Unknown" as const,
-    }));
-    const state = await this.readDeviceState().catch(() => null);
-    const firmware = await this.readFirmware().catch(() => null);
-
-    const dpi = state?.dpi ?? DEFAULT_DPI;
-    const pollingRateHz = state?.pollingRateHz ?? DEFAULT_POLLING;
-    const debounceMs = state?.debounceMs ?? DEFAULT_DEBOUNCE;
-    const liftOffDistance = state?.liftOffDistance ?? "Medium";
-
+    const battery = await this.readBattery();
     const target = this.reportTarget ?? this.resolveReportTarget();
+
+    const detailParts = [
+      meta.wired ? "Wired USB" : "2.4 GHz dongle",
+      `PID 0x${this.device.productId.toString(16).toUpperCase()}`,
+      "WE protocol",
+      `report 0x${target.reportId.toString(16)}/${target.payloadLength}B`,
+    ];
+    if (battery.percent === null) {
+      detailParts.push(this.lastBatteryError
+        ? `battery fail: ${this.lastBatteryError}`
+        : "battery unread");
+      if (this.lastBatteryRaw) detailParts.push(`raw ${this.lastBatteryRaw}`);
+    }
+    detailParts.push("settings map pending RE");
+
     return {
       brand: "Endgame Gear",
       name: meta.name,
       batteryPercent: battery.percent,
       batteryState: battery.state,
-      dpi: this.clampDpi(dpi),
-      pollingRateHz: POLLING_RATES.includes(pollingRateHz as (typeof POLLING_RATES)[number])
-        ? pollingRateHz
-        : DEFAULT_POLLING,
+      // Placeholders — not live device values until settings are reverse-engineered.
+      dpi: 800,
+      pollingRateHz: 1000,
       supportedPollingRates: this.supportedPollingRates,
       activeProfile: null,
       connectionType: meta.wired ? "Wired" : "Wireless",
-      connectionDetail:
-        `${meta.wired ? "Wired USB" : "2.4 GHz dongle"} · PID 0x${this.device.productId.toString(16).toUpperCase()}`
-        + ` · WE · report 0x${target.reportId.toString(16)}/${target.payloadLength}B`
-        + (battery.percent === null ? " · battery unread" : ""),
-      debounceMs,
-      liftOffDistance,
-      firmware: firmware
-        ? [`Firmware ${firmware}`]
-        : state?.firmware
-          ? [`Firmware ${state.firmware}`]
-          : ["Firmware unavailable"],
+      connectionDetail: detailParts.join(" · "),
+      debounceMs: null,
+      liftOffDistance: null,
+      firmware: battery.percent !== null
+        ? ["Firmware unread (settings map pending)"]
+        : ["Connect OK · battery protocol probing"],
     };
   }
 
-  async setDpi(dpi: number): Promise<number> {
-    if (!this.getDpiOptions().includes(dpi)) {
-      throw new Error("OP1we CPI must be between 50 and 19,000 in 50 CPI steps.");
-    }
-    await this.writeSetting(COMMAND.dpi, [dpi & 0xff, (dpi >> 8) & 0xff]);
-    const confirmed = (await this.readDeviceState()).dpi;
-    if (confirmed !== dpi) {
-      throw new Error(`The mouse kept ${confirmed} CPI instead of ${dpi} CPI. Settings command map may need a capture from WE software.`);
-    }
-    return confirmed;
+  async setDpi(_dpi: number): Promise<number> {
+    throw this.settingsNotMappedError("CPI");
   }
 
-  async setPollingRate(rate: number): Promise<number> {
-    if (!POLLING_RATES.includes(rate as (typeof POLLING_RATES)[number])) {
-      throw new Error("Unsupported OP1we polling rate. Use 125, 250, 500, or 1000 Hz.");
-    }
-    await this.writeSetting(COMMAND.polling, [this.encodePolling(rate)]);
-    const confirmed = (await this.readDeviceState()).pollingRateHz;
-    if (confirmed !== rate) {
-      throw new Error(`The mouse kept ${confirmed} Hz instead of ${rate} Hz. Settings command map may need a capture from WE software.`);
-    }
-    return confirmed;
+  async setPollingRate(_rate: number): Promise<number> {
+    throw this.settingsNotMappedError("polling rate");
   }
 
-  async setLiftOffDistance(value: NonNullable<MouseStatus["liftOffDistance"]>): Promise<void> {
-    if (value === "Low") {
-      throw new Error("The OP1we supports Medium or High lift-off distance.");
-    }
-    const encoded = value === "Medium" ? 1 : 2;
-    await this.writeSetting(COMMAND.lod, [encoded]);
-    const confirmed = (await this.readDeviceState()).liftOffDistance;
-    if (confirmed !== value) {
-      throw new Error("The mouse did not confirm the requested lift-off distance. Settings command map may need a capture from WE software.");
-    }
+  async setLiftOffDistance(_value: NonNullable<MouseStatus["liftOffDistance"]>): Promise<void> {
+    throw this.settingsNotMappedError("lift-off distance");
   }
 
-  async setDebounceTime(milliseconds: number): Promise<number> {
-    if (!Number.isInteger(milliseconds) || milliseconds < 0 || milliseconds > 15) {
-      throw new Error("Debounce must be an integer from 0 to 15 ms.");
-    }
-    await this.writeSetting(COMMAND.debounce, [milliseconds]);
-    const confirmed = (await this.readDeviceState()).debounceMs;
-    if (confirmed !== milliseconds) {
-      throw new Error(`The mouse kept ${confirmed} ms debounce instead of ${milliseconds} ms. Settings command map may need a capture from WE software.`);
-    }
-    return confirmed;
+  async setDebounceTime(_milliseconds: number): Promise<number> {
+    throw this.settingsNotMappedError("debounce");
+  }
+
+  private settingsNotMappedError(label: string): Error {
+    return new Error(
+      `OP1we ${label} is not reverse-engineered yet. `
+      + "Battery uses a known command; DPI/polling/LOD/debounce need a USB capture "
+      + "of Endgame Gear WE Series software. The values shown are placeholders.",
+    );
   }
 
   async close(): Promise<void> {
     if (this.device.opened) await this.device.close();
   }
 
-  async probeCommands(from = 0xa8, to = 0xc0): Promise<string> {
-    const lines: string[] = [`target: ${this.describeCollections()}`];
+  /**
+   * Dump command responses for reverse engineering (DevTools / temporary UI).
+   */
+  async probeCommands(from = 0x00, to = 0xff): Promise<string> {
+    const lines: string[] = [
+      `device: ${this.device.productName || "unknown"}`,
+      `pid: 0x${this.device.productId.toString(16)}`,
+      `collections: ${this.describeCollections()}`,
+      `target: report 0x${(this.reportTarget ?? this.resolveReportTarget()).reportId.toString(16)}`
+        + `/${(this.reportTarget ?? this.resolveReportTarget()).payloadLength}B`,
+    ];
     for (let command = from; command <= to; command += 1) {
       try {
-        const response = await this.query(command, { wake: command === COMMAND.battery });
-        const hex = [...response].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
-        lines.push(`0x${command.toString(16)}: ${hex}`);
+        const response = await this.query(command, { wake: command === BATTERY_COMMAND });
+        const hex = [...response].slice(0, 24).map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
+        const tail = response.byteLength > 24 ? " …" : "";
+        lines.push(`0x${command.toString(16).padStart(2, "0")}: (${response.byteLength}B) ${hex}${tail}`);
       } catch (error) {
         const message = error instanceof Error ? error.message : "failed";
-        lines.push(`0x${command.toString(16)}: ${message}`);
+        lines.push(`0x${command.toString(16).padStart(2, "0")}: ${message}`);
+      }
+    }
+    return lines.join("\n");
+  }
+
+  /** Narrow battery-focused probe used on connect diagnostics. */
+  async probeBattery(): Promise<string> {
+    const lines: string[] = [];
+    const sizes = this.payloadLengthsToTry();
+    for (const length of sizes) {
+      for (const reportId of [WE_REPORT_ID, 0xa0]) {
+        try {
+          this.reportTarget = { reportId, payloadLength: length };
+          const response = await this.query(BATTERY_COMMAND, { wake: true });
+          await this.delay(100);
+          const second = await this.query(BATTERY_COMMAND, { wake: true });
+          const parsed = this.parseBatteryResponse(second);
+          lines.push(
+            `report 0x${reportId.toString(16)}/${length}B → ${second.byteLength}B `
+            + `raw[${this.toHex(second, 20)}] parse=${parsed.percent ?? "null"}%`,
+          );
+          if (parsed.percent !== null) {
+            this.lastBatteryRaw = this.toHex(second, 20);
+            return lines.join("\n");
+          }
+          void response;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "failed";
+          lines.push(`report 0x${reportId.toString(16)}/${length}B → ${message}`);
+        }
       }
     }
     return lines.join("\n");
@@ -279,137 +285,108 @@ export class EggWeHidClient {
     percent: number | null;
     state: MouseStatus["batteryState"];
   }> {
-    // Public WE battery protocol: double-read with wake delays, command 0xb4.
-    await this.query(COMMAND.battery, { wake: true });
-    await this.delay(100);
-    const response = await this.query(COMMAND.battery, { wake: true });
-    const statusByte = this.responseByte(response, 1);
-    const percentByte = this.responseByte(response, 16);
+    this.lastBatteryError = null;
+    this.lastBatteryRaw = null;
 
-    if (statusByte !== 0x01 && statusByte !== 0x08) {
-      if (percentByte !== undefined && percentByte <= 100) {
-        return {
-          percent: percentByte,
-          state: this.productMeta().wired ? "Charging" : "Discharging",
-        };
+    // Try verified framing first, then a small set of alternate lengths only if needed.
+    const attempts = this.payloadLengthsToTry().flatMap((length) => ([
+      { reportId: WE_REPORT_ID, payloadLength: length },
+      { reportId: 0xa0, payloadLength: length },
+    ]));
+
+    let lastError: Error | null = null;
+    for (const attempt of attempts) {
+      try {
+        this.reportTarget = attempt;
+        // Public protocol: double-read with wake delays.
+        await this.query(BATTERY_COMMAND, { wake: true });
+        await this.delay(100);
+        const response = await this.query(BATTERY_COMMAND, { wake: true });
+        this.lastBatteryRaw = this.toHex(response, 24);
+        const parsed = this.parseBatteryResponse(response);
+        if (parsed.percent !== null) {
+          return {
+            percent: parsed.percent,
+            state: this.productMeta().wired ? "Charging" : "Discharging",
+          };
+        }
+        // Keep the working transport even if parse failed — try next framing.
+        lastError = new Error(`no battery byte in ${this.lastBatteryRaw}`);
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
       }
-      return { percent: null, state: "Unknown" };
     }
-    return {
-      percent: Math.min(percentByte ?? 0, 100),
-      state: this.productMeta().wired ? "Charging" : "Discharging",
-    };
+
+    this.lastBatteryError = lastError?.message ?? "unknown";
+    // Restore preferred target for later probes.
+    this.reportTarget = this.resolveReportTarget();
+    return { percent: null, state: "Unknown" };
   }
 
-  /**
-   * Map Windows-style offsets (report id at index 0) onto WebHID buffers
-   * that usually omit the report id.
-   */
-  private responseByte(response: Uint8Array, windowsIndex: number): number | undefined {
-    if (this.responseIncludesReportId === true) return response[windowsIndex];
-    if (this.responseIncludesReportId === false) return response[windowsIndex - 1];
+  private payloadLengthsToTry(): number[] {
+    const fromDescriptor = EggWeHidClient.findFeatureReport(this.device, WE_REPORT_ID)?.payloadLength;
+    const lengths = [
+      WE_PAYLOAD_LENGTH, // 63 — matches Windows 64-byte buffer with report id
+      fromDescriptor,
+      64,
+      32,
+      31,
+      15,
+      7,
+    ].filter((value): value is number => typeof value === "number" && value > 0);
+    return [...new Set(lengths)];
+  }
 
-    // Auto-detect once we see a plausible battery frame.
-    if (response[0] === 0xa1 || response[0] === 0xa0) {
+  private parseBatteryResponse(response: Uint8Array): { percent: number | null } {
+    if (response.byteLength === 0) return { percent: null };
+
+    // Detect whether report id is present.
+    if (response[0] === WE_REPORT_ID || response[0] === 0xa0) {
       this.responseIncludesReportId = true;
-      return response[windowsIndex];
+    } else if (this.responseIncludesReportId === null) {
+      this.responseIncludesReportId = false;
     }
-    this.responseIncludesReportId = false;
-    return response[windowsIndex - 1];
-  }
 
-  private async readDeviceState(): Promise<{
-    dpi: number;
-    pollingRateHz: number;
-    liftOffDistance: NonNullable<MouseStatus["liftOffDistance"]>;
-    debounceMs: number;
-    firmware: string | null;
-  }> {
-    try {
-      const block = await this.query(COMMAND.status);
-      if (this.looksLikeStatus(block)) return this.parseStatusBlock(block);
-    } catch {
-      // Fall through to defaults — provisional status commands often fail.
-    }
-    return {
-      dpi: DEFAULT_DPI,
-      pollingRateHz: DEFAULT_POLLING,
-      liftOffDistance: "Medium",
-      debounceMs: DEFAULT_DEBOUNCE,
-      firmware: null,
+    const at = (windowsIndex: number): number | undefined => {
+      if (this.responseIncludesReportId) return response[windowsIndex];
+      return response[windowsIndex - 1];
     };
-  }
 
-  private parseStatusBlock(block: Uint8Array): {
-    dpi: number;
-    pollingRateHz: number;
-    liftOffDistance: NonNullable<MouseStatus["liftOffDistance"]>;
-    debounceMs: number;
-    firmware: string | null;
-  } {
-    const dpi = this.clampDpi(
-      (this.responseByte(block, 4) ?? 0) | ((this.responseByte(block, 5) ?? 0) << 8),
-    );
-    const pollingRateHz = this.decodePolling(this.responseByte(block, 6) ?? 0);
-    const lodRaw = this.responseByte(block, 7) ?? 1;
-    const liftOffDistance: NonNullable<MouseStatus["liftOffDistance"]> =
-      lodRaw === 2 ? "High" : "Medium";
-    const debounceMs = Math.min(Math.max(this.responseByte(block, 8) ?? DEFAULT_DEBOUNCE, 0), 15);
-    const major = this.responseByte(block, 10);
-    const minor = this.responseByte(block, 11);
-    const firmware = major !== undefined && minor !== undefined && (major !== 0 || minor !== 0)
-      ? `${major}.${minor}`
-      : null;
-    return {
-      dpi,
-      pollingRateHz: POLLING_RATES.includes(pollingRateHz as (typeof POLLING_RATES)[number])
-        ? pollingRateHz
-        : DEFAULT_POLLING,
-      liftOffDistance,
-      debounceMs,
-      firmware,
-    };
-  }
-
-  private looksLikeStatus(block: Uint8Array): boolean {
-    const dpi = (this.responseByte(block, 4) ?? 0) | ((this.responseByte(block, 5) ?? 0) << 8);
-    const polling = this.decodePolling(this.responseByte(block, 6) ?? 0);
-    const lod = this.responseByte(block, 7);
-    const debounce = this.responseByte(block, 8);
-    return dpi >= 50 && dpi <= 19000 && dpi % 50 === 0
-      && POLLING_RATES.includes(polling as (typeof POLLING_RATES)[number])
-      && (lod === 1 || lod === 2)
-      && debounce !== undefined && debounce <= 15;
-  }
-
-  private async readFirmware(): Promise<string | null> {
-    const response = await this.query(COMMAND.firmware);
-    const major = this.responseByte(response, 2) ?? this.responseByte(response, 10);
-    const minor = this.responseByte(response, 3) ?? this.responseByte(response, 11);
-    if (major === undefined || minor === undefined) return null;
-    if (major === 0 && minor === 0) return null;
-    return `${major}.${minor}`;
-  }
-
-  private async writeSetting(command: number, payload: number[]): Promise<void> {
-    // WE battery uses the same report for set+get; do not use 0xa0 unless that
-    // is the only report the interface exposes.
-    const data = new Uint8Array(Math.max(1 + payload.length, 2));
-    data[0] = command;
-    data[1] = payload.length;
-    for (let index = 0; index < payload.length; index += 1) {
-      data[2 + index] = payload[index] & 0xff;
+    // Documented layout (Windows indices): [1]=status 0x01|0x08, [16]=percent.
+    const status = at(1);
+    const documented = at(16);
+    if ((status === 0x01 || status === 0x08) && documented !== undefined && documented <= 100) {
+      return { percent: documented };
     }
-    await this.sendFeature(data);
-    await this.delay(50);
+
+    // Alternate common layouts seen across CompX-ish devices.
+    const candidates = [
+      at(16), at(15), at(5), at(4), at(3), at(2),
+      response[15], response[16], response[5], response[4], response[0],
+    ];
+    for (const value of candidates) {
+      if (value !== undefined && value > 0 && value <= 100) {
+        return { percent: value };
+      }
+    }
+
+    // Last resort: any byte in 5–100 that is not a known status marker alone.
+    for (let index = 0; index < response.byteLength; index += 1) {
+      const value = response[index];
+      if (value >= 5 && value <= 100 && value !== WE_REPORT_ID && value !== BATTERY_COMMAND) {
+        // Prefer later bytes (payload) over early command echoes.
+        if (index >= 2) return { percent: value };
+      }
+    }
+    return { percent: null };
   }
 
   private query(command: number, options: { wake?: boolean } = {}): Promise<Uint8Array> {
     const run = async (): Promise<Uint8Array> => {
       await this.open();
-      const data = new Uint8Array(1);
-      data[0] = command;
-      await this.sendFeature(data);
+      const payload = new Uint8Array(1);
+      payload[0] = command;
+      await this.sendFeatureExact(payload);
       if (options.wake) await this.delay(350);
       else await this.delay(40);
       return await this.receiveFeature();
@@ -419,107 +396,51 @@ export class EggWeHidClient {
     return next;
   }
 
-  private async sendFeature(payload: Uint8Array): Promise<void> {
+  /**
+   * Send using the current report target only (exact size). Do not “succeed”
+   * on a random length — that was caching a silent no-op framing.
+   */
+  private async sendFeatureExact(payload: Uint8Array): Promise<void> {
     await this.open();
     const target = this.reportTarget ?? this.resolveReportTarget();
-    const candidates = this.sendCandidates(target, payload);
-    let lastError: Error | null = null;
-
-    for (const candidate of candidates) {
-      try {
-        // Copy into a standalone ArrayBuffer so TS/BufferSource stay happy.
-        const body = new Uint8Array(candidate.data.byteLength);
-        body.set(candidate.data);
-        await this.device.sendFeatureReport(candidate.reportId, body);
-        this.reportTarget = { reportId: candidate.reportId, payloadLength: candidate.data.byteLength };
-        return;
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
-      }
+    const data = new Uint8Array(target.payloadLength);
+    data.set(payload.subarray(0, Math.min(payload.byteLength, data.byteLength)));
+    try {
+      await this.device.sendFeatureReport(target.reportId, data);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `${message} (report 0x${target.reportId.toString(16)}, ${target.payloadLength}B payload, `
+        + `pid 0x${this.device.productId.toString(16)}, ${this.describeCollections()})`,
+      );
     }
-
-    const detail = this.describeCollections();
-    const message = lastError?.message ?? "Failed to write the feature report.";
-    throw new Error(
-      `${message} Tried report(s) on ${this.device.productName || "device"} `
-      + `(PID 0x${this.device.productId.toString(16)}, ${detail}). `
-      + "Close official WE software and pick the vendor interface if several appear.",
-    );
-  }
-
-  /**
-   * Build sized payloads. WebHID requires the exact feature report length from
-   * the descriptor; wrong length → "Failed to write the feature report."
-   */
-  private sendCandidates(
-    preferred: FeatureReportTarget,
-    payload: Uint8Array,
-  ): Array<{ reportId: number; data: Uint8Array }> {
-    const reports = EggWeHidClient.listFeatureReports(this.device);
-    const reportIds = [
-      preferred.reportId,
-      ...PREFERRED_REPORT_IDS,
-      ...reports.map((report) => report.reportId),
-    ].filter((id, index, all) => all.indexOf(id) === index);
-
-    const lengths = [
-      preferred.payloadLength,
-      ...reports.map((report) => report.payloadLength),
-      63, // 64-byte report with id excluded
-      64,
-      32,
-      31,
-      Math.max(payload.byteLength, 1),
-    ].filter((length, index, all) => length > 0 && all.indexOf(length) === index);
-
-    const candidates: Array<{ reportId: number; data: Uint8Array }> = [];
-    for (const reportId of reportIds) {
-      for (const length of lengths) {
-        const data = new Uint8Array(length);
-        data.set(payload.subarray(0, Math.min(payload.byteLength, length)));
-        candidates.push({ reportId, data });
-      }
-    }
-    return candidates;
   }
 
   private async receiveFeature(): Promise<Uint8Array> {
     await this.open();
     const target = this.reportTarget ?? this.resolveReportTarget();
-    const reportIds = [target.reportId, ...PREFERRED_REPORT_IDS]
-      .filter((id, index, all) => all.indexOf(id) === index);
-    let lastError: Error | null = null;
-    for (const reportId of reportIds) {
-      try {
-        const view = await this.device.receiveFeatureReport(reportId);
-        return this.copyDataView(view);
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
+    try {
+      const view = await this.device.receiveFeatureReport(target.reportId);
+      return this.copyDataView(view);
+    } catch (error) {
+      // Some stacks want the same report id used for set; try the other common id once.
+      if (target.reportId === WE_REPORT_ID) {
+        try {
+          const view = await this.device.receiveFeatureReport(0xa0);
+          return this.copyDataView(view);
+        } catch {
+          // fall through
+        }
       }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`${message} (receive report 0x${target.reportId.toString(16)})`);
     }
-    throw lastError ?? new Error("Failed to read the feature report.");
   }
 
-  private encodePolling(rate: number): number {
-    const table: Record<number, number> = { 125: 8, 250: 4, 500: 2, 1000: 1 };
-    const encoded = table[rate];
-    if (!encoded) throw new Error("Unsupported OP1we polling rate.");
-    return encoded;
-  }
-
-  private decodePolling(value: number): number {
-    const table: Record<number, number> = {
-      1: 1000, 2: 500, 4: 250, 8: 125,
-      125: 125, 250: 250, 500: 500, 1000: 1000,
-    };
-    return table[value] ?? value;
-  }
-
-  private clampDpi(dpi: number): number {
-    if (this.getDpiOptions().includes(dpi)) return dpi;
-    const stepped = Math.round(dpi / 50) * 50;
-    if (this.getDpiOptions().includes(stepped)) return stepped;
-    return DEFAULT_DPI;
+  private toHex(bytes: Uint8Array, max = 24): string {
+    const slice = bytes.subarray(0, max);
+    const hex = [...slice].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
+    return bytes.byteLength > max ? `${hex}…` : hex;
   }
 
   private copyDataView(view: DataView): Uint8Array {

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -271,47 +271,86 @@ export class EggWeHidClient {
   }
 
   // ---------------------------------------------------------------------------
-  // Battery — at most one feature transaction (no multi-command probes)
+  // Battery — few short attempts, no refresh loop
+  // Earlier working path used report 0x06 (7B) + cmd 0x04 on this hardware.
   // ---------------------------------------------------------------------------
 
-  private resolvePreferredTarget(): FeatureReportTarget {
-    const features = EggWeHidClient.listFeatureReports(this.device)
+  private batteryTargets(): FeatureReportTarget[] {
+    const fromDescriptor = EggWeHidClient.listFeatureReports(this.device)
       .filter((report) => report.payloadLength > 0);
-    // Prefer 16-byte config report when present; fall back to 7-byte (0x06).
-    const by08 = features.find((report) => report.reportId === 0x08 && report.payloadLength >= 15);
-    if (by08) return by08;
-    const by06 = features.find((report) => report.reportId === 0x06);
-    if (by06) return by06;
-    if (features[0]) return features[0];
-    return { reportId: 0x06, payloadLength: 7 };
+    const extras: FeatureReportTarget[] = [
+      { reportId: 0x06, payloadLength: 7 },
+      { reportId: 0x08, payloadLength: 16 },
+      { reportId: 0x08, payloadLength: 15 },
+      { reportId: 0x06, payloadLength: 6 },
+    ];
+    const merged = [...fromDescriptor, ...extras];
+    // Prefer 0x06 first — that is what succeeded on the user's OP1we before.
+    merged.sort((left, right) => {
+      const rank = (report: FeatureReportTarget): number => {
+        if (report.reportId === 0x06) return 0;
+        if (report.reportId === 0x08) return 1;
+        return 2;
+      };
+      return rank(left) - rank(right) || left.payloadLength - right.payloadLength;
+    });
+    const seen = new Set<string>();
+    return merged.filter((target) => {
+      const key = `${target.reportId}:${target.payloadLength}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
   }
 
   private async readBatteryOnce(wireless: boolean): Promise<{
     percent: number | null;
     state: MouseStatus["batteryState"];
   }> {
-    const target = this.resolvePreferredTarget();
-    // Try 0x04 first (CompX/Pulsar-style). One packet only on wireless.
+    // Cap attempts: wireless ≤2, wired ≤6 (2 reports × 2 cmds × variants, early exit).
+    const targets = this.batteryTargets().slice(0, wireless ? 2 : 4);
     const commands = wireless ? [0x04] : [0x04, 0xb4];
+    let lastRaw = "";
 
-    for (const command of commands) {
-      try {
-        const response = await this.featureExchange(target, command, wireless);
-        const parsed = this.parseBattery(response, command, wireless);
-        if (parsed.percent !== null) {
-          return {
-            percent: parsed.percent,
-            state: parsed.charging
-              ? (parsed.percent >= 99 ? "Full" : "Charging")
-              : (wireless ? "Discharging" : "Charging"),
-          };
+    for (const target of targets) {
+      for (const command of commands) {
+        for (const withChecksum of target.payloadLength >= 16 ? [false, true] : [false]) {
+          try {
+            const response = await this.featureExchange(target, command, wireless, withChecksum);
+            lastRaw = [...response].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
+            const parsed = this.parseBattery(response, command, wireless);
+            if (parsed.percent !== null) {
+              console.info(
+                `[OpenMouse WE battery] ok report=0x${target.reportId.toString(16)} `
+                + `len=${target.payloadLength} cmd=0x${command.toString(16)} `
+                + `checksum=${withChecksum} raw=[${lastRaw}] → ${parsed.percent}%`,
+              );
+              return {
+                percent: parsed.percent,
+                state: parsed.charging
+                  ? (parsed.percent >= 99 ? "Full" : "Charging")
+                  : (wireless ? "Discharging" : "Charging"),
+              };
+            }
+            console.info(
+              `[OpenMouse WE battery] no parse report=0x${target.reportId.toString(16)} `
+              + `len=${target.payloadLength} cmd=0x${command.toString(16)} raw=[${lastRaw}]`,
+            );
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            lastRaw = message;
+            console.info(
+              `[OpenMouse WE battery] fail report=0x${target.reportId.toString(16)} `
+              + `len=${target.payloadLength} cmd=0x${command.toString(16)}: ${message}`,
+            );
+          }
         }
-        // Wired: try next command once. Wireless: stop after first attempt.
-        if (wireless) break;
-      } catch {
-        if (wireless) break;
       }
+      // Wireless: at most two report targets (0x06 then 0x08), no command flood.
+      if (wireless) break;
     }
+
+    console.info(`[OpenMouse WE battery] unread last=${lastRaw || "none"}`);
     return { percent: null, state: "Unknown" };
   }
 
@@ -319,26 +358,33 @@ export class EggWeHidClient {
     target: FeatureReportTarget,
     command: number,
     wireless: boolean,
+    withChecksum: boolean,
   ): Promise<Uint8Array> {
     const packet = new Uint8Array(target.payloadLength);
     packet[0] = command;
-    if (target.payloadLength >= 16) {
-      // Pulsar-style length + checksum on 16-byte frames.
+    if (withChecksum && target.payloadLength >= 16) {
       packet[4] = 0;
       let sum = 0;
       for (let i = 0; i < packet.length - 1; i += 1) sum += packet[i];
       packet[15] = (0x55 - (sum & 0xff) - target.reportId) & 0xff;
     }
     await this.device.sendFeatureReport(target.reportId, packet);
-    await this.delay(wireless ? 30 : 50);
-    const view = await this.device.receiveFeatureReport(target.reportId);
-    return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+    // Short settle; double-get can help flaky feature endpoints on cable only.
+    await this.delay(wireless ? 40 : 60);
+    let view = await this.device.receiveFeatureReport(target.reportId);
+    let bytes = new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+    if (!wireless && bytes.every((byte) => byte === 0)) {
+      await this.delay(80);
+      view = await this.device.receiveFeatureReport(target.reportId);
+      bytes = new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+    }
+    return bytes;
   }
 
   /**
    * Parse battery from a single response.
-   * Observed earlier: wrong byte → 52% vs OEM ~70%; 100% on dongle was a flag.
-   * Prefer CompX layout percent @5; reject 100 unless charge looks full.
+   * Accept 1–99 at likely payload indices. Reject bare 100 on wireless.
+   * Also try Windows-style layout (report id at [0]) by shifting indices +1.
    */
   private parseBattery(
     response: Uint8Array,
@@ -347,36 +393,47 @@ export class EggWeHidClient {
   ): { percent: number | null; charging: boolean } {
     if (response.byteLength === 0) return { percent: null, charging: !wireless };
 
-    const max = response.byteLength - 1;
-    const chargeFlag = max >= 6 ? response[6] : undefined;
-    const charging = chargeFlag === 1 || chargeFlag === 2 || (!wireless && chargeFlag !== 0);
-
-    const tryIndex = (index: number): number | null => {
-      if (index < 0 || index > max) return null;
-      const raw = response[index];
-      if (raw === command) return null;
-      if (raw === 0 || raw > 100) return null;
-      // 100% on wireless is almost always a status flag, not charge level.
-      if (raw === 100 && wireless && chargeFlag !== 1 && chargeFlag !== 2) return null;
-      if (raw === 100 && !charging && wireless) return null;
-      if (raw >= 1 && raw <= 100) return raw;
-      return null;
+    // Detect whether byte0 is a report id (0x06/0x08) rather than a command echo.
+    const hasReportIdPrefix = response[0] === 0x06 || response[0] === 0x08;
+    const at = (index: number): number | undefined => {
+      const real = hasReportIdPrefix ? index + 1 : index;
+      return real < response.byteLength ? response[real] : undefined;
     };
 
-    // 1) Preferred CompX/Pulsar layout: percent at [5]
-    const at5 = tryIndex(5);
-    if (at5 !== null) return { percent: at5, charging };
+    const chargeFlag = at(6);
+    const charging = chargeFlag === 1 || chargeFlag === 2
+      || (!wireless && chargeFlag !== 0 && chargeFlag !== undefined);
 
-    // 2) Other payload indices (skip [0] command echo; skip last byte if 16B checksum)
-    const last = response.byteLength >= 16 ? max - 1 : max;
-    const order = [4, 3, 2, 6, 1, 7].filter((index) => index <= last);
-    for (const index of order) {
-      const value = tryIndex(index);
-      if (value !== null && value !== 100) return { percent: value, charging };
+    const asPercent = (raw: number | undefined): number | null => {
+      if (raw === undefined) return null;
+      if (raw === command) return null;
+      if (raw === 0 || raw > 100) return null;
+      if (raw === 100) {
+        // Only trust 100 when charge flag implies charging/full.
+        if (chargeFlag === 1 || chargeFlag === 2) return 100;
+        if (wireless) return null;
+        return 100;
+      }
+      return raw;
+    };
+
+    // Preferred order: CompX/Pulsar percent @5, then nearby payload bytes.
+    for (const index of [5, 4, 3, 2, 6, 1, 7]) {
+      const value = asPercent(at(index));
+      if (value !== null && value < 100) {
+        return { percent: value, charging: charging || !wireless };
+      }
     }
 
-    // 3) Allow 100% only if charge flag says charging/full
-    const full = tryIndex(5) ?? tryIndex(4);
+    // Direct buffer scan (no shift) as last resort — skip [0].
+    for (let index = 1; index < response.byteLength; index += 1) {
+      const value = asPercent(response[index]);
+      if (value !== null && value < 100) {
+        return { percent: value, charging: charging || !wireless };
+      }
+    }
+
+    const full = asPercent(at(5)) ?? asPercent(at(4)) ?? asPercent(response[5]);
     if (full === 100) return { percent: 100, charging: true };
 
     return { percent: null, charging: !wireless };

--- a/src/egg-we-hid.ts
+++ b/src/egg-we-hid.ts
@@ -94,12 +94,30 @@ export class EggWeHidClient {
     if (OP1WE_CABLE_PIDS.has(device.productId)) score += 8;
     if (OP1WE_RECEIVER_PIDS.has(device.productId)) score += 2;
     if (!this.isReceiverDevice(device)) score += 4;
+    // From hidapitester report descriptors on PID 0x1962:
+    //   FF02/2 → Feature report id 8, 16 data bytes
+    //   FF04/2 → Feature report id 6, 7 data bytes
+    //   FF01   → Input only (id 9); FF03 → Input only (id 2)
+    const pages = this.usagePages(device);
+    if (pages.has(0xff02)) score += 10;
+    if (pages.has(0xff04)) score += 8;
     const features = this.listFeatureReports(device);
-    if (features.some((report) => report.reportId === 0x08)) score += 3;
-    if (features.some((report) => report.reportId === 0x06)) score += 1;
-    // Prefer interfaces that actually expose config reports over bare boot mice.
+    if (features.some((report) => report.reportId === 0x08 && report.payloadLength >= 15)) score += 6;
+    if (features.some((report) => report.reportId === 0x06 && report.payloadLength === 7)) score += 4;
     if (features.length > 0) score += 2;
     return score;
+  }
+
+  private static usagePages(device: HIDDevice): Set<number> {
+    const pages = new Set<number>();
+    const visit = (collections: readonly HIDCollectionInfo[]): void => {
+      for (const collection of collections) {
+        pages.add(collection.usagePage);
+        visit(collection.children);
+      }
+    };
+    visit(device.collections);
+    return pages;
   }
 
   isWirelessPath(): boolean {
@@ -271,105 +289,78 @@ export class EggWeHidClient {
   }
 
   // ---------------------------------------------------------------------------
-  // Battery
-  // User capture: feature 0x08/16B returns 08 + zeros (no payload yet);
-  // feature 0x06 with wrong length fails write. Need exact sizes + possibly
-  // output/input (Pulsar-style) or OEM wake sequence — Wireshark will settle.
+  // Battery — from report descriptors (hidapitester on PID 0x1962):
+  //   FF02/2: Feature report id 8, Report Count 16  (WebHID payload = 16 bytes, no report id)
+  //   FF04/2: Feature report id 6, Report Count 7
+  //   FF01:   Input report id 9 only — not feature
+  //   FF03:   Input report id 2 only — not feature
+  // Write on FF02/8 and FF04/6 succeeded in hidapitester; GetFeature failed when
+  // length omitted the +1 report-id byte (Windows). WebHID sizes the buffer itself.
   // ---------------------------------------------------------------------------
 
   private batteryFeatureTargets(): FeatureReportTarget[] {
     const fromDescriptor = EggWeHidClient.listFeatureReports(this.device)
       .filter((report) => report.payloadLength > 0);
-    // Only exact sizes that match this hardware (never invent len=6).
-    const known: FeatureReportTarget[] = [
-      { reportId: 0x06, payloadLength: 7 },
+    // Descriptor-backed sizes only.
+    const preferred: FeatureReportTarget[] = [
       { reportId: 0x08, payloadLength: 16 },
+      { reportId: 0x06, payloadLength: 7 },
     ];
-    const merged = [...fromDescriptor, ...known];
+    const merged = [...fromDescriptor, ...preferred];
     const seen = new Set<string>();
     return merged
       .filter((target) => {
-        // Drop known-bad sizes from empty item counts.
+        if (target.reportId === 0x08 && target.payloadLength !== 16) return false;
         if (target.reportId === 0x06 && target.payloadLength !== 7) return false;
-        if (target.reportId === 0x08 && target.payloadLength < 15) return false;
+        if (target.reportId !== 0x08 && target.reportId !== 0x06) return false;
         const key = `${target.reportId}:${target.payloadLength}`;
         if (seen.has(key)) return false;
         seen.add(key);
         return true;
       })
-      .sort((left, right) => {
-        // Prefer 0x06/7 (previously returned data) then 0x08/16.
-        if (left.reportId !== right.reportId) {
-          return left.reportId === 0x06 ? -1 : right.reportId === 0x06 ? 1 : left.reportId - right.reportId;
-        }
-        return left.payloadLength - right.payloadLength;
-      });
+      .sort((left, right) => left.reportId === 0x08 ? -1 : right.reportId === 0x08 ? 1 : 0);
   }
 
   private async readBatteryOnce(wireless: boolean): Promise<{
     percent: number | null;
     state: MouseStatus["batteryState"];
   }> {
-    const targets = this.batteryFeatureTargets().slice(0, wireless ? 2 : 4);
-    const commands = wireless ? [0x04] : [0x04, 0xb4, 0x05];
+    // WebHID data buffer excludes report id: 16 bytes for report 8, 7 for report 6.
+    const targets = this.batteryFeatureTargets();
+    const commands = wireless ? [0x04] : [0x04, 0xb4, 0x05, 0x01, 0x02, 0x03];
     let lastRaw = "";
 
     for (const target of targets) {
       for (const command of commands) {
-        // Feature report path (no checksum first — zeros were returned with/without).
         try {
-          const response = await this.featureExchange(target, command, wireless, false);
+          const response = await this.featureExchange(target, command, wireless);
           lastRaw = this.toHex(response);
           const parsed = this.parseBattery(response, command, wireless);
           if (parsed.percent !== null) {
-            console.info(`[OpenMouse WE battery] ok feature 0x${target.reportId.toString(16)}/${target.payloadLength} cmd=0x${command.toString(16)} raw=[${lastRaw}] → ${parsed.percent}%`);
+            console.info(
+              `[OpenMouse WE battery] ok id=0x${target.reportId.toString(16)} `
+              + `len=${target.payloadLength} cmd=0x${command.toString(16)} `
+              + `raw=[${lastRaw}] → ${parsed.percent}%`,
+            );
             return this.batteryResult(parsed.percent, parsed.charging, wireless);
           }
-          console.info(`[OpenMouse WE battery] empty feature 0x${target.reportId.toString(16)}/${target.payloadLength} cmd=0x${command.toString(16)} raw=[${lastRaw}]`);
+          console.info(
+            `[OpenMouse WE battery] empty id=0x${target.reportId.toString(16)} `
+            + `cmd=0x${command.toString(16)} raw=[${lastRaw}]`,
+          );
         } catch (error) {
           lastRaw = error instanceof Error ? error.message : String(error);
-          console.info(`[OpenMouse WE battery] fail feature 0x${target.reportId.toString(16)}/${target.payloadLength} cmd=0x${command.toString(16)}: ${lastRaw}`);
+          console.info(
+            `[OpenMouse WE battery] fail id=0x${target.reportId.toString(16)} `
+            + `cmd=0x${command.toString(16)}: ${lastRaw}`,
+          );
         }
-
-        // Wired only: double-read wake (old EGG battery pattern) for 0xb4 / 0x04.
-        if (!wireless && (command === 0x04 || command === 0xb4)) {
-          try {
-            const response = await this.featureExchangeWake(target, command);
-            lastRaw = this.toHex(response);
-            const parsed = this.parseBattery(response, command, wireless);
-            if (parsed.percent !== null) {
-              console.info(`[OpenMouse WE battery] ok wake 0x${target.reportId.toString(16)} cmd=0x${command.toString(16)} raw=[${lastRaw}] → ${parsed.percent}%`);
-              return this.batteryResult(parsed.percent, parsed.charging, wireless);
-            }
-          } catch (error) {
-            lastRaw = error instanceof Error ? error.message : String(error);
-          }
-        }
-
-        // Output/input path (same report id family as Pulsar 0x08) — cable only.
-        if (!wireless && target.reportId === 0x08) {
-          try {
-            const response = await this.outputExchange(target, command);
-            lastRaw = this.toHex(response);
-            const parsed = this.parseBattery(response, command, wireless);
-            if (parsed.percent !== null) {
-              console.info(`[OpenMouse WE battery] ok output 0x08 cmd=0x${command.toString(16)} raw=[${lastRaw}] → ${parsed.percent}%`);
-              return this.batteryResult(parsed.percent, parsed.charging, wireless);
-            }
-            console.info(`[OpenMouse WE battery] empty output 0x08 cmd=0x${command.toString(16)} raw=[${lastRaw}]`);
-          } catch (error) {
-            lastRaw = error instanceof Error ? error.message : String(error);
-            console.info(`[OpenMouse WE battery] fail output 0x08: ${lastRaw}`);
-          }
-        }
+        if (wireless) break;
       }
       if (wireless) break;
     }
 
-    console.info(
-      `[OpenMouse WE battery] unread pid=0x${this.device.productId.toString(16)} `
-      + `reports=${this.describeCollections()} last=${lastRaw || "none"}`,
-    );
+    console.info(`[OpenMouse WE battery] unread last=${lastRaw || "none"}`);
     return { percent: null, state: "Unknown" };
   }
 
@@ -378,81 +369,32 @@ export class EggWeHidClient {
     charging: boolean,
     wireless: boolean,
   ): { percent: number; state: MouseStatus["batteryState"] } {
-    if (charging) {
-      return { percent, state: percent >= 99 ? "Full" : "Charging" };
-    }
+    if (charging) return { percent, state: percent >= 99 ? "Full" : "Charging" };
     return { percent, state: wireless ? "Discharging" : "Charging" };
   }
 
+  /**
+   * WebHID: sendFeatureReport(reportId, data) — data does NOT include report id.
+   * Payload length must match Report Count from the descriptor (16 or 7).
+   */
   private async featureExchange(
     target: FeatureReportTarget,
     command: number,
     wireless: boolean,
-    withChecksum: boolean,
-  ): Promise<Uint8Array> {
-    const packet = new Uint8Array(target.payloadLength);
-    packet[0] = command;
-    if (withChecksum && target.payloadLength >= 16) {
-      packet[4] = 0;
-      let sum = 0;
-      for (let i = 0; i < packet.length - 1; i += 1) sum += packet[i];
-      packet[15] = (0x55 - (sum & 0xff) - target.reportId) & 0xff;
-    }
-    await this.device.sendFeatureReport(target.reportId, packet);
-    await this.delay(wireless ? 40 : 80);
-    const view = await this.device.receiveFeatureReport(target.reportId);
-    return this.copyView(view);
-  }
-
-  /** Classic EGG-style double transaction (discard first response). */
-  private async featureExchangeWake(
-    target: FeatureReportTarget,
-    command: number,
   ): Promise<Uint8Array> {
     const packet = new Uint8Array(target.payloadLength);
     packet[0] = command;
     await this.device.sendFeatureReport(target.reportId, packet);
-    await this.delay(200);
-    try {
-      await this.device.receiveFeatureReport(target.reportId);
-    } catch {
-      // ignore first
+    await this.delay(wireless ? 40 : 100);
+    // Second get helps some devices that ACK write then populate on next get.
+    let view = await this.device.receiveFeatureReport(target.reportId);
+    let bytes = this.copyView(view);
+    if (!wireless && this.isAllZero(bytes)) {
+      await this.delay(150);
+      view = await this.device.receiveFeatureReport(target.reportId);
+      bytes = this.copyView(view);
     }
-    await this.delay(80);
-    await this.device.sendFeatureReport(target.reportId, packet);
-    await this.delay(200);
-    return this.copyView(await this.device.receiveFeatureReport(target.reportId));
-  }
-
-  private async outputExchange(
-    target: FeatureReportTarget,
-    command: number,
-  ): Promise<Uint8Array> {
-    const packet = new Uint8Array(target.payloadLength);
-    packet[0] = command;
-    // Soft wait for matching input report.
-    const reply = new Promise<Uint8Array>((resolve) => {
-      const timer = window.setTimeout(() => {
-        this.device.removeEventListener("inputreport", onInput);
-        resolve(new Uint8Array());
-      }, 600);
-      const onInput = (event: HIDInputReportEvent): void => {
-        if (event.reportId !== target.reportId) return;
-        window.clearTimeout(timer);
-        this.device.removeEventListener("inputreport", onInput);
-        resolve(this.copyView(event.data));
-      };
-      this.device.addEventListener("inputreport", onInput);
-    });
-    await this.device.sendReport(target.reportId, packet);
-    const input = await reply;
-    if (input.byteLength > 0) return input;
-    // Fall back to feature get on same id.
-    try {
-      return this.copyView(await this.device.receiveFeatureReport(target.reportId));
-    } catch {
-      return input;
-    }
+    return bytes;
   }
 
   private parseBattery(
@@ -460,21 +402,17 @@ export class EggWeHidClient {
     command: number,
     wireless: boolean,
   ): { percent: number | null; charging: boolean } {
-    if (response.byteLength === 0) return { percent: null, charging: !wireless };
-
-    // Strip leading report id if present (08 00 00… from user's capture).
-    let data = response;
-    if ((response[0] === 0x06 || response[0] === 0x08) && response.byteLength > 1) {
-      // If everything after report id is zero, there is no battery payload yet.
-      if (response.slice(1).every((byte) => byte === 0)) {
-        return { percent: null, charging: !wireless };
-      }
-      data = response.slice(1);
+    if (response.byteLength === 0 || this.isAllZero(response)) {
+      return { percent: null, charging: !wireless };
     }
 
-    // All-zero payload = device ignored the command.
-    if (data.every((byte) => byte === 0)) {
-      return { percent: null, charging: !wireless };
+    // WebHID usually omits report id. If present, strip it.
+    let data = response;
+    if ((response[0] === 0x06 || response[0] === 0x08) && response.byteLength > 1) {
+      if (this.isAllZero(response.subarray(1))) {
+        return { percent: null, charging: !wireless };
+      }
+      data = response.subarray(1);
     }
 
     const chargeFlag = data[6];
@@ -488,15 +426,16 @@ export class EggWeHidClient {
       return raw;
     };
 
-    for (const index of [5, 4, 3, 2, 6, 1, 7, 8, 9, 10]) {
+    // Prefer byte 1 as "command data" after our cmd at [0], then classic @5.
+    for (const index of [1, 5, 4, 3, 2, 6, 7, 8, 9, 10]) {
       const value = asPercent(data[index]);
       if (value !== null && value < 100) {
         return { percent: value, charging: charging || !wireless };
       }
     }
 
-    // Any non-zero 1–99 in payload (last resort).
-    for (let index = 1; index < data.byteLength; index += 1) {
+    for (let index = 0; index < data.byteLength; index += 1) {
+      if (index === 0 && data[0] === command) continue;
       const value = asPercent(data[index]);
       if (value !== null && value < 100) {
         return { percent: value, charging: charging || !wireless };
@@ -504,6 +443,13 @@ export class EggWeHidClient {
     }
 
     return { percent: null, charging: !wireless };
+  }
+
+  private isAllZero(bytes: Uint8Array): boolean {
+    for (let i = 0; i < bytes.byteLength; i += 1) {
+      if (bytes[i] !== 0) return false;
+    }
+    return true;
   }
 
   private toHex(bytes: Uint8Array): string {

--- a/src/egg-we-protocol.test.ts
+++ b/src/egg-we-protocol.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  WE_OFF,
+  WE_REPORT_ID,
+  weBuildReadEepromPayload,
+  weBuildWriteEepromPayload,
+  wePackDpiStage,
+  wePackScalarPair,
+  weParseReadEepromResponse,
+  weParseWriteEepromResponse,
+  wePatchActiveDpi,
+  weReportChecksum,
+  weUnpackDpiStage,
+  weUnpackScalarPair,
+} from "./egg-we-protocol.ts";
+
+test("commands produce a valid report checksum", () => {
+  for (const payload of [weBuildReadEepromPayload(0x1234, 8), weBuildWriteEepromPayload(0x12, [1, 2, 3, 4])]) {
+    assert.equal(payload.length, 16);
+    assert.equal(payload[15], weReportChecksum(WE_REPORT_ID, [...payload.subarray(0, 15)]));
+    assert.equal(([WE_REPORT_ID, ...payload].reduce((sum, byte) => sum + byte, 0) & 0xff), 0x55);
+  }
+});
+
+test("scalar pairs reject corrupt checksums", () => {
+  const [value, checksum] = wePackScalarPair(7);
+  assert.equal(weUnpackScalarPair(value, checksum), 7);
+  assert.equal(weUnpackScalarPair(value, checksum ^ 1), null);
+});
+
+test("read and write responses require successful status", () => {
+  const read = new Uint8Array([0x08, 0, 0, 0x34, 2, 0xaa, 0xbb]);
+  assert.deepEqual([...weParseReadEepromResponse(read, 0x1234, 2)!], [0xaa, 0xbb]);
+  read[1] = 1;
+  assert.equal(weParseReadEepromResponse(read, 0x1234, 2), null);
+  assert.equal(weParseWriteEepromResponse(new Uint8Array([0x07, 0])), true);
+  assert.equal(weParseWriteEepromResponse(new Uint8Array([0x07, 1])), false);
+});
+
+test("DPI changes only the active stage and preserves flags", () => {
+  const profile = new Uint8Array(WE_OFF.dpiStages + WE_OFF.maxDpiStages * WE_OFF.dpiStageBytes);
+  for (let index = 0; index < WE_OFF.maxDpiStages; index += 1) {
+    profile.set(wePackDpiStage(400 + index * 50, 400 + index * 50, index), WE_OFF.dpiStages + index * 4);
+  }
+  const before = new Uint8Array(profile);
+  wePatchActiveDpi(profile, 1600, 3);
+  for (let index = 0; index < WE_OFF.maxDpiStages; index += 1) {
+    const offset = WE_OFF.dpiStages + index * 4;
+    if (index !== 3) assert.deepEqual(profile.slice(offset, offset + 4), before.slice(offset, offset + 4));
+  }
+  assert.deepEqual(weUnpackDpiStage(profile.slice(WE_OFF.dpiStages + 12, WE_OFF.dpiStages + 16)), { x: 1600, y: 1600, flags: 3 });
+});
+
+test("DPI patch refuses corrupt source stages", () => {
+  const profile = new Uint8Array(WE_OFF.dpiStages + 4);
+  assert.throws(() => wePatchActiveDpi(profile, 800, 0), /checksum is invalid/);
+});

--- a/src/egg-we-protocol.ts
+++ b/src/egg-we-protocol.ts
@@ -254,14 +254,16 @@ export function weDecodeProfile(mem: Uint8Array): WeProfile {
   };
 }
 
-/** Patch DPI stages 0..count-1 in a profile image (same CPI on X/Y). */
-export function wePatchAllActiveDpi(mem: Uint8Array, cpi: number, stageCount: number): void {
-  const count = Math.min(Math.max(stageCount, 1), WE_OFF.maxDpiStages);
-  const packed = wePackDpiStage(cpi, cpi, 0);
-  for (let i = 0; i < count; i += 1) {
-    const off = WE_OFF.dpiStages + i * WE_OFF.dpiStageBytes;
-    mem.set(packed, off);
+/** Patch only the selected DPI stage, preserving its protocol flags. */
+export function wePatchActiveDpi(mem: Uint8Array, cpi: number, activeLevel: number): void {
+  if (!Number.isInteger(activeLevel) || activeLevel < 0 || activeLevel >= WE_OFF.maxDpiStages) {
+    throw new Error("WE active DPI stage is out of range.");
   }
+  const off = WE_OFF.dpiStages + activeLevel * WE_OFF.dpiStageBytes;
+  if (mem.length < off + WE_OFF.dpiStageBytes) throw new Error("WE profile is missing the active DPI stage.");
+  const existing = weUnpackDpiStage(mem.subarray(off, off + WE_OFF.dpiStageBytes));
+  if (!existing) throw new Error("WE active DPI stage checksum is invalid.");
+  mem.set(wePackDpiStage(cpi, cpi, existing.flags), off);
 }
 
 export function wePatchScalar(mem: Uint8Array, addr: number, value: number): void {

--- a/src/egg-we-protocol.ts
+++ b/src/egg-we-protocol.ts
@@ -1,0 +1,275 @@
+/**
+ * Pure Endgame Gear WE-series (OP1we) profile protocol helpers.
+ * Used by EggWeHidClient and unit-tested without WebHID.
+ *
+ * Framing: feature report id 0x08, 16-byte payload, full report sum == 0x55.
+ * ReadEEPROM cmd 0x08 / WriteEEPROM cmd 0x07 — body [0, hi, lo, len, data…].
+ */
+
+export const WE_REPORT_ID = 0x08;
+export const WE_PAYLOAD_LEN = 16;
+export const WE_CHECKSUM_TARGET = 0x55;
+export const WE_CMD_GET_POWER = 0x04;
+export const WE_CMD_READ_EEPROM = 0x08;
+export const WE_CMD_WRITE_EEPROM = 0x07;
+export const WE_CMD_GET_CONNECT = 0x03;
+export const WE_CMD_GET_CUR_PROFILE = 0x0e;
+export const WE_MAX_EEPROM_CHUNK = 8;
+
+/** Profile map (NOTES.md / OEM GetProfile logs). */
+export const WE_OFF = {
+  /**
+   * Header value+crc pairs (live dump: 01 54 | 04 51 | 01 54 | … | 02 53).
+   * Report-rate was briefly mis-mapped to 0x04, which is DEFLEVEL — writing “Hz”
+   * changed the active CPI stage. Correct map:
+   */
+  /** Report-rate divider: 8→125, 4→250, 2→500, 1→1000 Hz (OEM max 1000). */
+  reportRate: 0x00,
+  dpiStageCount: 0x02, // DM
+  activeDpiLevel: 0x04, // DEFLEVEL — which CPI stage is active (not report rate!)
+  lod: 0x0a, // 1=Medium, 2=High
+  dpiStages: 0x0c, // 8 × 4-byte stages
+  dpiStageBytes: 4,
+  maxDpiStages: 8,
+  debounce: 0xa9, // ms
+  sleep: 0xad, // raw; OEM displays raw*10
+} as const;
+
+/** OEM-style rates only (upper bound 1000 Hz — no 2K/4K/8K). */
+export const WE_POLLING_RATES = [125, 250, 500, 1000] as const;
+export type WePollingRate = (typeof WE_POLLING_RATES)[number];
+
+export type WeLod = "Medium" | "High";
+
+export interface WeDpiStage {
+  x: number;
+  y: number;
+  flags: number;
+}
+
+export interface WeProfile {
+  activeDpiLevel: number;
+  dpiStageCount: number;
+  pollingRateHz: number;
+  lod: WeLod | null;
+  lodRaw: number | null;
+  debounceMs: number | null;
+  sleepRaw: number | null;
+  stages: WeDpiStage[];
+  /** Active stage CPI (X axis). */
+  dpi: number;
+}
+
+/** Sum of reportId + first 15 payload bytes; last payload byte is checksum. */
+export function weReportChecksum(reportId: number, data15: readonly number[]): number {
+  let sum = reportId;
+  for (const byte of data15) sum += byte & 0xff;
+  return (WE_CHECKSUM_TARGET - (sum & 0xff)) & 0xff;
+}
+
+/** Build 16-byte WebHID feature payload (no report id). */
+export function weBuildCmdPayload(cmd: number, dataAfterCmd: readonly number[] = []): Uint8Array {
+  const payload = new Uint8Array(WE_PAYLOAD_LEN);
+  payload[0] = cmd & 0xff;
+  for (let i = 0; i < Math.min(14, dataAfterCmd.length); i += 1) {
+    payload[i + 1] = dataAfterCmd[i]! & 0xff;
+  }
+  const data15 = [...payload.subarray(0, 15)];
+  payload[15] = weReportChecksum(WE_REPORT_ID, data15);
+  return payload;
+}
+
+export function weBuildReadEepromPayload(addr: number, length: number): Uint8Array {
+  if (!Number.isInteger(length) || length < 1 || length > WE_MAX_EEPROM_CHUNK) {
+    throw new Error(`WE ReadEEPROM length must be 1–${WE_MAX_EEPROM_CHUNK}.`);
+  }
+  if (!Number.isInteger(addr) || addr < 0 || addr > 0xffff) {
+    throw new Error("WE EEPROM address out of range.");
+  }
+  const hi = (addr >> 8) & 0xff;
+  const lo = addr & 0xff;
+  return weBuildCmdPayload(WE_CMD_READ_EEPROM, [0, hi, lo, length]);
+}
+
+export function weBuildWriteEepromPayload(addr: number, data: readonly number[]): Uint8Array {
+  if (data.length < 1 || data.length > WE_MAX_EEPROM_CHUNK) {
+    throw new Error(`WE WriteEEPROM length must be 1–${WE_MAX_EEPROM_CHUNK}.`);
+  }
+  if (!Number.isInteger(addr) || addr < 0 || addr > 0xffff) {
+    throw new Error("WE EEPROM address out of range.");
+  }
+  const hi = (addr >> 8) & 0xff;
+  const lo = addr & 0xff;
+  return weBuildCmdPayload(WE_CMD_WRITE_EEPROM, [0, hi, lo, data.length, ...data.map((b) => b & 0xff)]);
+}
+
+/**
+ * Parse input report 9 body (WebHID omits report id).
+ * ReadEEPROM success: [cmd, status, 0, addr_lo, len, data…]
+ */
+export function weParseReadEepromResponse(
+  response: Uint8Array,
+  expectedAddr: number,
+  expectedLen: number,
+): Uint8Array | null {
+  let data = response;
+  if (data.length > 0 && data[0] === 0x09) data = data.subarray(1);
+  if (data.length < 5 + expectedLen) return null;
+  if (data[0] !== WE_CMD_READ_EEPROM) return null;
+  if (data[1] !== 0) return null;
+  if (data[3] !== (expectedAddr & 0xff)) return null;
+  if (data[4] !== expectedLen) return null;
+  return data.subarray(5, 5 + expectedLen);
+}
+
+/** WriteEEPROM ACK: status 0 and optional echo. */
+export function weParseWriteEepromResponse(response: Uint8Array): boolean {
+  let data = response;
+  if (data.length > 0 && data[0] === 0x09) data = data.subarray(1);
+  if (data.length < 2) return false;
+  return data[0] === WE_CMD_WRITE_EEPROM && data[1] === 0;
+}
+
+export function weScalarCrc(value: number): number {
+  return (WE_CHECKSUM_TARGET - (value & 0xff)) & 0xff;
+}
+
+export function wePackScalarPair(value: number): [number, number] {
+  const v = value & 0xff;
+  return [v, weScalarCrc(v)];
+}
+
+export function weUnpackScalarPair(value: number, crc: number): number | null {
+  if (weScalarCrc(value) !== (crc & 0xff)) return null;
+  return value & 0xff;
+}
+
+/** CPI ↔ stage byte: cpi = (byte + 1) * 50  (50…12800). */
+export function weCpiToByte(cpi: number): number {
+  if (!Number.isInteger(cpi) || cpi < 50 || cpi > 12800 || cpi % 50 !== 0) {
+    throw new Error("WE CPI must be 50–12,800 in steps of 50.");
+  }
+  return cpi / 50 - 1;
+}
+
+export function weByteToCpi(byte: number): number {
+  return ((byte & 0xff) + 1) * 50;
+}
+
+export function weStageCrc(x: number, y: number, flags: number): number {
+  return (WE_CHECKSUM_TARGET - ((x + y + flags) & 0xff)) & 0xff;
+}
+
+export function wePackDpiStage(xCpi: number, yCpi: number, flags = 0): Uint8Array {
+  const x = weCpiToByte(xCpi);
+  const y = weCpiToByte(yCpi);
+  const f = flags & 0xff;
+  return new Uint8Array([x, y, f, weStageCrc(x, y, f)]);
+}
+
+export function weUnpackDpiStage(bytes: Uint8Array | readonly number[]): WeDpiStage | null {
+  if (bytes.length < 4) return null;
+  const x = bytes[0]! & 0xff;
+  const y = bytes[1]! & 0xff;
+  const flags = bytes[2]! & 0xff;
+  const crc = bytes[3]! & 0xff;
+  if (weStageCrc(x, y, flags) !== crc) return null;
+  return { x: weByteToCpi(x), y: weByteToCpi(y), flags };
+}
+
+export function weEncodeLod(value: WeLod): number {
+  if (value === "Medium") return 1;
+  if (value === "High") return 2;
+  throw new Error("OP1we LOD supports Medium (1 mm class) or High only.");
+}
+
+export function weDecodeLod(raw: number): WeLod | null {
+  if (raw === 1) return "Medium";
+  if (raw === 2) return "High";
+  return null;
+}
+
+/** Divider byte → Hz (1=1000, 2=500, 4=250, 8=125). */
+export function weDecodeReportRate(raw: number): number | null {
+  const map: Record<number, number> = { 1: 1000, 2: 500, 4: 250, 8: 125 };
+  return map[raw & 0xff] ?? null;
+}
+
+export function weEncodeReportRate(hz: number): number {
+  const map: Record<number, number> = { 1000: 1, 500: 2, 250: 4, 125: 8 };
+  if (!(hz in map)) {
+    throw new Error("OP1we supports 125, 250, 500, or 1000 Hz report rate.");
+  }
+  return map[hz]!;
+}
+
+export function weIsValidPollingRate(hz: number): hz is WePollingRate {
+  return (WE_POLLING_RATES as readonly number[]).includes(hz);
+}
+
+/**
+ * Decode a contiguous profile memory image starting at address 0
+ * (at least through 0xB4 for full basics).
+ */
+export function weDecodeProfile(mem: Uint8Array): WeProfile {
+  const pair = (addr: number): number | null => {
+    if (mem.length < addr + 2) return null;
+    return weUnpackScalarPair(mem[addr]!, mem[addr + 1]!);
+  };
+
+  const activeDpiLevel = pair(WE_OFF.activeDpiLevel) ?? 0;
+  let dpiStageCount = pair(WE_OFF.dpiStageCount) ?? 1;
+  dpiStageCount = Math.min(Math.max(dpiStageCount, 1), WE_OFF.maxDpiStages);
+
+  const rateRaw = pair(WE_OFF.reportRate);
+  const pollingRateHz = rateRaw !== null ? (weDecodeReportRate(rateRaw) ?? 1000) : 1000;
+
+  const lodRaw = pair(WE_OFF.lod);
+  const debounceMs = pair(WE_OFF.debounce);
+  const sleepRaw = pair(WE_OFF.sleep);
+
+  const stages: WeDpiStage[] = [];
+  for (let i = 0; i < WE_OFF.maxDpiStages; i += 1) {
+    const off = WE_OFF.dpiStages + i * WE_OFF.dpiStageBytes;
+    if (mem.length < off + 4) break;
+    const stage = weUnpackDpiStage(mem.subarray(off, off + 4));
+    if (stage) stages.push(stage);
+    else stages.push({ x: 800, y: 800, flags: 0 });
+  }
+
+  const level = Math.min(Math.max(activeDpiLevel, 0), Math.max(stages.length - 1, 0));
+  const active = stages[level] ?? stages[0];
+  const dpi = active?.x ?? 800;
+
+  return {
+    activeDpiLevel: level,
+    dpiStageCount,
+    pollingRateHz,
+    lod: lodRaw !== null ? weDecodeLod(lodRaw) : null,
+    lodRaw,
+    debounceMs,
+    sleepRaw,
+    stages,
+    dpi,
+  };
+}
+
+/** Patch DPI stages 0..count-1 in a profile image (same CPI on X/Y). */
+export function wePatchAllActiveDpi(mem: Uint8Array, cpi: number, stageCount: number): void {
+  const count = Math.min(Math.max(stageCount, 1), WE_OFF.maxDpiStages);
+  const packed = wePackDpiStage(cpi, cpi, 0);
+  for (let i = 0; i < count; i += 1) {
+    const off = WE_OFF.dpiStages + i * WE_OFF.dpiStageBytes;
+    mem.set(packed, off);
+  }
+}
+
+export function wePatchScalar(mem: Uint8Array, addr: number, value: number): void {
+  const [v, c] = wePackScalarPair(value);
+  mem[addr] = v;
+  mem[addr + 1] = c;
+}
+
+export function weIsValidCpi(cpi: number): boolean {
+  return Number.isInteger(cpi) && cpi >= 50 && cpi <= 12800 && cpi % 50 === 0;
+}

--- a/src/mouse-types.ts
+++ b/src/mouse-types.ts
@@ -1,6 +1,32 @@
+/**
+ * Optional UI policy from a driver (used by control.ts).
+ * Drivers added in a PR should set only the flags they need so the shell
+ * stays free of brand-specific branching.
+ */
+export interface MouseUiHints {
+  /** Stable driver id, e.g. "egg-we". */
+  family?: string;
+  /** When false, core settings grid stays hidden. Default true. */
+  settingsReady?: boolean;
+  /** Hide 0.7 mm LOD option. */
+  hideLodLow?: boolean;
+  /** Hide poll rates not listed in supportedPollingRates. */
+  hideUnsupportedPollingRates?: boolean;
+  /** Hide Motion Sync / angle snap / ripple card. */
+  hideProcessingCard?: boolean;
+  /** Always show battery column (even wired with null %). */
+  forceShowBattery?: boolean;
+  /** Override the polling-rate footnote. */
+  pollingNote?: string;
+  /** Sidebar name before first status read. */
+  defaultDisplayName?: string;
+}
+
 export interface MouseStatus {
   brand: "Logitech" | "Pulsar" | "Endgame Gear";
   name: string;
+  /** Driver-supplied UI policy (optional; keeps control.ts brand-agnostic). */
+  ui?: MouseUiHints;
   batteryPercent: number | null;
   batteryVoltageMv?: number | null;
   batteryState: "Charging" | "Charging slowly" | "Almost full" | "Full" | "Discharging" | "Unknown";

--- a/src/webhid.d.ts
+++ b/src/webhid.d.ts
@@ -15,8 +15,14 @@ interface HIDConnectionEvent extends Event {
   readonly device: HIDDevice;
 }
 
+interface HIDReportItem {
+  readonly reportSize: number;
+  readonly reportCount: number;
+}
+
 interface HIDReportInfo {
   readonly reportId: number;
+  readonly items: readonly HIDReportItem[];
 }
 
 interface HIDCollectionInfo {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }
 


### PR DESCRIPTION
## Adding op1we (and some other WE models) support to openmouse

> TL;DR: added support for op1we (both wired and wireless)

<img width="990" height="460" alt="image" src="https://github.com/user-attachments/assets/dce0ce09-cb4b-4c97-b34a-2ab2fa337d4a" />

### What is working (tested only on op1we):
- [X] Sensitivity Changes
- [X] Polling rate 
- [X] Lift off distance

### Some slight issues/things to know:

- Battery percentage on wired is slightly off, for example at full charge it is as 90%, _will try to fix_, but might either remove, or add approx (~) to compensate. Thoughts?

### Files added:

`src/egg-we-protocol.ts` Pure WE protocol
`src/egg-we-hid.ts` Live WebHID client: battery, profile R/W, cable + wireless
`src/egg-we-control.ts` Essentially the extension of control.ts, but in a separate file, so control.ts doesn't get too large.
`src/control.ts` Wire WE into connect/sidebar/UI via control helpers + status.ui
`src/mouse-types.ts` Optional MouseUiHints so drivers declare UI without brand branches

> **Before even considering merging, we should first test this with other op1we users, and then also snekxs should prob check that I am not editing any files that he doesn't want to be changed. I have tried to keep things as separate as possible to ensure that we don't come across merge conflicts.**

W idea hope all goes well, I will def use this when it is released.
