### PR TITLE
feat(logitech): Add wired Logitech G Pro X Superlight 2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test src/*.test.ts src/devices/endgame/*.test.ts src/devices/orbital/*.test.ts",
+    "test": "node --test src/*.test.ts src/devices/endgame/*.test.ts src/devices/logitech/*.test.ts src/devices/orbital/*.test.ts",
     "check": "npm run build && npm test",
     "preview": "vite preview"
   },

--- a/src/control.ts
+++ b/src/control.ts
@@ -1318,9 +1318,7 @@ async function applyLiftOffDistance(lod: NonNullable<MouseStatus["liftOffDistanc
     setText("#read-status", error instanceof Error ? error.message : "Unable to set lift-off distance.");
   } finally {
     settingInProgress = false;
-    buttons.forEach((button) => {
-      button.disabled = activeClient !== null && button.dataset.lod === "Low";
-    });
+    buttons.forEach((button) => { button.disabled = false; });
   }
 }
 

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -1,11 +1,16 @@
 import type { MouseStatus } from "../mouse-types";
+import {
+  LOGITECH_DEVICE_PROFILES,
+  LOGITECH_VENDOR_ID,
+  decodeLiftOffDistance,
+  encodeLiftOffDistance,
+  logitechDeviceProfile,
+  type LogitechDeviceProfile,
+} from "./protocol";
 
-const LOGITECH_VENDOR_ID = 0x046d;
 // HID++ control interfaces, including the PRO X 2 Superstrike USB interface.
-const LOGITECH_RECEIVER_PRODUCT_IDS = new Set([0xc54d, 0xc539, 0xc0a8]);
 const SHORT_REPORT_ID = 0x10;
 const LONG_REPORT_ID = 0x11;
-const DEVICE_INDEX = 0x01;
 
 const FEATURE = {
   deviceName: 0x0005,
@@ -69,6 +74,7 @@ interface DeviceIdentity {
 }
 
 export class LogitechHidppClient {
+  private readonly profile: LogitechDeviceProfile;
   private dpiOptionsCache: number[] | null = null;
   private dpiFeatureResolved: ResolvedFeature | null = null;
   private rateFeatureResolved: ResolvedFeature | null = null;
@@ -82,7 +88,7 @@ export class LogitechHidppClient {
     }
 
     const report = new Uint8Array(event.data.buffer.slice(event.data.byteOffset, event.data.byteOffset + event.data.byteLength));
-    if (report[0] === DEVICE_INDEX && report[1] === this.reportRateFeatureIndex && report[2] === 0x00 && report[3] === 0x01) {
+    if (report[0] === this.profile.deviceIndex && report[1] === this.reportRateFeatureIndex && report[2] === 0x00 && report[3] === 0x01) {
       const rate = REPORT_RATE_HZ[report[4] ?? -1];
       if (rate) {
         this.livePollingRateHz = rate;
@@ -92,7 +98,7 @@ export class LogitechHidppClient {
       }
     }
     const matchingIndex = this.waiters.findIndex(
-      (waiter) => report[0] === DEVICE_INDEX && report[1] === waiter.featureIndex && report[2] === waiter.functionId,
+      (waiter) => report[0] === this.profile.deviceIndex && report[1] === waiter.featureIndex && report[2] === waiter.functionId,
     );
     if (matchingIndex >= 0) {
       this.waiters.splice(matchingIndex, 1)[0].resolve(report);
@@ -101,7 +107,7 @@ export class LogitechHidppClient {
 
     // HID++ can emit a status notification between a write acknowledgement and
     // the matching read response. Leave the pending request in place and wait.
-    if (report[0] === DEVICE_INDEX && report[1] === 0xff) {
+    if (report[0] === this.profile.deviceIndex && report[1] === 0xff) {
       const failedIndex = this.waiters.findIndex(
         (waiter) => report[2] === waiter.featureIndex && report[3] === waiter.functionId,
       );
@@ -118,10 +124,14 @@ export class LogitechHidppClient {
     reject: (reason: Error) => void;
   }> = [];
 
-  constructor(readonly device: HIDDevice) {}
+  constructor(readonly device: HIDDevice) {
+    const profile = logitechDeviceProfile(device.vendorId, device.productId);
+    if (!profile) throw new Error("Unsupported Logitech HID++ device.");
+    this.profile = profile;
+  }
 
   static isSupported(device: HIDDevice): boolean {
-    if (device.vendorId !== LOGITECH_VENDOR_ID || !LOGITECH_RECEIVER_PRODUCT_IDS.has(device.productId)) {
+    if (!logitechDeviceProfile(device.vendorId, device.productId)) {
       return false;
     }
     const hasHidppCollection = (collections: readonly HIDCollectionInfo[]): boolean =>
@@ -137,7 +147,7 @@ export class LogitechHidppClient {
     }
 
     const devices = await navigator.hid.requestDevice({
-      filters: [...LOGITECH_RECEIVER_PRODUCT_IDS].map((productId) => ({
+      filters: [...LOGITECH_DEVICE_PROFILES.keys()].map((productId) => ({
         vendorId: LOGITECH_VENDOR_ID,
         productId,
         usagePage: 0xff00,
@@ -175,6 +185,8 @@ export class LogitechHidppClient {
     // also makes every input report unambiguous to the WebHID event handler.
     const name = await this.readName(nameFeature.index);
     const identity = await this.readIdentity(firmwareFeature.index);
+    const isSuperstrike = this.isSuperstrike(identity);
+    this.isSuperstrikeDevice = isSuperstrike;
     const battery = batteryFeature.index
       ? await this.readBattery(batteryFeature.index)
       : batteryVoltageFeature.index
@@ -204,9 +216,7 @@ export class LogitechHidppClient {
     const analogButtonTuning = analogButtonsFeature.index
       ? await this.readAnalogButtonTuning(analogButtonsFeature.index)
       : undefined;
-    const isSuperstrike = this.isSuperstrike(identity);
-    this.isSuperstrikeDevice = isSuperstrike;
-    const wired = this.device.productId === 0xc0a8;
+    const wired = this.profile.connectionType === "Wired";
 
     return {
       brand: "Logitech",
@@ -219,13 +229,15 @@ export class LogitechHidppClient {
       supportsSeparateDpiAxes,
       analogButtonTuning,
       liftOffDistance: dpiState.liftOffDistance,
+      supportedLiftOffDistances: dpiFeature.legacy
+        ? undefined
+        : isSuperstrike ? ["Low", "High"] : ["Low", "Medium", "High"],
       // The USB connection exposes the Superstrike as a 1 kHz device. Its
       // Lightspeed receiver can use the higher rates advertised by HID++.
       pollingRateHz: isSuperstrike && wired ? Math.min(pollingRateHz, 1000) : pollingRateHz,
       supportedPollingRates: isSuperstrike && wired
         ? supportedPollingRates.filter((rate) => rate <= 1000)
         : supportedPollingRates,
-      supportedLiftOffDistances: isSuperstrike ? ["Low", "High"] : undefined,
       connectionType: wired ? "Wired" : "Wireless",
       activeProfile: profileState.activeProfile,
       deviceMode: profileState.deviceMode,
@@ -261,10 +273,19 @@ export class LogitechHidppClient {
     if (!feature.index) {
       throw new Error("This mouse does not expose report-rate controls.");
     }
-    const confirmation = this.waitForRateChange(pollingRateHz);
+    if (!this.profile.confirmPollingRateByReadback) {
+      const confirmation = this.waitForRateChange(pollingRateHz);
+      await this.request(feature.index, 0x30, rateIndex);
+      await confirmation;
+      return pollingRateHz;
+    }
     await this.request(feature.index, 0x30, rateIndex);
-    await confirmation;
-    return pollingRateHz;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const confirmed = await this.readPollingRate(feature.index);
+      if (confirmed === pollingRateHz) return confirmed;
+      if (attempt < 4) await new Promise<void>((resolve) => window.setTimeout(resolve, 100));
+    }
+    throw new Error("The mouse acknowledged the rate write but kept a different active rate.");
   }
 
   async getDpiOptions(): Promise<number[]> {
@@ -345,13 +366,12 @@ export class LogitechHidppClient {
   }
 
   async setLiftOffDistance(liftOffDistance: NonNullable<LogitechMouseStatus["liftOffDistance"]>): Promise<NonNullable<LogitechMouseStatus["liftOffDistance"]>> {
-    if (liftOffDistance === "Low" && !this.isSuperstrikeDevice) {
-      throw new Error("This mouse does not support a Low lift-off distance.");
-    }
     if (liftOffDistance === "Medium" && this.isSuperstrikeDevice) {
       throw new Error("The Superstrike supports only Low and High lift-off distance.");
     }
-    const lod = ({ Low: 0, Medium: 1, High: 2 } as const)[liftOffDistance];
+    const lod = this.isSuperstrikeDevice
+      ? ({ Low: 0, Medium: 1, High: 2 } as const)[liftOffDistance]
+      : encodeLiftOffDistance(liftOffDistance);
     await this.ensureHostControl();
     const feature = await this.getFeature(FEATURE.extendedDpi);
     if (!feature.index) {
@@ -367,7 +387,9 @@ export class LogitechHidppClient {
       lod,
     ]);
     const confirmed = await this.readDpiConfiguration(feature.index);
-    const result = confirmed.lod === 0 ? "Low" : confirmed.lod === 1 ? "Medium" : confirmed.lod === 2 ? "High" : null;
+    const result = this.isSuperstrikeDevice
+      ? confirmed.lod === 0 ? "Low" : confirmed.lod === 1 ? "Medium" : confirmed.lod === 2 ? "High" : null
+      : decodeLiftOffDistance(confirmed.lod);
     if (result !== liftOffDistance) {
       throw new Error(`The mouse kept ${result ?? "an unknown"} lift-off distance instead of ${liftOffDistance}.`);
     }
@@ -622,7 +644,9 @@ export class LogitechHidppClient {
     const configuration = await this.readDpiConfiguration(featureIndex);
     const dpi = configuration.x;
     const lod = configuration.lod;
-    const liftOffDistance = lod === 0 ? "Low" : lod === 1 ? "Medium" : lod === 2 ? "High" : null;
+    const liftOffDistance = this.isSuperstrikeDevice
+      ? lod === 0 ? "Low" : lod === 1 ? "Medium" : lod === 2 ? "High" : null
+      : decodeLiftOffDistance(lod);
     return { dpi, dpiY: configuration.y, liftOffDistance };
   }
 
@@ -672,12 +696,12 @@ export class LogitechHidppClient {
       throw new Error("This Logitech mouse does not expose extended report-rate controls.");
     }
 
-    const reply = await this.request(featureIndex, 0x20);
+    const reply = await this.request(featureIndex, 0x20, this.profile.reportRateConnectionType);
     const rate = REPORT_RATE_HZ[reply[3] ?? -1];
     if (!rate) {
       throw new Error("The mouse returned an unknown report-rate value.");
     }
-    return this.livePollingRateHz ?? rate;
+    return this.profile.confirmPollingRateByReadback ? rate : this.livePollingRateHz ?? rate;
   }
 
   private waitForRateChange(rate: number): Promise<void> {
@@ -780,7 +804,7 @@ export class LogitechHidppClient {
     }
 
     const report = new Uint8Array([
-      DEVICE_INDEX,
+      this.profile.deviceIndex,
       featureIndex,
       functionId,
       parameters[0] ?? 0,
@@ -801,7 +825,7 @@ export class LogitechHidppClient {
       throw new Error("HID++ long requests support at most 16 parameter bytes.");
     }
     const report = new Uint8Array(19);
-    report[0] = DEVICE_INDEX;
+    report[0] = this.profile.deviceIndex;
     report[1] = featureIndex;
     report[2] = functionId;
     report.set(parameters, 3);

--- a/src/devices/logitech/protocol.test.ts
+++ b/src/devices/logitech/protocol.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decodeLiftOffDistance,
+  encodeLiftOffDistance,
+  logitechDeviceProfile,
+} from "./protocol.ts";
+
+test("Superlight 2 transports use the correct HID++ addressing", () => {
+  assert.equal(logitechDeviceProfile(0x046d, 0xc09b)?.deviceIndex, 0xff);
+  assert.equal(logitechDeviceProfile(0x046d, 0xc09b)?.reportRateConnectionType, 0);
+  assert.equal(logitechDeviceProfile(0x046d, 0xc54d)?.deviceIndex, 0x01);
+  assert.equal(logitechDeviceProfile(0x046d, 0xc54d)?.reportRateConnectionType, 1);
+});
+
+test("extended DPI lift-off values follow HID++ 0x2202", () => {
+  assert.deepEqual(["Low", "Medium", "High"].map((value) => encodeLiftOffDistance(value as "Low" | "Medium" | "High")), [1, 2, 3]);
+  assert.deepEqual([0, 1, 2, 3, 4].map(decodeLiftOffDistance), [null, "Low", "Medium", "High", null]);
+});

--- a/src/devices/logitech/protocol.ts
+++ b/src/devices/logitech/protocol.ts
@@ -1,0 +1,33 @@
+export const LOGITECH_VENDOR_ID = 0x046d;
+
+export interface LogitechDeviceProfile {
+  deviceIndex: number;
+  reportRateConnectionType: 0 | 1;
+  connectionType: "Wired" | "Wireless";
+  confirmPollingRateByReadback: boolean;
+}
+
+// Direct USB HID++ traffic for the Superlight 2 uses index 0xff. Receiver
+// traffic addresses the paired mouse in slot 0x01.
+export const LOGITECH_DEVICE_PROFILES: ReadonlyMap<number, LogitechDeviceProfile> = new Map([
+  [0xc09b, { deviceIndex: 0xff, reportRateConnectionType: 0, connectionType: "Wired", confirmPollingRateByReadback: true }],
+  [0xc54d, { deviceIndex: 0x01, reportRateConnectionType: 1, connectionType: "Wireless", confirmPollingRateByReadback: true }],
+  [0xc539, { deviceIndex: 0x01, reportRateConnectionType: 1, connectionType: "Wireless", confirmPollingRateByReadback: false }],
+  [0xc0a8, { deviceIndex: 0x01, reportRateConnectionType: 0, connectionType: "Wired", confirmPollingRateByReadback: false }],
+]);
+
+export function logitechDeviceProfile(vendorId: number, productId: number): LogitechDeviceProfile | null {
+  if (vendorId !== LOGITECH_VENDOR_ID) return null;
+  return LOGITECH_DEVICE_PROFILES.get(productId) ?? null;
+}
+
+export type LogitechLiftOffDistance = "Low" | "Medium" | "High";
+
+/** HID++ 0x2202 reserves 0 for unsupported, followed by Low/Medium/High. */
+export function encodeLiftOffDistance(value: LogitechLiftOffDistance): number {
+  return ({ Low: 1, Medium: 2, High: 3 } as const)[value];
+}
+
+export function decodeLiftOffDistance(value: number): LogitechLiftOffDistance | null {
+  return ({ 1: "Low", 2: "Medium", 3: "High" } as const)[value as 1 | 2 | 3] ?? null;
+}

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -9,9 +9,9 @@ export const VENDOR_ID = {
   orbital: 0x1915,
 } as const;
 
