### PR TITLE
feat: add ATK A9 device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm run check
 The control panel is organized by responsibility: `control.ts` coordinates the
 application, while the template, events, DOM helpers, persisted preferences,
 battery history, and device-client selection live in focused modules under
-`src/`. Vendor drivers are grouped under `src/devices/`: `endgame/`,
+`src/`. Vendor drivers are grouped under `src/devices/`: `atk/`, `endgame/`,
 `logitech/`, `pulsar/`, and `wlmouse/`; shared device types and HID filters
 remain directly under `src/devices/`.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The control panel is organized by responsibility: `control.ts` coordinates the
 application, while the template, events, DOM helpers, persisted preferences,
 battery history, and device-client selection live in focused modules under
 `src/`. Vendor drivers are grouped under `src/devices/`: `atk/`, `endgame/`,
-`logitech/`, `pulsar/`, `wlmouse/` and `teevolution/`; shared device types and HID filters
+`logitech/`, `pulsar/`, `razer/`, `teevolution/`, and `wlmouse/`; shared device types and HID filters
 remain directly under `src/devices/`.
 
 ## Adding a vendor

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test src/*.test.ts src/devices/endgame/*.test.ts src/devices/orbital/*.test.ts",
+    "test": "node --test src/*.test.ts src/devices/atk/*.test.ts src/devices/endgame/*.test.ts src/devices/orbital/*.test.ts",
     "check": "npm run build && npm test",
     "preview": "vite preview"
   },

--- a/src/control.css
+++ b/src/control.css
@@ -68,7 +68,9 @@
   .control-shell .device-overview .summary-stat small { margin-top: .1rem; }
   .control-shell .device-overview .summary-stat > span, .control-shell .setting-heading p { margin-bottom: .3rem; }
   .control-shell .device-overview .meter { margin-top: .4rem; }
-  .control-shell .settings-grid { flex: 0 0 auto; grid-template-columns: 1.2fr .9fr .9fr; grid-template-rows: 176px; gap: .65rem; margin-top: .65rem; }
+  /* Cards grow past the shared row height when a driver adds a third preset
+     row, e.g. a mouse sitting on a custom DPI gets a seventh preset button. */
+  .control-shell .settings-grid { flex: 0 0 auto; grid-template-columns: 1.2fr .9fr .9fr; grid-template-rows: minmax(176px, auto); gap: .65rem; margin-top: .65rem; }
   .control-shell .setting-card { min-height: 176px; padding: .85rem; }
   .control-shell .dpi-card { grid-row: auto; }
   .control-shell .setting-heading { margin-bottom: .75rem; }

--- a/src/control.ts
+++ b/src/control.ts
@@ -39,6 +39,7 @@ import {
   isEggWeClient,
   type EggWeHidClient,
 } from "./devices/endgame/egg-we-control";
+import { AtkHidClient } from "./devices/atk/hid";
 import { LamzuHidClient } from "./devices/lamzu/hid";
 import { LogitechHidppClient } from "./devices/logitech/hidpp";
 import type { MouseStatus } from "./devices/mouse-types";
@@ -60,7 +61,7 @@ let activeClient: LogitechHidppClient | null = null;
 let activePulsarClient: PulsarClient | null = null;
 let activeEggClient: EggOp1HidClient | null = null;
 let activeEggWeClient: EggWeHidClient | null = null;
-let activeDmClient: WLMouseHidClient | LamzuHidClient | null = null;
+let activeDmClient: WLMouseHidClient | LamzuHidClient | AtkHidClient | null = null;
 let activeOrbitalClient: OrbitalHidClient | null = null;
 let refreshTimer: number | null = null;
 let refreshInProgress = false;
@@ -439,7 +440,7 @@ function showStatus(status: MouseStatus): void {
     || (status.brand === "Endgame Gear" && Array.isArray(status.eggCpiStages));
   const isEggWe = ui?.family === "egg-we" || activeEggWeClient !== null;
   const isEgg = isEgg8k || isEggWe;
-  const isDmFamily = ui?.family === "wlmouse" || ui?.family === "lamzu" || activeDmClient !== null;
+  const isDmFamily = ui?.family === "wlmouse" || ui?.family === "lamzu" || ui?.family === "atk" || activeDmClient !== null;
   const settingsPending = ui?.settingsReady === false;
   const isWired = status.connectionType === "Wired";
   // Always clear device-specific panels first. A status read from the previous
@@ -724,7 +725,7 @@ async function activateClient(client: SupportedClient): Promise<void> {
   activeDevice = client.device;
   recordDiagnosticCommand("Read device status");
   lastRenderedStatusKey = null;
-  if (client instanceof WLMouseHidClient || client instanceof LamzuHidClient) {
+  if (client instanceof WLMouseHidClient || client instanceof LamzuHidClient || client instanceof AtkHidClient) {
     activeDmClient = client;
     const status = await client.readStatus();
     deviceStatuses.set(client.device, status);

--- a/src/devices/atk/hid.ts
+++ b/src/devices/atk/hid.ts
@@ -1,0 +1,413 @@
+import {
+  WE_CMD_READ_EEPROM,
+  WE_CMD_WRITE_EEPROM,
+  WE_REPORT_ID,
+  weBuildCmdPayload,
+  wePackScalarPair,
+} from "../endgame/egg-we-protocol";
+import type { MouseStatus } from "../mouse-types";
+import { VENDOR_ID } from "../vendors";
+import { atkDecodeLiftOff, atkPackDpiStage, atkUnpackDpiStage } from "./protocol";
+
+// ATK mice (A9 family and siblings) use the same OEM framing as the Endgame
+// Gear WE series — 16-byte EEPROM commands on report 0x08 — but carry them on
+// output/input reports rather than feature reports.
+const BATTERY_COMMAND = 0x04;
+const VERSION_COMMAND = 0x12;
+const FRAME_LENGTH = 16;
+const DATA_OFFSET = 5;
+const MAX_DATA_LENGTH = 10;
+const REPLY_TIMEOUT_MS = 500;
+const WRITE_SETTLE_MS = 10;
+
+// Byte addresses in the mouse's configuration EEPROM.
+const REGISTER = {
+  // 0x0000: polling rate, DPI stage count, active DPI stage (value/checksum pairs).
+  system: 0x0000,
+  liftOffDistance: 0x000a,
+  // Four bytes per DPI stage.
+  dpiBase: 0x000c,
+  // 0x00a9: debounce, motion sync, sleep timer, linear correction, ripple control.
+  advanced: 0x00a9,
+  // 0x00bd: angle tuning degrees, then the angle-snapping enable flag.
+  angle: 0x00bd,
+} as const;
+
+const SYSTEM_LENGTH = 6;
+const ADVANCED_LENGTH = 10;
+const ANGLE_LENGTH = 4;
+const DPI_STAGE_LENGTH = 4;
+const MAX_DPI_STAGES = 6;
+
+const DPI_MIN = 50;
+const DPI_MAX = 42000;
+const DEBOUNCE_MAX_MS = 15;
+const SLEEP_STEP_SECONDS = 10;
+const SLEEP_MAX_SECONDS = 0xff * SLEEP_STEP_SECONDS;
+const SLEEP_SECONDS: readonly number[] = [30, 60, 120, 300, 600, 1800];
+
+const POLLING_RATES: ReadonlyArray<readonly [number, number]> = [
+  [0x08, 125],
+  [0x04, 250],
+  [0x02, 500],
+  [0x01, 1000],
+  [0x10, 2000],
+  [0x20, 4000],
+  [0x40, 8000],
+];
+
+type LiftOffDistance = NonNullable<MouseStatus["liftOffDistance"]>;
+
+/** Register codes are tenths of a millimetre offset by 6 (1 = 0.7 mm). */
+const LIFT_OFF_CODES: ReadonlyArray<readonly [number, LiftOffDistance]> = [
+  [1, "Low"],
+  [4, "Medium"],
+  [11, "High"],
+];
+
+export class AtkHidClient {
+  // Sleep is stored in 10-second units with no "never" value.
+  readonly canDisableSleep = false;
+  // Written out rather than a parameter property so node --test can strip types.
+  readonly device: HIDDevice;
+
+  private queue: Promise<unknown> = Promise.resolve();
+  private lastStatus: MouseStatus | null = null;
+
+  constructor(device: HIDDevice) {
+    this.device = device;
+  }
+
+  static isSupported(device: HIDDevice): boolean {
+    const search = (collection: HIDCollectionInfo): boolean =>
+      (collection.usagePage === 0xff02 && collection.usage === 0x0002)
+      || collection.children.some(search);
+    return device.vendorId === VENDOR_ID.atk && device.collections.some(search);
+  }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) await this.device.open();
+  }
+
+  async close(): Promise<void> {
+    this.lastStatus = null;
+    if (this.device.opened) await this.device.close();
+  }
+
+  /** ATK broadcasts are undocumented; the panel falls back to polling. */
+  async startNotifications(): Promise<boolean> {
+    return false;
+  }
+
+  displayName(): string {
+    const name = this.device.productName?.trim();
+    if (!name) return "ATK";
+    return /^atk/i.test(name) ? name : `ATK ${name}`;
+  }
+
+  maxDpi(): number {
+    return DPI_MAX;
+  }
+
+  getSleepOptions(): readonly number[] {
+    return SLEEP_SECONDS;
+  }
+
+  getDebounceMaxMs(): number {
+    return DEBOUNCE_MAX_MS;
+  }
+
+  getSupportedPollingRates(): number[] {
+    return POLLING_RATES.map(([, hertz]) => hertz);
+  }
+
+  /**
+   * The encoding steps by 10 DPI, then 50 above 10,000 and 100 above 30,000.
+   * Models top out below 42,000; writes are confirmed by reading back.
+   */
+  getDpiOptions(): number[] {
+    const options: number[] = [];
+    for (let dpi = DPI_MIN; dpi <= 10000; dpi += 10) options.push(dpi);
+    for (let dpi = 10050; dpi <= 30000; dpi += 50) options.push(dpi);
+    for (let dpi = 30100; dpi <= DPI_MAX; dpi += 100) options.push(dpi);
+    return options;
+  }
+
+  async readStatus(live = false): Promise<MouseStatus> {
+    await this.open();
+    const battery = await this.readBattery();
+    const system = await this.read(REGISTER.system, SYSTEM_LENGTH);
+    const stage = await this.readDpiStage(this.stageIndex(system));
+    if (live && this.lastStatus) {
+      return this.lastStatus = {
+        ...this.lastStatus,
+        batteryPercent: battery,
+        pollingRateHz: this.decodePollingRate(system[0]),
+        dpi: stage.x,
+        dpiY: stage.y,
+      };
+    }
+    const firmware = await this.readFirmware();
+    const liftOffDistance = await this.read(REGISTER.liftOffDistance, 2);
+    const advanced = await this.read(REGISTER.advanced, ADVANCED_LENGTH);
+    const angle = await this.read(REGISTER.angle, ANGLE_LENGTH).catch(() => null);
+    return this.lastStatus = {
+      brand: "ATK",
+      name: this.displayName(),
+      ui: {
+        family: "atk",
+        hideUnsupportedPollingRates: true,
+        forceShowBattery: battery !== null,
+      },
+      batteryPercent: battery,
+      batteryState: "Unknown",
+      dpi: stage.x,
+      dpiY: stage.y,
+      supportsSeparateDpiAxes: false,
+      pollingRateHz: this.decodePollingRate(system[0]),
+      supportedPollingRates: this.getSupportedPollingRates(),
+      activeProfile: null,
+      connectionType: battery === null ? "Wired" : "Wireless",
+      connectionDetail: battery === null ? "Wired USB" : "2.4 GHz receiver",
+      debounceMs: advanced[0],
+      motionSync: advanced[2] === 1,
+      sleepTimeout: advanced[4] * SLEEP_STEP_SECONDS || null,
+      rippleControl: advanced[8] === 1,
+      angleSnapping: angle ? angle[2] === 1 : null,
+      angleTuning: angle ? this.decodeAngle(angle[0]) : null,
+      liftOffDistance: this.decodeLiftOffDistance(liftOffDistance[0]),
+      firmware,
+    };
+  }
+
+  async setPollingRate(pollingRateHz: number): Promise<number> {
+    const encoded = POLLING_RATES.find(([, hertz]) => hertz === pollingRateHz);
+    if (!encoded) throw new Error(`This mouse does not support ${pollingRateHz} Hz.`);
+    await this.write(REGISTER.system, wePackScalarPair(encoded[0]));
+    const confirmed = this.decodePollingRate((await this.read(REGISTER.system, SYSTEM_LENGTH))[0]);
+    if (confirmed !== pollingRateHz) {
+      throw new Error(`The mouse kept ${confirmed} Hz instead of ${pollingRateHz} Hz.`);
+    }
+    this.patch({ pollingRateHz: confirmed });
+    return confirmed;
+  }
+
+  async setDpi(dpi: number, dpiY: number = dpi): Promise<number> {
+    for (const value of [dpi, dpiY]) {
+      if (!Number.isInteger(value) || value < DPI_MIN || value > DPI_MAX) {
+        throw new Error(`${value.toLocaleString()} is not a supported DPI value.`);
+      }
+    }
+    const index = this.stageIndex(await this.read(REGISTER.system, SYSTEM_LENGTH));
+    await this.write(this.dpiAddress(index), atkPackDpiStage(dpi, dpiY));
+    const confirmed = await this.readDpiStage(index);
+    if (confirmed.x !== dpi || confirmed.y !== dpiY) {
+      throw new Error(`The mouse kept ${confirmed.x.toLocaleString()} DPI instead of ${dpi.toLocaleString()}.`);
+    }
+    this.patch({ dpi: confirmed.x, dpiY: confirmed.y });
+    return confirmed.x;
+  }
+
+  async setLiftOffDistance(value: LiftOffDistance): Promise<LiftOffDistance> {
+    const encoded = LIFT_OFF_CODES.find(([, name]) => name === value);
+    if (!encoded) throw new Error(`This mouse does not support a ${value.toLowerCase()} lift-off distance.`);
+    await this.write(REGISTER.liftOffDistance, wePackScalarPair(encoded[0]));
+    const confirmed = this.decodeLiftOffDistance((await this.read(REGISTER.liftOffDistance, 2))[0]);
+    if (confirmed !== value) {
+      throw new Error(`The mouse kept a ${String(confirmed).toLowerCase()} lift-off distance instead of ${value.toLowerCase()}.`);
+    }
+    this.patch({ liftOffDistance: confirmed });
+    return confirmed;
+  }
+
+  async setMotionSync(enabled: boolean): Promise<boolean> {
+    return await this.setAdvancedFlag(2, enabled, "motionSync", "Motion Sync");
+  }
+
+  async setRippleControl(enabled: boolean): Promise<boolean> {
+    return await this.setAdvancedFlag(8, enabled, "rippleControl", "ripple control");
+  }
+
+  async setAngleSnapping(enabled: boolean): Promise<boolean> {
+    const group = await this.read(REGISTER.angle, ANGLE_LENGTH);
+    await this.write(REGISTER.angle, [group[0], enabled ? 1 : 0].flatMap((value) => wePackScalarPair(value)));
+    const confirmed = (await this.read(REGISTER.angle, ANGLE_LENGTH))[2] === 1;
+    if (confirmed !== enabled) throw new Error(`The mouse left angle snapping ${confirmed ? "on" : "off"}.`);
+    this.patch({ angleSnapping: confirmed });
+    return confirmed;
+  }
+
+  async setDebounceTime(milliseconds: number): Promise<number> {
+    if (!Number.isInteger(milliseconds) || milliseconds < 0 || milliseconds > DEBOUNCE_MAX_MS) {
+      throw new Error(`Debounce must be a whole number of milliseconds between 0 and ${DEBOUNCE_MAX_MS}.`);
+    }
+    const confirmed = await this.writeAdvanced(0, milliseconds);
+    if (confirmed !== milliseconds) {
+      throw new Error(`The mouse kept ${confirmed} ms of debounce instead of ${milliseconds} ms.`);
+    }
+    this.patch({ debounceMs: confirmed });
+    return confirmed;
+  }
+
+  async setSleepTimeout(seconds: number): Promise<number> {
+    if (!Number.isInteger(seconds) || seconds < SLEEP_STEP_SECONDS || seconds > SLEEP_MAX_SECONDS) {
+      throw new Error(`The sleep timeout must be between ${SLEEP_STEP_SECONDS} and ${SLEEP_MAX_SECONDS} seconds.`);
+    }
+    const units = Math.round(seconds / SLEEP_STEP_SECONDS);
+    const confirmed = await this.writeAdvanced(4, units) * SLEEP_STEP_SECONDS;
+    if (confirmed !== units * SLEEP_STEP_SECONDS) {
+      throw new Error(`The mouse kept a ${confirmed} second sleep timeout instead of ${seconds} seconds.`);
+    }
+    this.patch({ sleepTimeout: confirmed });
+    return confirmed;
+  }
+
+  private async setAdvancedFlag(
+    offset: number,
+    enabled: boolean,
+    field: "motionSync" | "rippleControl",
+    label: string,
+  ): Promise<boolean> {
+    const confirmed = await this.writeAdvanced(offset, enabled ? 1 : 0) === 1;
+    if (confirmed !== enabled) throw new Error(`The mouse left ${label} ${confirmed ? "on" : "off"}.`);
+    this.patch({ [field]: confirmed });
+    return confirmed;
+  }
+
+  /** The advanced block is written whole, so read it back, patch one pair, write. */
+  private async writeAdvanced(offset: number, value: number): Promise<number> {
+    const group = Array.from(await this.read(REGISTER.advanced, ADVANCED_LENGTH));
+    group.splice(offset, 2, ...wePackScalarPair(value));
+    await this.write(REGISTER.advanced, group);
+    return (await this.read(REGISTER.advanced, ADVANCED_LENGTH))[offset];
+  }
+
+  private dpiAddress(index: number): number {
+    return REGISTER.dpiBase + index * DPI_STAGE_LENGTH;
+  }
+
+  private async readDpiStage(index: number): Promise<{ x: number; y: number }> {
+    const stage = atkUnpackDpiStage(await this.read(this.dpiAddress(index), DPI_STAGE_LENGTH));
+    if (!stage) throw new Error("The mouse reported a DPI stage that failed its checksum.");
+    return stage;
+  }
+
+  private stageIndex(system: Uint8Array): number {
+    const stages = Math.min(Math.max(system[2], 1), MAX_DPI_STAGES);
+    return Math.min(system[4], stages - 1);
+  }
+
+  private decodePollingRate(value: number): number {
+    const match = POLLING_RATES.find(([code]) => code === value);
+    if (!match) throw new Error(`The mouse reported an unknown polling-rate value 0x${value.toString(16)}.`);
+    return match[1];
+  }
+
+  private decodeLiftOffDistance(code: number): LiftOffDistance | null {
+    const millimetres = atkDecodeLiftOff(code);
+    if (millimetres === null) return null;
+    if (millimetres < 1) return "Low";
+    return millimetres < 1.5 ? "Medium" : "High";
+  }
+
+  private decodeAngle(byte: number): number {
+    return byte > 0x80 ? byte - 0x100 : byte;
+  }
+
+  private patch(changes: Partial<MouseStatus>): void {
+    if (this.lastStatus) this.lastStatus = { ...this.lastStatus, ...changes };
+  }
+
+  /**
+   * Command 0x12 (GetMouseVersion) is named by libatk-rs but its payload is not
+   * documented, so the reply is reported as major.minor and the raw bytes are
+   * kept alongside it until a device confirms the layout.
+   */
+  private async readFirmware(): Promise<string[]> {
+    const reply = await this.exchange(
+      weBuildCmdPayload(VERSION_COMMAND),
+      (frame) => frame[0] === VERSION_COMMAND,
+    ).catch(() => null);
+    if (!reply) return [];
+    const data = reply.subarray(DATA_OFFSET, DATA_OFFSET + Math.min(reply[4], MAX_DATA_LENGTH));
+    if (data.length < 2) return [];
+    const bytes = [...data].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
+    return [`Mouse ${data[0]}.${data[1]}`, `Reported bytes ${bytes}`];
+  }
+
+  private async readBattery(): Promise<number | null> {
+    const reply = await this.exchange(
+      weBuildCmdPayload(BATTERY_COMMAND),
+      (frame) => frame[0] === BATTERY_COMMAND,
+    ).catch(() => null);
+    return reply ? Math.min(reply[DATA_OFFSET], 100) : null;
+  }
+
+  private async read(address: number, length: number): Promise<Uint8Array> {
+    const reply = await this.exchange(
+      weBuildCmdPayload(WE_CMD_READ_EEPROM, [0, (address >> 8) & 0xff, address & 0xff, length]),
+      // Some firmware answers a read with the write command id.
+      (frame) => (frame[0] === WE_CMD_READ_EEPROM || frame[0] === WE_CMD_WRITE_EEPROM)
+        && frame[2] === ((address >> 8) & 0xff)
+        && frame[3] === (address & 0xff)
+        && frame[4] >= length,
+    );
+    return reply.subarray(DATA_OFFSET, DATA_OFFSET + length);
+  }
+
+  private async write(address: number, data: readonly number[]): Promise<void> {
+    const payload = weBuildCmdPayload(
+      WE_CMD_WRITE_EEPROM,
+      [0, (address >> 8) & 0xff, address & 0xff, data.length, ...data],
+    );
+    await this.run(async () => {
+      await this.open();
+      // Copy for an ArrayBuffer-backed view, as the WebHID typings require.
+      await this.device.sendReport(WE_REPORT_ID, new Uint8Array(payload).buffer);
+      await delay(WRITE_SETTLE_MS);
+    });
+  }
+
+  /** Send a frame and resolve with the first input report the matcher accepts. */
+  private async exchange(frame: Uint8Array, matches: (frame: Uint8Array) => boolean): Promise<Uint8Array> {
+    return await this.run(async () => {
+      await this.open();
+      return await new Promise<Uint8Array>((resolve, reject) => {
+        const finish = () => {
+          clearTimeout(timer);
+          this.device.removeEventListener("inputreport", listener);
+        };
+        const timer = setTimeout(() => {
+          finish();
+          reject(new Error("The mouse did not answer — it may be asleep or out of range."));
+        }, REPLY_TIMEOUT_MS);
+        const listener = (event: HIDInputReportEvent) => {
+          if (event.reportId !== WE_REPORT_ID) return;
+          const reply = copyDataView(event.data);
+          if (reply.length < FRAME_LENGTH || !matches(reply)) return;
+          finish();
+          resolve(reply);
+        };
+        this.device.addEventListener("inputreport", listener);
+        this.device.sendReport(WE_REPORT_ID, new Uint8Array(frame).buffer).catch((error: unknown) => {
+          finish();
+          reject(error);
+        });
+      });
+    });
+  }
+
+  private async run<T>(task: () => Promise<T>): Promise<T> {
+    const started = this.queue.then(task, task);
+    this.queue = started.catch(() => undefined);
+    return await started;
+  }
+}
+
+function copyDataView(view: DataView): Uint8Array {
+  return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/src/devices/atk/hid.ts
+++ b/src/devices/atk/hid.ts
@@ -105,6 +105,15 @@ export class AtkHidClient {
     return /^atk/i.test(name) ? name : `ATK ${name}`;
   }
 
+  /**
+   * A wired A9 still reports a battery level, so the receiver is identified by
+   * its own product string instead: "ATK Nearlink Mouse Dongle" against the
+   * mouse's own "ATK A9 PLUS 2.0 NK".
+   */
+  isWireless(): boolean {
+    return /receiver|dongle/i.test(this.device.productName || "");
+  }
+
   maxDpi(): number {
     return DPI_MAX;
   }
@@ -167,8 +176,8 @@ export class AtkHidClient {
       pollingRateHz: this.decodePollingRate(system[0]),
       supportedPollingRates: this.getSupportedPollingRates(),
       activeProfile: null,
-      connectionType: battery === null ? "Wired" : "Wireless",
-      connectionDetail: battery === null ? "Wired USB" : "2.4 GHz receiver",
+      connectionType: this.isWireless() ? "Wireless" : "Wired",
+      connectionDetail: this.isWireless() ? "2.4 GHz receiver" : "Wired USB",
       debounceMs: advanced[0],
       motionSync: advanced[2] === 1,
       sleepTimeout: advanced[4] * SLEEP_STEP_SECONDS || null,

--- a/src/devices/atk/hid.ts
+++ b/src/devices/atk/hid.ts
@@ -319,9 +319,8 @@ export class AtkHidClient {
   }
 
   /**
-   * Command 0x12 (GetMouseVersion) is named by libatk-rs but its payload is not
-   * documented, so the reply is reported as major.minor and the raw bytes are
-   * kept alongside it until a device confirms the layout.
+   * Command 0x12 (GetMouseVersion) reports the version as BCD, matching the
+   * Endgame Gear siblings: an A9 Nearlink dongle answering 0x01 0x23 is 1.23.
    */
   private async readFirmware(): Promise<string[]> {
     const reply = await this.exchange(
@@ -331,8 +330,8 @@ export class AtkHidClient {
     if (!reply) return [];
     const data = reply.subarray(DATA_OFFSET, DATA_OFFSET + Math.min(reply[4], MAX_DATA_LENGTH));
     if (data.length < 2) return [];
-    const bytes = [...data].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
-    return [`Mouse ${data[0]}.${data[1]}`, `Reported bytes ${bytes}`];
+    const bcd = (byte: number) => byte.toString(16).padStart(2, "0");
+    return [`Mouse ${Number(bcd(data[0]))}.${bcd(data[1])}`];
   }
 
   private async readBattery(): Promise<number | null> {

--- a/src/devices/atk/protocol.test.ts
+++ b/src/devices/atk/protocol.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  atkDecodeLiftOff,
+  atkPackDpiStage,
+  atkUnpackDpiStage,
+} from "./protocol.ts";
+
+test("DPI stages survive a round trip across every step range", () => {
+  for (const [x, y] of [[50, 50], [800, 800], [10000, 1600], [10050, 10050], [26000, 26000], [42000, 42000]]) {
+    const stage = atkPackDpiStage(x!, y!);
+    const sum = stage.reduce((total, byte) => total + byte, 0);
+
+    assert.equal(sum & 0xff, 0x55, `stage checksum for ${x}/${y}`);
+    assert.deepEqual(atkUnpackDpiStage(stage), { x, y });
+  }
+});
+
+test("DPI stages with a corrupt checksum are rejected", () => {
+  const stage = atkPackDpiStage(1600, 1600);
+  stage[3] ^= 0xff;
+
+  assert.equal(atkUnpackDpiStage(stage), null);
+  assert.equal(atkUnpackDpiStage([1, 2, 3]), null);
+});
+
+test("Lift-off codes decode to millimetres", () => {
+  assert.equal(atkDecodeLiftOff(1), 0.7);
+  assert.equal(atkDecodeLiftOff(4), 1);
+  assert.equal(atkDecodeLiftOff(11), 1.7);
+  assert.equal(atkDecodeLiftOff(0), null);
+});

--- a/src/devices/atk/protocol.ts
+++ b/src/devices/atk/protocol.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure ATK (A9 family) DPI codec, unit-tested without WebHID.
+ *
+ * ATK shares the Endgame Gear WE framing (see egg-we-protocol.ts): feature
+ * command 0x08 reads an EEPROM address, 0x07 writes one, every frame and every
+ * value/checksum pair sums to 0x55. Only the DPI stage encoding differs — ATK
+ * packs a mode nibble per axis so newer sensors reach 42,000 DPI.
+ */
+
+const CHECKSUM_TOTAL = 0x55;
+
+/**
+ * Per-axis mode nibble: bits 2-3 extend the value byte, bit 1 selects the
+ * 50-DPI step range above 10,000, bit 0 doubles the result above 30,000.
+ */
+export function atkEncodeDpiAxis(dpi: number): { byte: number; nibble: number } {
+  let value = dpi;
+  let doubled = 0;
+  if (value > 30000) {
+    doubled = 1;
+    value = Math.round(value / 2);
+  }
+  if (value <= 10000) {
+    const code = Math.floor(value / 10) - 1;
+    return { byte: code & 0xff, nibble: ((code >> 8) << 2) | doubled };
+  }
+  const code = Math.floor((value - 10050) / 50);
+  return { byte: code & 0xff, nibble: ((code >> 8) << 2) | 2 | doubled };
+}
+
+export function atkDecodeDpiAxis(byte: number, nibble: number): number {
+  const code = (((nibble >> 2) & 0x03) << 8) | (byte & 0xff);
+  const base = (nibble & 2) !== 0 ? 10050 + code * 50 : (code + 1) * 10;
+  return (nibble & 1) !== 0 ? base * 2 : base;
+}
+
+/** One DPI stage: [x, y, packed nibbles, checksum]. */
+export function atkPackDpiStage(x: number, y: number): number[] {
+  const encodedX = atkEncodeDpiAxis(x);
+  const encodedY = atkEncodeDpiAxis(y);
+  const mode = ((encodedY.nibble & 0x0f) << 4) | (encodedX.nibble & 0x0f);
+  const sum = (encodedX.byte + encodedY.byte + mode) & 0xff;
+  return [encodedX.byte, encodedY.byte, mode, (CHECKSUM_TOTAL - sum) & 0xff];
+}
+
+export function atkUnpackDpiStage(data: Uint8Array | readonly number[]): { x: number; y: number } | null {
+  if (data.length < 4) return null;
+  const sum = (data[0]! + data[1]! + data[2]! + data[3]!) & 0xff;
+  if (sum !== CHECKSUM_TOTAL) return null;
+  return {
+    x: atkDecodeDpiAxis(data[0]!, data[2]! & 0x0f),
+    y: atkDecodeDpiAxis(data[1]!, (data[2]! >> 4) & 0x0f),
+  };
+}
+
+/** Register holds tenths of a millimetre offset by 6 (code 1 = 0.7 mm). */
+export function atkDecodeLiftOff(code: number): number | null {
+  return code ? (code + 6) / 10 : null;
+}

--- a/src/devices/mouse-types.ts
+++ b/src/devices/mouse-types.ts
@@ -23,7 +23,7 @@ export interface MouseUiHints {
 }
 
 export interface MouseStatus {
-  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "Lamzu" | "Orbital";
+  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "Lamzu" | "Orbital" | "ATK";
   name: string;
   /** Driver-supplied UI policy (optional; keeps control.ts brand-agnostic). */
   ui?: MouseUiHints;

--- a/src/devices/registry.ts
+++ b/src/devices/registry.ts
@@ -1,3 +1,4 @@
+import { AtkHidClient } from "./atk/hid";
 import { EggOp1HidClient } from "./endgame/egg-op1-hid";
 import { eggWeCreate, eggWeIsSupported, eggWeSupportScore, isEggWeClient, type EggWeHidClient } from "./endgame/egg-we-control";
 import { LamzuHidClient } from "./lamzu/hid";
@@ -8,7 +9,7 @@ import { PulsarProHidClient } from "./pulsar/pulsar-pro-hid";
 import { WLMouseHidClient } from "./wlmouse/hid";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | AtkHidClient;
 
 interface DeviceDriver {
   brand: string;
@@ -26,6 +27,7 @@ const DEVICE_DRIVERS: readonly DeviceDriver[] = [
   { brand: "WLMouse", supports: (device) => WLMouseHidClient.isSupported(device), create: (device) => new WLMouseHidClient(device), score: () => 5 },
   { brand: "Lamzu", supports: (device) => LamzuHidClient.isSupported(device), create: (device) => new LamzuHidClient(device), score: () => 5 },
   { brand: "Orbital", supports: (device) => OrbitalHidClient.isSupported(device), create: (device) => new OrbitalHidClient(device), score: () => 6 },
+  { brand: "ATK", supports: (device) => AtkHidClient.isSupported(device), create: (device) => new AtkHidClient(device), score: () => 5 },
 ];
 
 function driverFor(device: HIDDevice): DeviceDriver | undefined {

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -7,6 +7,7 @@ export const VENDOR_ID = {
   lamzu: 0x373e,
   logitech: 0x046d,
   orbital: 0x1915,
+  atk: 0x373b,
 } as const;
 
 // Logitech wireless receivers that expose an HID++ control interface.
@@ -57,6 +58,7 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.wlmouse },
   { vendorId: VENDOR_ID.lamzu },
   { vendorId: VENDOR_ID.orbital, usagePage: 0xff0a, usage: 1 },
+  { vendorId: VENDOR_ID.atk, usagePage: 0xff02, usage: 2 },
   ...EGG_WE_HID_FILTERS,
   ...LOGITECH_RECEIVER_FILTERS,
 ];


### PR DESCRIPTION
## Why is this PR needed? ##

ATK's A9 family has no driver here, so those mice never reach the device picker. The vendor is missing from the WebHID filters, and the browser only offers what the filters list.

## How was it solved? ##

ATK turned out to speak the same OEM protocol this repo already implements for the Endgame Gear WE series: 16-byte EEPROM frames on report 0x08 that sum to 0x55, with command 0x08 to read an address and 0x07 to write one. So the driver imports that framing from the Endgame module instead of copying it. The part that really is ATK-specific is the DPI codec, which packs a mode nibble per axis and gets to 42,000 DPI on PAW3950-class sensors. That sits in its own module with no imports, so round-trip tests can cover it.

The client handles DPI, polling rate, lift-off distance, Motion Sync, ripple control, angle snapping, debounce, sleep, battery and firmware. Every write is confirmed by reading the register back, so a value the mouse clamps raises a specific error instead of quietly doing nothing. Devices match on vendor 0x373b plus the vendor command collection rather than a product list, and the control panel reuses the settings path WLMouse and Lamzu already take.

## Notes for reviewers (if any) ##

- Tested on an ATK A9 Nearlink dongle, 0x373b / 0x10c9. It reports battery, firmware 1.23, 320 DPI at 1000 Hz, 2 mm lift-off, 8 ms debounce, 2 minute sleep and Motion Sync on, all matching the mouse. DPI and polling writes are confirmed on the device. The other setters are written from the protocol but not exercised yet.
- The register map comes from two reverse-engineering projects that were done independently and agree byte for byte: [libatk-rs](https://github.com/cyberphantom52/libatk-rs) and [ClickSync](https://github.com/Nuitfanee/ClickSync).
- The driver offers 125 to 8000 Hz and DPI up to 42,000 because neither limit can be read from the device. Anything the mouse does not support fails on read-back rather than being hidden. Happy to gate both behind a per-product table if you would rather.
- The device name comes from the receiver, so it shows the dongle instead of the mouse model.

---

### Checklist ###

- [x] Code follows project coding standards
- [x] Best practices are followed
- [x] The issue is fully resolved
- [x] Changes are tested locally — build and 22 unit tests green, DPI and polling verified on an A9
- [x] Unit test added
- [ ] E2E test added
- [ ] Demo video uploaded OR screenshots attached (if applicable)
- [x] No breaking changes OR breaking changes are clearly mentioned
- [x] No new dependencies OR dependencies are documented — none added
- [x] Cloud / deployment changes required (clearly mentioned if yes) — none
- [x] Database migration required (clearly mentioned if yes) — none
- [x] No sensitive data (keys, secrets) included
- [x] Logs and debug code removed