-// Logitech HID++ control interfaces. 0xc54d is Bolt/newer Lightspeed, 0xc539
-// is HERO-era Lightspeed, and 0xc0a8 is the PRO X 2 Superstrike USB interface.
-export const LOGITECH_RECEIVER_PRODUCT_IDS = [0xc54d, 0xc539, 0xc0a8] as const;
+// Logitech HID++ control interfaces. 0xc54d/0xc539 are receiver interfaces;
+// 0xc0a8 and 0xc09b are the Superstrike and Superlight 2 USB interfaces.
+export const LOGITECH_RECEIVER_PRODUCT_IDS = [0xc54d, 0xc539, 0xc0a8, 0xc09b] as const;
 
 export const LOGITECH_RECEIVER_FILTERS: HIDDeviceFilter[] = LOGITECH_RECEIVER_PRODUCT_IDS.map(
   (productId) => ({ vendorId: VENDOR_ID.logitech, productId, usagePage: 0xff00, usage: 0x0001 }),


### PR DESCRIPTION
## Summary

- Add wired Logitech G Pro X Superlight 2 support for USB product ID `046d:c09b`
- Use the correct HID++ device indexes for direct USB and LIGHTSPEED receiver connections
- Make HID++ `0x8061` polling-rate reads transport-aware while retaining the existing `046d:c54d` receiver route
- Confirm polling-rate writes by reading the active rate back from the mouse
- Correct HID++ `0x2202` lift-off-distance encoding and enable all three LOD options
- Add protocol tests for Logitech transport profiles and LOD values

## Testing

Automated:

- `npm test` — 15 tests passed
- `npm run build`
- `git diff --check`

Manual testing with a Logitech G Pro X Superlight 2:

- Detected over USB and the LIGHTSPEED receiver
- DPI changes affected physical sensitivity and were confirmed by device readback
- Wired polling options were correctly limited to the rates advertised over USB
- Wireless polling options through 8K were accepted and confirmed by device readback
- Wireless battery reporting worked
- All three lift-off-distance options were selectable and confirmed by device readback

## Testing limitations

The physical cutoff height of each lift-off-distance option was not measured with calibrated equipment.

Browser polling-rate tests peaked at approximately 1380 Hz when configured above 1K. The same limitation occurred when configuring the mouse through G Hub. TestUFO notes that browsers may not keep up with high-end mouse polling rates, so this was not treated as evidence that the HID++ write failed.

## G Hub interaction

G Hub does not live-update its displayed profile when another application changes the mouse, and opening G Hub may reapply its saved software profile.

OpenMouse confirms DPI, polling rate, and LOD changes by reading the active values back directly from the mouse.