### PR TITLE
feat(core): Implement unsaved-changes bar

### DIFF
--- a/src/control-events.ts
+++ b/src/control-events.ts
@@ -17,24 +17,26 @@ export interface ControlEventHandlers {
   toggleSidebar(): void;
   resetInterfacePreferences(): void;
   copyDiagnostics(): Promise<void>;
-  chooseCustomDpi(): Promise<void>;
+  chooseCustomDpi(): void;
   finishCustomDpiEditing(): void;
-  applyLogitechAxisDpi(): Promise<void>;
-  applyLogitechAnalogButton(button: 0 | 1): Promise<void>;
-  applyLogitechAnalogButtons(): Promise<void>;
+  applyLogitechAxisDpi(): void;
+  applyLogitechAnalogButton(button: 0 | 1): void;
+  applyLogitechAnalogButtons(): void;
   setSuperstrikeTuningMode(mode: "independent" | "both"): void;
-  toggleDongleLed(): Promise<void>;
-  applyPulsarValue(setting: "debounce" | "sleep", value: number): Promise<void>;
-  toggleSleep(enabled: boolean): Promise<void>;
-  applyPulsarToggle(setting: PulsarToggleSetting, enabled: boolean): Promise<void>;
-  applyEggFilter(setting: EggFilterSetting, enabled: boolean): Promise<void>;
-  applyEggSpdtMode(button: "left" | "right", mode: EggSpdtMode): Promise<void>;
-  applyEggCpiLevels(levels: number): Promise<void>;
+  toggleDongleLed(): void;
+  applyPulsarValue(setting: "debounce" | "sleep", value: number): void;
+  toggleSleep(enabled: boolean): void;
+  applyPulsarToggle(setting: PulsarToggleSetting, enabled: boolean): void;
+  applyEggFilter(setting: EggFilterSetting, enabled: boolean): void;
+  applyEggSpdtMode(button: "left" | "right", mode: EggSpdtMode): void;
+  applyEggCpiLevels(levels: number): void;
   updateCustomPollingPreview(): void;
-  applyEggPollingDivider(divider: number): Promise<void>;
-  applyProSetting(setting: "wheelAcceleration" | "angleTuning" | "profile", value: boolean | number): Promise<void>;
-  applyPollingRate(rate: number): Promise<void>;
-  applyLiftOffDistance(lod: NonNullable<MouseStatus["liftOffDistance"]>): Promise<void>;
+  applyEggPollingDivider(divider: number): void;
+  applyProSetting(setting: "wheelAcceleration" | "angleTuning" | "profile", value: boolean | number): void;
+  applyPollingRate(rate: number): void;
+  applyLiftOffDistance(lod: NonNullable<MouseStatus["liftOffDistance"]>): void;
+  flashPendingChanges(): Promise<void>;
+  revertPendingChanges(): void;
 }
 
 function onClick(selector: string, listener: () => void): void {
@@ -48,6 +50,8 @@ export function bindControlEvents(handlers: ControlEventHandlers): void {
     const button = (event.target as HTMLElement).closest<HTMLButtonElement>("[data-device-index]");
     if (button) void handlers.selectAuthorizedDevice(Number(button.dataset.deviceIndex));
   });
+  onClick("#pending-flash", () => void handlers.flashPendingChanges());
+  onClick("#pending-revert", handlers.revertPendingChanges);
   onClick("#interface-settings-button", handlers.openInterfaceSettings);
   onClick("#close-interface-settings", handlers.closeInterfaceSettings);
 

--- a/src/control-template.ts
+++ b/src/control-template.ts
@@ -86,5 +86,21 @@ export function controlTemplate(buildLabel: string): string {
           <button id="reset-interface-settings" class="interface-reset" type="button">Reset interface preferences</button>
         </section>
       </main>
+
+      <div id="pending-changes-bar" class="pending-bar" role="region" aria-label="Unsaved changes" hidden>
+        <div class="pending-bar-inner">
+          <span class="pending-bar-progress" aria-hidden="true"></span>
+          <span class="pending-bar-dot" aria-hidden="true"></span>
+          <div class="pending-bar-copy">
+            <p class="overline">PENDING</p>
+            <strong id="pending-changes-count">1 unsaved change</strong>
+            <small id="pending-changes-summary" role="status" aria-live="polite"></small>
+          </div>
+          <div class="pending-bar-actions">
+            <button id="pending-revert" class="pending-revert" type="button"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3.5 8.5h11a5.5 5.5 0 0 1 0 11H8" /><path d="M7.5 4 3 8.5 7.5 13" /></svg><span>Revert</span></button>
+            <button id="pending-flash" class="pending-flash" type="button"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M13.8 2 4 13.9h5.7L8.9 22 20 9.8h-6.1L13.8 2Z" /></svg><i class="pending-spinner" aria-hidden="true"></i><span id="pending-flash-label">Flash</span></button>
+          </div>
+        </div>
+      </div>
     </div>`;
 }

--- a/src/control.css
+++ b/src/control.css
@@ -56,8 +56,40 @@
 .panel-footer .live-status-label i { width: .38rem; height: .38rem; border-radius: 50%; background: #69d28d; box-shadow: 0 0 0 3px rgb(105 210 141 / 10%); }
 .panel-footer #read-status { color: #b3b3b7; font-size: .7rem; }
 
+.pending-bar { position: fixed; z-index: 60; right: 0; bottom: 0; left: 0; display: flex; justify-content: center; padding: 0 1rem 1rem; pointer-events: none; }
+.pending-bar[hidden] { display: none; }
+.pending-bar-inner { position: relative; display: flex; width: min(100%, 760px); align-items: center; gap: 1rem; padding: .7rem .7rem .7rem 1rem; overflow: hidden; border: 1px solid color-mix(in srgb, var(--ui-accent) 28%, #29292d); border-radius: 12px; background: linear-gradient(135deg, color-mix(in srgb, var(--ui-accent) 8%, #131316), #101012 62%); box-shadow: 0 18px 42px rgb(0 0 0 / 55%); pointer-events: auto; animation: pending-bar-rise .34s cubic-bezier(.22, .92, .28, 1.1) both; }
+.pending-bar.is-leaving .pending-bar-inner { animation: pending-bar-sink .22s ease-in both; }
+.pending-bar-dot { flex: 0 0 auto; width: .45rem; height: .45rem; border-radius: 50%; background: var(--ui-accent); box-shadow: 0 0 0 3px var(--ui-accent-soft); animation: pending-bar-pulse 1.8s ease-in-out infinite; }
+.pending-bar-copy { display: flex; min-width: 0; flex-direction: column; gap: .1rem; }
+.pending-bar-copy .overline { margin: 0; color: #77777c; font-family: "JetBrains Mono", monospace; font-size: .52rem; letter-spacing: .09em; }
+.pending-bar-copy strong { color: #ececef; font-size: .82rem; font-weight: 600; letter-spacing: -.01em; }
+.pending-bar-copy small { overflow: hidden; color: #8b8b90; font-size: .64rem; text-overflow: ellipsis; white-space: nowrap; }
+.pending-bar-actions { display: flex; flex: 0 0 auto; align-items: center; gap: .45rem; margin-left: auto; }
+.pending-bar-actions button { display: inline-flex; align-items: center; gap: .42rem; padding: .5rem .8rem; border-radius: 7px; font-size: .68rem; font-weight: 700; transition: border-color .18s ease, background .18s ease, transform .18s ease, opacity .18s ease; }
+.pending-bar-actions button:disabled { cursor: default; opacity: .55; transform: none; }
+.pending-bar-actions svg { flex: 0 0 auto; width: .8rem; height: .8rem; }
+.pending-revert { border: 1px solid #3a3a3f; background: #19191c; color: #b3b3b7; }
+.pending-revert:hover:not(:disabled) { border-color: #737378; background: #222225; color: #fff; transform: translateY(-1px); }
+.pending-flash { border: 1px solid var(--ui-accent); background: var(--ui-accent); color: var(--ui-accent-ink); }
+.pending-flash:hover:not(:disabled) { transform: translateY(-1px); }
+.pending-spinner { display: none; flex: 0 0 auto; width: .72rem; height: .72rem; border: 2px solid color-mix(in srgb, var(--ui-accent-ink) 32%, transparent); border-top-color: var(--ui-accent-ink); border-radius: 50%; animation: pending-spin .7s linear infinite; }
+.pending-bar.is-flashing .pending-flash svg { display: none; }
+.pending-bar.is-flashing .pending-spinner { display: block; }
+.pending-bar-progress { position: absolute; top: 0; left: 0; width: 100%; height: 2px; opacity: 0; background: linear-gradient(90deg, transparent, var(--ui-accent), transparent); background-size: 45% 100%; background-repeat: no-repeat; transition: opacity .2s ease; }
+.pending-bar.is-flashing .pending-bar-progress { opacity: 1; animation: pending-bar-sweep 1.1s ease-in-out infinite; }
+
+@keyframes pending-bar-rise { from { opacity: 0; transform: translateY(130%) scale(.97); } to { opacity: 1; transform: none; } }
+@keyframes pending-bar-sink { from { opacity: 1; transform: none; } to { opacity: 0; transform: translateY(130%) scale(.97); } }
+@keyframes pending-bar-pulse { 0%, 100% { box-shadow: 0 0 0 3px var(--ui-accent-soft); } 50% { box-shadow: 0 0 0 6px transparent; } }
+@keyframes pending-spin { to { transform: rotate(360deg); } }
+@keyframes pending-bar-sweep { from { background-position: -45% 0; } to { background-position: 145% 0; } }
+
 @media (min-width: 900px) {
   .control-shell { height: 100vh; overflow: hidden; }
+  .control-shell .pending-bar { left: 260px; }
+  .control-shell.sidebar-hidden .pending-bar { left: 0; }
+  .control-shell.has-pending-changes .control-panel { padding-bottom: 5.5rem; }
   .control-shell .control-panel { display: flex; flex-direction: column; width: min(100% - 3rem, 1180px); min-height: 0; padding: .65rem 0; }
   .control-shell .preview-banner { padding: .45rem .65rem; }
   .control-shell .panel-header { padding: .8rem 0 .65rem; }
@@ -93,4 +125,6 @@
   .control-shell .sidebar { position: static; height: auto; min-height: 0; border-right: 0; border-bottom: 1px solid #29292d; }
   .control-shell .sidebar-footer { display: none; }
   .control-shell .control-panel { width: min(100% - 2rem, 1180px); }
+  .control-shell.has-pending-changes .control-panel { padding-bottom: 7rem; }
+  .pending-bar-copy small { display: none; }
 }

--- a/src/control.ts
+++ b/src/control.ts
@@ -13,7 +13,19 @@ import {
 import { renderDeviceSidebar as renderDeviceSidebarView } from "./device-sidebar";
 import { renderEggControls } from "./devices/endgame/egg-controls-view";
 import { hidTraffic, isMark, markHidActivity, startHidCapture, type HidTrafficEntry } from "./hid-diagnostics";
+import {
+  clearPendingChanges,
+  dropPendingChange,
+  hasPendingChanges,
+  isPendingChange,
+  onPendingChanges,
+  pendingChanges,
+  stagePendingChange,
+  withPendingChanges,
+  type PendingChange,
+} from "./pending-changes";
 import { formatHex, setControlValue, setText, setToggleValue } from "./ui/dom";
+import { renderPendingBar, setPendingBarBusy, setPendingBarStatus } from "./ui/pending-bar";
 import {
   DEFAULT_INTERFACE_PREFERENCES,
   loadInterfacePreferences,
@@ -73,6 +85,8 @@ let activeDevice: HIDDevice | null = null;
 const deviceStatuses = new Map<HIDDevice, MouseStatus>();
 let latestDiagnosticsSnapshot = "";
 let latestDiagnosticStatus: MouseStatus | null = null;
+// Last status read from the device, before staged changes are previewed over it
+let latestDeviceStatus: MouseStatus | null = null;
 let lastDiagnosticCommand: string | null = null;
 let lastDiagnosticError: string | null = null;
 /** Prevents overlapping reconnect loops from leaving the UI stuck on "Reconnecting…". */
@@ -91,6 +105,101 @@ function activeSettingsClient(): SupportedClient | null {
 
 function hasActiveClient(): boolean {
   return activeSettingsClient() !== null;
+}
+
+function requireSettingsClient(): SupportedClient {
+  const client = activeSettingsClient();
+  if (!client) throw new Error("The mouse is no longer connected.");
+  return client;
+}
+
+/**
+ * Records a settings change without touching the device. The control repaints
+ * from the previewed status so it shows the staged value, and the unsaved-changes
+ * bar offers to flash or discard it.
+ */
+function stageChange(change: PendingChange): void {
+  if (settingInProgress) {
+    setText("#read-status", "Wait for the current flash to finish.");
+    return;
+  }
+  if (matchesDeviceStatus(change)) {
+    // The control was moved back to the value the mouse already holds, so there
+    // is nothing left to flash for this setting.
+    dropPendingChange(change.key);
+    if (latestDeviceStatus) showStatus(latestDeviceStatus);
+    setText("#read-status", `${change.label} already matches the mouse.`);
+    return;
+  }
+  stagePendingChange(change);
+  if (latestDeviceStatus) showStatus(latestDeviceStatus);
+  setText("#read-status", `${change.label} staged. Flash to write it to the mouse.`);
+}
+
+// True when previewing the change over the device status would leave it unchanged
+function matchesDeviceStatus(change: PendingChange): boolean {
+  if (!latestDeviceStatus) return false;
+  const preview = structuredClone(latestDeviceStatus);
+  change.preview(preview);
+  return JSON.stringify(preview) === JSON.stringify(latestDeviceStatus);
+}
+
+function revertPendingChanges(): void {
+  if (settingInProgress || !hasPendingChanges()) return;
+  clearPendingChanges();
+  if (latestDeviceStatus) showStatus(latestDeviceStatus);
+  setText("#read-status", "Discarded the staged changes.");
+}
+
+// Held before each write so the flashing state is legible rather than a flicker.
+const FLASH_STEP_DELAY_MS = 420;
+// Held after the last write, so the bar does not vanish the instant it lands.
+const FLASH_SETTLE_MS = 320;
+
+async function flashPause(milliseconds = FLASH_STEP_DELAY_MS): Promise<void> {
+  // The pause only exists to show the animation, so skip it when motion is reduced.
+  if (interfacePreferences.reducedMotion) return;
+  await wait(milliseconds);
+}
+
+async function flashPendingChanges(): Promise<void> {
+  const queued = pendingChanges();
+  if (queued.length === 0 || settingInProgress || refreshInProgress) return;
+  settingInProgress = true;
+  setPendingBarBusy(true);
+  let written = 0;
+  let failure: string | null = null;
+  try {
+    for (const change of queued) {
+      setPendingBarStatus(`${change.progress} (${written + 1} of ${queued.length})`);
+      setText("#read-status", change.progress);
+      // Let the step render before the write blocks on HID traffic.
+      await flashPause();
+      recordDiagnosticCommand(change.command);
+      await change.apply();
+      // Drop each change as it lands, so a later failure leaves only the
+      // unwritten ones staged and the user can retry just those.
+      dropPendingChange(change.key);
+      written += 1;
+    }
+  } catch (error) {
+    recordDiagnosticError(error, "Unable to flash the staged changes.");
+    failure = error instanceof Error ? error.message : "Unable to flash the staged changes.";
+  }
+  await flashPause(FLASH_SETTLE_MS);
+  const client = activeSettingsClient();
+  const status = client ? await statusAfterWrite(client).catch(() => null) : null;
+  settingInProgress = false;
+  if (status) showStatus(status);
+  setPendingBarBusy(false);
+  if (failure) {
+    setText("#read-status", failure);
+    setPendingBarStatus(failure);
+    return;
+  }
+  setText("#read-status", written === 1
+    ? "Flashed 1 change to the mouse."
+    : `Flashed ${written} changes to the mouse.`);
 }
 
 let interfacePreferences = loadInterfacePreferences(localStorage);
@@ -178,7 +287,11 @@ function renderControl(): void {
     applyProSetting,
     applyPollingRate,
     applyLiftOffDistance,
+    flashPendingChanges,
+    revertPendingChanges,
   });
+  onPendingChanges(renderPendingBar);
+  renderPendingBar();
   populateInterfaceSettings();
   applyInterfacePreferences();
   if (!isSuperstrikePreview) {
@@ -488,9 +601,13 @@ async function copyDiagnostics(): Promise<void> {
   }
 }
 
-function showStatus(status: MouseStatus): void {
-  latestDiagnosticStatus = status;
-  lastRenderedStatusKey = JSON.stringify(status);
+function showStatus(deviceStatus: MouseStatus): void {
+  latestDeviceStatus = deviceStatus;
+  latestDiagnosticStatus = deviceStatus;
+  lastRenderedStatusKey = JSON.stringify(deviceStatus);
+  // Controls render from the previewed status so staged changes survive a
+  // background refresh; diagnostics and the sidebar keep the device's own values.
+  const status = withPendingChanges(deviceStatus);
   // Driver UI hints (e.g. status.ui.family === "egg-we") avoid brand-specific imports.
   const ui = status.ui;
   const isEgg8k = activeEggClient !== null
@@ -585,7 +702,8 @@ function showStatus(status: MouseStatus): void {
     const seconds = activeDmClient.getSleepOptions();
     fillSleepOptions(seconds.map((value) => [value, sleepLabel(value)] as const));
     fillDebounceOptions(activeDmClient.getDebounceMaxMs());
-    lastSleepSeconds = status.sleepTimeout ?? seconds[0] ?? 60;
+    // Read from the device value so toggling sleep back on restores a real timeout.
+    lastSleepSeconds = deviceStatus.sleepTimeout ?? seconds[0] ?? 60;
     setToggleValue("#sleep-toggle", status.sleepTimeout !== null && status.sleepTimeout !== undefined);
     setControlValue("#debounce-select", status.debounceMs);
     setControlValue("#sleep-select", status.sleepTimeout);
@@ -642,18 +760,18 @@ function showStatus(status: MouseStatus): void {
   }
   setText("#device-title", status.name);
   if (activeDevice) {
-    deviceStatuses.set(activeDevice, status);
+    deviceStatuses.set(activeDevice, deviceStatus);
     void renderDeviceSidebar();
   }
   setText("#device-status", "Connected");
   // Same banner copy as other brands — no RE/debug messaging in the chrome.
   setText("#connection-banner", "Connected directly through WebHID. Supported settings can be adjusted here.");
   if (settingsPending) {
-    setText("#read-status", status.batteryPercent === null
+    setText("#read-status", deviceStatus.batteryPercent === null
       ? "Connected"
-      : `Battery ${status.batteryPercent}%`);
-  } else {
-    setText("#read-status", `Current: ${status.dpi.toLocaleString()} DPI · ${status.pollingRateHz.toLocaleString()} Hz`);
+      : `Battery ${deviceStatus.batteryPercent}%`);
+  } else if (!hasPendingChanges()) {
+    setText("#read-status", `Current: ${deviceStatus.dpi.toLocaleString()} DPI · ${deviceStatus.pollingRateHz.toLocaleString()} Hz`);
   }
   const meter = document.querySelector<HTMLElement>("#battery-meter");
   if (meter) meter.style.width = status.batteryPercent === null ? "0%" : `${status.batteryPercent}%`;
@@ -704,6 +822,12 @@ function showStatus(status: MouseStatus): void {
   const axisControls = document.querySelector<HTMLElement>("#logitech-axis-controls");
   const showSeparateDpiAxes = status.brand === "Logitech" && status.supportsSeparateDpiAxes === true;
   if (axisControls) axisControls.style.display = showSeparateDpiAxes ? "block" : "none";
+  const dpiLabel = (source: MouseStatus): string => showSeparateDpiAxes
+    ? `X ${source.dpi.toLocaleString()} · Y ${(source.dpiY ?? source.dpi).toLocaleString()} DPI`
+    : `${source.dpi.toLocaleString()} DPI`;
+  setText("#dpi-pending", isPendingChange("dpi")
+    ? `Staged ${dpiLabel(status)}`
+    : `Current ${dpiLabel(deviceStatus)}`);
   settingsGrid?.classList.toggle("has-logitech-axis-controls", showSeparateDpiAxes);
   const dpiX = document.querySelector<HTMLInputElement>("#logitech-dpi-x");
   const dpiY = document.querySelector<HTMLInputElement>("#logitech-dpi-y");
@@ -713,7 +837,7 @@ function showStatus(status: MouseStatus): void {
   if (logitechDetails) logitechDetails.style.display = status.brand === "Logitech" ? "block" : "none";
   if (status.brand === "Logitech") renderLogitechDetails(status);
   renderLogitechAnalogButtonSettings(status);
-  renderDeviceDiagnostics(status);
+  renderDeviceDiagnostics(deviceStatus);
 }
 
 function renderLogitechAnalogButtonSettings(status: MouseStatus): void {
@@ -836,6 +960,9 @@ function statusNameForClient(client: SupportedClient): string {
 
 async function activateClient(client: SupportedClient): Promise<void> {
   resetDeviceSpecificPanels();
+  // Staged changes belong to the mouse they were made on.
+  clearPendingChanges();
+  latestDeviceStatus = null;
   activeClient = null;
   activePulsarClient = null;
   activeEggClient = null;
@@ -907,6 +1034,8 @@ function showDisconnectedState(): void {
   activeOrbitalClient = null;
   activeDevice = null;
   lastRenderedStatusKey = null;
+  clearPendingChanges();
+  latestDeviceStatus = null;
   resetDeviceSpecificPanels();
   const advanced = document.querySelector<HTMLElement>("#pulsar-advanced");
   if (advanced) advanced.style.display = "none";
@@ -1148,7 +1277,7 @@ function configureDpiControl(currentDpi: number): void {
   custom.disabled = false;
 }
 
-async function chooseCustomDpi(): Promise<void> {
+function chooseCustomDpi(): void {
   const input = document.querySelector<HTMLInputElement>("#dpi-output");
   const button = document.querySelector<HTMLButtonElement>("#custom-dpi");
   if (!input || !button) return;
@@ -1168,7 +1297,7 @@ async function chooseCustomDpi(): Promise<void> {
     input.select();
     return;
   }
-  if (await applyDpiValue(dpi)) finishCustomDpiEditing(dpi);
+  if (applyDpiValue(dpi)) finishCustomDpiEditing(dpi);
 }
 
 function finishCustomDpiEditing(dpi?: number): void {
@@ -1182,191 +1311,160 @@ function finishCustomDpiEditing(dpi?: number): void {
   button.textContent = "Custom";
 }
 
-async function applyDpiValue(dpi: number): Promise<boolean> {
-  const client = activeSettingsClient();
-  if (!client || !dpiOptions.includes(dpi) || refreshInProgress || settingInProgress) return false;
-  settingInProgress = true;
-  const buttons = document.querySelectorAll<HTMLButtonElement>("[data-dpi], #custom-dpi");
-  buttons.forEach((button) => { button.disabled = true; });
-  setText("#read-status", `Setting ${dpi.toLocaleString()} DPI…`);
-  recordDiagnosticCommand(`Set DPI to ${dpi.toLocaleString()}`);
-  try {
-    await client.setDpi(dpi);
-    showStatus(await statusAfterWrite(client));
-    setText("#dpi-pending", `Confirmed at ${dpi.toLocaleString()} DPI`);
-    return true;
-  } catch (error) {
-    recordDiagnosticError(error, "Unable to set DPI.");
-    setText("#read-status", error instanceof Error ? error.message : "Unable to set DPI.");
-    return false;
-  } finally {
-    settingInProgress = false;
-    buttons.forEach((button) => { button.disabled = false; });
-  }
+function applyDpiValue(dpi: number): boolean {
+  if (!hasActiveClient() || !dpiOptions.includes(dpi)) return false;
+  stageChange({
+    key: "dpi",
+    label: `DPI ${dpi.toLocaleString()}`,
+    command: `Set DPI to ${dpi.toLocaleString()}`,
+    progress: `Setting ${dpi.toLocaleString()} DPI…`,
+    preview: (status) => {
+      status.dpi = dpi;
+      // Only mirror the Y axis when the driver actually reports one, so the
+      // comparison against the device status stays exact.
+      if (status.dpiY !== undefined) status.dpiY = dpi;
+    },
+    apply: async () => {
+      await requireSettingsClient().setDpi(dpi);
+    },
+  });
+  return true;
 }
 
-async function applyLogitechAxisDpi(): Promise<void> {
-  if (!activeClient || refreshInProgress || settingInProgress) return;
+function applyLogitechAxisDpi(): void {
+  if (!activeClient) return;
   const dpiX = Number(document.querySelector<HTMLInputElement>("#logitech-dpi-x")?.value);
   const dpiY = Number(document.querySelector<HTMLInputElement>("#logitech-dpi-y")?.value);
   if (!dpiOptions.includes(dpiX) || !dpiOptions.includes(dpiY)) {
     setText("#read-status", "Both axis values must be advertised DPI values.");
     return;
   }
-  settingInProgress = true;
-  setText("#read-status", `Setting X ${dpiX.toLocaleString()} · Y ${dpiY.toLocaleString()} DPI…`);
-  recordDiagnosticCommand(`Set DPI axes to X ${dpiX.toLocaleString()} / Y ${dpiY.toLocaleString()}`);
-  try {
-    await activeClient.setDpi(dpiX, dpiY);
-    showStatus(await activeClient.readStatus());
-    setText("#dpi-pending", `Confirmed X ${dpiX.toLocaleString()} · Y ${dpiY.toLocaleString()} DPI`);
-  } catch (error) {
-    recordDiagnosticError(error, "Unable to set axis DPI.");
-    setText("#read-status", error instanceof Error ? error.message : "Unable to set axis DPI.");
-  } finally {
-    settingInProgress = false;
-  }
-}
-
-async function applyLogitechAnalogButton(button: 0 | 1): Promise<void> {
-  if (!activeClient || refreshInProgress || settingInProgress) return;
-  const side = button === 0 ? "left" : "right";
-  const read = (setting: "actuation" | "rapid-trigger" | "haptics"): number =>
-    Number(document.querySelector<HTMLInputElement>(`#logitech-${side}-${setting}`)?.value);
-  const tuning = { actuation: read("actuation"), rapidTrigger: read("rapid-trigger"), haptics: read("haptics") };
-  settingInProgress = true;
-  const controls = document.querySelectorAll<HTMLInputElement | HTMLButtonElement>("#logitech-analog-button-settings input, #logitech-analog-button-settings button");
-  controls.forEach((control) => { control.disabled = true; });
-  setText("#read-status", `Setting ${side} hall-effect button tuning…`);
-  recordDiagnosticCommand(`Set ${side} hall-effect button tuning`);
-  try {
-    await activeClient.setAnalogButtonTuning(button, tuning);
-    showStatus(await activeClient.readStatus());
-    setText("#read-status", `Confirmed ${side} hall-effect button tuning.`);
-  } catch (error) {
-    recordDiagnosticError(error, "Unable to set hall-effect button tuning.");
-    setText("#read-status", error instanceof Error ? error.message : "Unable to set hall-effect button tuning.");
-  } finally {
-    settingInProgress = false;
-    controls.forEach((control) => { control.disabled = false; });
-  }
-}
-
-async function applyLogitechAnalogButtons(): Promise<void> {
-  if (!activeClient || refreshInProgress || settingInProgress) return;
-  const read = (setting: "actuation" | "rapid-trigger" | "haptics"): number =>
-    Number(document.querySelector<HTMLInputElement>(`#logitech-both-${setting}`)?.value);
-  const tuning = { actuation: read("actuation"), rapidTrigger: read("rapid-trigger"), haptics: read("haptics") };
-  settingInProgress = true;
-  const controls = document.querySelectorAll<HTMLInputElement | HTMLButtonElement>("#logitech-analog-button-settings input, #logitech-analog-button-settings button");
-  controls.forEach((control) => { control.disabled = true; });
-  setText("#read-status", "Setting both HITS button profiles…");
-  recordDiagnosticCommand("Set both HITS button profiles");
-  try {
-    await activeClient.setAnalogButtonTuning(0, tuning);
-    await activeClient.setAnalogButtonTuning(1, tuning);
-    showStatus(await activeClient.readStatus());
-    setText("#read-status", "Confirmed both HITS button profiles.");
-  } catch (error) {
-    recordDiagnosticError(error, "Unable to set both HITS button profiles.");
-    setText("#read-status", error instanceof Error ? error.message : "Unable to set both HITS button profiles.");
-  } finally {
-    settingInProgress = false;
-    controls.forEach((control) => { control.disabled = false; });
-  }
-}
-
-async function applyPollingRate(rate: number): Promise<void> {
-  const client = activeSettingsClient();
-  if (!client || refreshInProgress || settingInProgress) return;
-  settingInProgress = true;
-  const buttons = document.querySelectorAll<HTMLButtonElement>("[data-rate]");
-  buttons.forEach((button) => {
-    button.disabled = true;
+  stageChange({
+    key: "dpi",
+    label: `DPI X ${dpiX.toLocaleString()} · Y ${dpiY.toLocaleString()}`,
+    command: `Set DPI axes to X ${dpiX.toLocaleString()} / Y ${dpiY.toLocaleString()}`,
+    progress: `Setting X ${dpiX.toLocaleString()} · Y ${dpiY.toLocaleString()} DPI…`,
+    preview: (status) => {
+      status.dpi = dpiX;
+      status.dpiY = dpiY;
+    },
+    apply: async () => {
+      if (!activeClient) throw new Error("The mouse is no longer connected.");
+      await activeClient.setDpi(dpiX, dpiY);
+    },
   });
-  setText("#read-status", `Setting ${rate.toLocaleString()} Hz…`);
-  recordDiagnosticCommand(`Set polling rate to ${rate.toLocaleString()} Hz`);
-  try {
-    await client.setPollingRate(rate);
-    showStatus(await statusAfterWrite(client));
-  } catch (error) {
-    recordDiagnosticError(error, "Unable to set polling rate.");
-    const status = await statusAfterWrite(client).catch(() => null);
-    if (status) showStatus(status);
-    setText("#read-status", error instanceof Error ? error.message : "Unable to set polling rate.");
-  } finally {
-    settingInProgress = false;
-    buttons.forEach((button) => {
-      button.disabled = false;
-    });
-  }
 }
 
-async function applyLiftOffDistance(lod: NonNullable<MouseStatus["liftOffDistance"]>): Promise<void> {
-  const client = activeSettingsClient();
-  if (!client || refreshInProgress || settingInProgress) return;
-  settingInProgress = true;
-  const buttons = document.querySelectorAll<HTMLButtonElement>("[data-lod]");
-  buttons.forEach((button) => { button.disabled = true; });
-  setText("#read-status", `Setting ${lod.toLowerCase()} lift-off distance…`);
-  recordDiagnosticCommand(`Set lift-off distance to ${lod}`);
-  try {
-    await client.setLiftOffDistance(lod);
-    showStatus(await statusAfterWrite(client));
-  } catch (error) {
-    recordDiagnosticError(error, "Unable to set lift-off distance.");
-    setText("#read-status", error instanceof Error ? error.message : "Unable to set lift-off distance.");
-  } finally {
-    settingInProgress = false;
-    buttons.forEach((button) => {
-      button.disabled = activeClient !== null && button.dataset.lod === "Low";
-    });
-  }
+function readAnalogTuning(group: "left" | "right" | "both"): { actuation: number; rapidTrigger: number; haptics: number } {
+  const read = (setting: "actuation" | "rapid-trigger" | "haptics"): number =>
+    Number(document.querySelector<HTMLInputElement>(`#logitech-${group}-${setting}`)?.value);
+  return { actuation: read("actuation"), rapidTrigger: read("rapid-trigger"), haptics: read("haptics") };
 }
 
-async function toggleDongleLed(): Promise<void> {
+/** Stages one hall-effect button profile. Keyed per button so "both" replaces either side. */
+function stageAnalogButton(button: 0 | 1, tuning: { actuation: number; rapidTrigger: number; haptics: number }): void {
+  const side = button === 0 ? "left" : "right";
+  stageChange({
+    key: `analog-button-${button}`,
+    label: `${side === "left" ? "Left" : "Right"} HITS tuning`,
+    command: `Set ${side} hall-effect button tuning`,
+    progress: `Setting ${side} hall-effect button tuning…`,
+    preview: (status) => {
+      const buttons = status.analogButtonTuning?.buttons;
+      if (buttons?.[button]) buttons[button] = { ...tuning };
+    },
+    apply: async () => {
+      if (!activeClient) throw new Error("The mouse is no longer connected.");
+      await activeClient.setAnalogButtonTuning(button, tuning);
+    },
+  });
+}
+
+function applyLogitechAnalogButton(button: 0 | 1): void {
+  if (!activeClient) return;
+  stageAnalogButton(button, readAnalogTuning(button === 0 ? "left" : "right"));
+}
+
+function applyLogitechAnalogButtons(): void {
+  if (!activeClient) return;
+  const tuning = readAnalogTuning("both");
+  stageAnalogButton(0, tuning);
+  stageAnalogButton(1, tuning);
+}
+
+function applyPollingRate(rate: number): void {
+  if (!hasActiveClient()) return;
+  stageChange({
+    key: "polling-rate",
+    label: `${rate.toLocaleString()} Hz`,
+    command: `Set polling rate to ${rate.toLocaleString()} Hz`,
+    progress: `Setting ${rate.toLocaleString()} Hz…`,
+    preview: (status) => {
+      status.pollingRateHz = rate;
+    },
+    apply: async () => {
+      await requireSettingsClient().setPollingRate(rate);
+    },
+  });
+}
+
+function applyLiftOffDistance(lod: NonNullable<MouseStatus["liftOffDistance"]>): void {
+  if (!hasActiveClient()) return;
+  stageChange({
+    key: "lift-off-distance",
+    label: `${lod} lift-off`,
+    command: `Set lift-off distance to ${lod}`,
+    progress: `Setting ${lod.toLowerCase()} lift-off distance…`,
+    preview: (status) => {
+      status.liftOffDistance = lod;
+    },
+    apply: async () => {
+      await requireSettingsClient().setLiftOffDistance(lod);
+    },
+  });
+}
+
+function toggleDongleLed(): void {
   const button = document.querySelector<HTMLButtonElement>("#dongle-led-toggle");
-  if (!button || !activePulsarClient || settingInProgress) return;
+  if (!button || !activePulsarClient) return;
   const enabled = button.dataset.enabled !== "true";
-  settingInProgress = true;
-  button.disabled = true;
-  setText("#read-status", `${enabled ? "Enabling" : "Disabling"} the receiver LED…`);
-  recordDiagnosticCommand(`${enabled ? "Enable" : "Disable"} receiver LED`);
-  try {
-    await activePulsarClient.setDongleLed(enabled);
-    showStatus(await activePulsarClient.readStatus());
-  } catch (error) {
-    recordDiagnosticError(error, "Unable to change the receiver LED.");
-    setText("#read-status", error instanceof Error ? error.message : "Unable to change the receiver LED.");
-  } finally {
-    settingInProgress = false;
-    button.disabled = false;
-  }
+  stageChange({
+    key: "dongle-led",
+    label: `Receiver LED ${enabled ? "on" : "off"}`,
+    command: `${enabled ? "Enable" : "Disable"} receiver LED`,
+    progress: `${enabled ? "Enabling" : "Disabling"} the receiver LED…`,
+    preview: (status) => {
+      status.dongleLedEnabled = enabled;
+    },
+    apply: async () => {
+      if (!activePulsarClient) throw new Error("The receiver is no longer connected.");
+      await activePulsarClient.setDongleLed(enabled);
+    },
+  });
 }
 
 type PulsarToggleSetting = "motionSync" | "angleSnapping" | "rippleControl" | "performanceMode";
 
-async function applyPulsarToggle(setting: PulsarToggleSetting, enabled: boolean): Promise<void> {
-  const client = activePulsarClient ?? activeEggClient ?? activeDmClient ?? activeOrbitalClient;
-  if (!client || settingInProgress) return;
-  settingInProgress = true;
-  setText("#read-status", `${enabled ? "Enabling" : "Disabling"} ${settingLabel(setting)}…`);
-  recordDiagnosticCommand(`${enabled ? "Enable" : "Disable"} ${settingLabel(setting)}`);
-  try {
-    if (setting === "motionSync") await client.setMotionSync(enabled);
-    if (setting === "angleSnapping") await client.setAngleSnapping(enabled);
-    if (setting === "rippleControl") await client.setRippleControl(enabled);
-    if (setting === "performanceMode" && !activePulsarClient && !activeOrbitalClient) throw new Error("Performance mode is not exposed by this device's protocol.");
-    if (setting === "performanceMode") await (activePulsarClient ?? activeOrbitalClient)!.setPerformanceMode(enabled);
-    showStatus(await statusAfterWrite(client));
-  } catch (error) {
-    recordDiagnosticError(error, "Unable to change the setting.");
-    const status = await statusAfterWrite(client).catch(() => null);
-    if (status) showStatus(status);
-    setText("#read-status", error instanceof Error ? error.message : "Unable to change the Pulsar setting.");
-  } finally {
-    settingInProgress = false;
-  }
+function applyPulsarToggle(setting: PulsarToggleSetting, enabled: boolean): void {
+  if (!(activePulsarClient ?? activeEggClient ?? activeDmClient ?? activeOrbitalClient)) return;
+  stageChange({
+    key: setting,
+    label: `${settingLabel(setting)} ${enabled ? "on" : "off"}`,
+    command: `${enabled ? "Enable" : "Disable"} ${settingLabel(setting)}`,
+    progress: `${enabled ? "Enabling" : "Disabling"} ${settingLabel(setting)}…`,
+    preview: (status) => {
+      status[setting] = enabled;
+    },
+    apply: async () => {
+      const client = activePulsarClient ?? activeEggClient ?? activeDmClient ?? activeOrbitalClient;
+      if (!client) throw new Error("The mouse is no longer connected.");
+      if (setting === "motionSync") await client.setMotionSync(enabled);
+      if (setting === "angleSnapping") await client.setAngleSnapping(enabled);
+      if (setting === "rippleControl") await client.setRippleControl(enabled);
+      if (setting === "performanceMode" && !activePulsarClient && !activeOrbitalClient) throw new Error("Performance mode is not exposed by this device's protocol.");
+      if (setting === "performanceMode") await (activePulsarClient ?? activeOrbitalClient)!.setPerformanceMode(enabled);
+    },
+  });
 }
 
 function settingLabel(setting: PulsarToggleSetting): string {
@@ -1378,42 +1476,42 @@ function settingLabel(setting: PulsarToggleSetting): string {
   } as const)[setting];
 }
 
-async function applyEggFilter(setting: "slamclick" | "motionJitter", enabled: boolean): Promise<void> {
-  if (!activeEggClient || settingInProgress) return;
-  settingInProgress = true;
+function applyEggFilter(setting: "slamclick" | "motionJitter", enabled: boolean): void {
+  if (!activeEggClient) return;
   const label = setting === "slamclick" ? "slamclick filter" : "motion-jitter filter";
-  setText("#read-status", `${enabled ? "Enabling" : "Disabling"} ${label}…`);
-  recordDiagnosticCommand(`${enabled ? "Enable" : "Disable"} ${label}`);
-  try {
-    if (setting === "slamclick") await activeEggClient.setSlamclickFilter(enabled);
-    else await activeEggClient.setMotionJitterFilter(enabled);
-    showStatus(await activeEggClient.readStatus());
-  } catch (error) {
-    recordDiagnosticError(error, `Unable to change the ${label}.`);
-    setText("#read-status", error instanceof Error ? error.message : `Unable to change the ${label}.`);
-    const status = await activeEggClient.readStatus().catch(() => null);
-    if (status) showStatus(status);
-  } finally {
-    settingInProgress = false;
-  }
+  stageChange({
+    key: `egg-${setting}`,
+    label: `${label} ${enabled ? "on" : "off"}`,
+    command: `${enabled ? "Enable" : "Disable"} ${label}`,
+    progress: `${enabled ? "Enabling" : "Disabling"} ${label}…`,
+    preview: (status) => {
+      if (setting === "slamclick") status.slamclickFilter = enabled;
+      else status.motionJitterFilter = enabled;
+    },
+    apply: async () => {
+      if (!activeEggClient) throw new Error("The mouse is no longer connected.");
+      if (setting === "slamclick") await activeEggClient.setSlamclickFilter(enabled);
+      else await activeEggClient.setMotionJitterFilter(enabled);
+    },
+  });
 }
 
-async function applyEggSpdtMode(button: "left" | "right", mode: EggSpdtMode): Promise<void> {
-  if (!activeEggClient || settingInProgress) return;
-  settingInProgress = true;
-  setText("#read-status", `Setting the ${button} button to ${mode}…`);
-  recordDiagnosticCommand(`Set ${button} button GX mode to ${mode}`);
-  try {
-    await activeEggClient.setSpdtMode(button, mode);
-    showStatus(await activeEggClient.readStatus());
-  } catch (error) {
-    recordDiagnosticError(error, `Unable to change the ${button} button GX mode.`);
-    setText("#read-status", error instanceof Error ? error.message : `Unable to change the ${button} button GX mode.`);
-    const status = await activeEggClient.readStatus().catch(() => null);
-    if (status) showStatus(status);
-  } finally {
-    settingInProgress = false;
-  }
+function applyEggSpdtMode(button: "left" | "right", mode: EggSpdtMode): void {
+  if (!activeEggClient) return;
+  stageChange({
+    key: `egg-spdt-${button}`,
+    label: `${button === "left" ? "Left" : "Right"} GX ${mode}`,
+    command: `Set ${button} button GX mode to ${mode}`,
+    progress: `Setting the ${button} button to ${mode}…`,
+    preview: (status) => {
+      if (button === "left") status.leftSpdtMode = mode;
+      else status.rightSpdtMode = mode;
+    },
+    apply: async () => {
+      if (!activeEggClient) throw new Error("The mouse is no longer connected.");
+      await activeEggClient.setSpdtMode(button, mode);
+    },
+  });
 }
 
 function updateCustomPollingPreview(): void {
@@ -1424,78 +1522,137 @@ function updateCustomPollingPreview(): void {
 }
 
 
-async function applyEggCpiLevels(levels: number): Promise<void> {
-  await applyEggChange("CPI stage count", async (client) => client.setCpiLevels(levels));
+function applyEggCpiLevels(levels: number): void {
+  stageEggChange({
+    key: "egg-cpi-levels",
+    label: `${levels} CPI stage${levels === 1 ? "" : "s"}`,
+    what: "CPI stage count",
+    preview: (status) => {
+      status.eggCpiLevels = levels;
+    },
+    change: async (client) => client.setCpiLevels(levels),
+  });
 }
 
-async function applyEggCpiStage(level: number, x: number, y: number): Promise<void> {
-  await applyEggChange(`CPI stage ${level + 1}`, async (client) => client.setCpiStage(level, x, y));
+function applyEggCpiStage(level: number, x: number, y: number): void {
+  stageEggChange({
+    key: `egg-cpi-stage-${level}`,
+    label: `CPI stage ${level + 1} → ${x === y ? x.toLocaleString() : `${x.toLocaleString()}/${y.toLocaleString()}`}`,
+    what: `CPI stage ${level + 1}`,
+    preview: (status) => {
+      const stage = status.eggCpiStages?.[level];
+      if (stage) {
+        stage.x = x;
+        stage.y = y;
+      }
+    },
+    change: async (client) => client.setCpiStage(level, x, y),
+  });
 }
 
-async function applyEggPollingDivider(divider: number): Promise<void> {
-  await applyEggChange("custom polling divider", async (client) => client.setCustomPollingDivider(divider));
+function applyEggPollingDivider(divider: number): void {
+  stageEggChange({
+    key: "egg-polling-divider",
+    label: `Polling divider ${divider}`,
+    what: "custom polling divider",
+    preview: (status) => {
+      status.eggPollingDivider = divider;
+    },
+    change: async (client) => client.setCustomPollingDivider(divider),
+  });
 }
 
-async function applyEggMulticlick(button: EggButtonIndex, value: number): Promise<void> {
-  await applyEggChange(`${EGG_BUTTON_NAMES[button]} multiclick filter`, async (client) => client.setMulticlickFilter(button, value));
+function applyEggMulticlick(button: EggButtonIndex, value: number): void {
+  stageEggChange({
+    key: `egg-multiclick-${button}`,
+    label: `${EGG_BUTTON_NAMES[button]} multiclick ${value}`,
+    what: `${EGG_BUTTON_NAMES[button]} multiclick filter`,
+    preview: (status) => {
+      if (status.eggMulticlickFilters) status.eggMulticlickFilters[button] = value;
+    },
+    change: async (client) => client.setMulticlickFilter(button, value),
+  });
 }
 
-async function applyEggButtonMapping(button: EggButtonIndex, mapping: EggButtonMapping): Promise<void> {
-  await applyEggChange(`${EGG_BUTTON_NAMES[button]} mapping`, async (client) => client.setButtonMapping(button, mapping));
+function applyEggButtonMapping(button: EggButtonIndex, mapping: EggButtonMapping): void {
+  stageEggChange({
+    key: `egg-mapping-${button}`,
+    label: `${EGG_BUTTON_NAMES[button]} → ${mapping}`,
+    what: `${EGG_BUTTON_NAMES[button]} mapping`,
+    preview: (status) => {
+      if (status.eggButtonMappings) status.eggButtonMappings[button] = mapping;
+    },
+    change: async (client) => client.setButtonMapping(button, mapping),
+  });
 }
 
-async function applyEggChange(label: string, change: (client: EggOp1HidClient) => Promise<void>): Promise<void> {
-  if (!activeEggClient || settingInProgress) return;
-  settingInProgress = true;
-  setText("#read-status", `Changing ${label}…`);
-  recordDiagnosticCommand(`Change ${label}`);
-  try {
-    await change(activeEggClient);
-    showStatus(await activeEggClient.readStatus());
-  } catch (error) {
-    recordDiagnosticError(error, `Unable to change ${label}.`);
-    setText("#read-status", error instanceof Error ? error.message : `Unable to change ${label}.`);
-    const status = await activeEggClient.readStatus().catch(() => null);
-    if (status) showStatus(status);
-  } finally {
-    settingInProgress = false;
-  }
+function stageEggChange(options: {
+  key: string;
+  label: string;
+  what: string;
+  preview: PendingChange["preview"];
+  change: (client: EggOp1HidClient) => Promise<void>;
+}): void {
+  if (!activeEggClient) return;
+  stageChange({
+    key: options.key,
+    label: options.label,
+    command: `Change ${options.what}`,
+    progress: `Changing ${options.what}…`,
+    preview: options.preview,
+    apply: async () => {
+      if (!activeEggClient) throw new Error("The mouse is no longer connected.");
+      await options.change(activeEggClient);
+    },
+  });
 }
 
-async function applyPulsarValue(setting: "debounce" | "sleep", value: number): Promise<void> {
-  const client = activePulsarClient ?? activeDmClient ?? activeOrbitalClient;
-  if (!client || settingInProgress) return;
-  settingInProgress = true;
-  setText("#read-status", `Setting ${setting === "debounce" ? `${value} ms debounce` : "auto sleep"}…`);
-  recordDiagnosticCommand(setting === "debounce" ? `Set debounce to ${value} ms` : `Set auto sleep to ${value} seconds`);
-  try {
-    if (setting === "debounce") await client.setDebounceTime(value);
-    else await client.setSleepTimeout(value);
-    showStatus(await statusAfterWrite(client));
-  } catch (error) {
-    recordDiagnosticError(error, "Unable to change that setting.");
-    setText("#read-status", error instanceof Error ? error.message : "Unable to change that setting.");
-  } finally {
-    settingInProgress = false;
-  }
+function applyPulsarValue(setting: "debounce" | "sleep", value: number): void {
+  if (!(activePulsarClient ?? activeDmClient ?? activeOrbitalClient)) return;
+  const asleep = value !== WLMOUSE_SLEEP_NEVER;
+  stageChange({
+    key: setting,
+    label: setting === "debounce"
+      ? `${value} ms debounce`
+      : asleep ? `Auto sleep ${sleepLabel(value)}` : "Auto sleep off",
+    command: setting === "debounce" ? `Set debounce to ${value} ms` : `Set auto sleep to ${value} seconds`,
+    progress: `Setting ${setting === "debounce" ? `${value} ms debounce` : "auto sleep"}…`,
+    preview: (status) => {
+      if (setting === "debounce") status.debounceMs = value;
+      // Drivers report a disabled sleep timer as null, so mirror that here.
+      else status.sleepTimeout = asleep ? value : null;
+    },
+    apply: async () => {
+      const client = activePulsarClient ?? activeDmClient ?? activeOrbitalClient;
+      if (!client) throw new Error("The mouse is no longer connected.");
+      if (setting === "debounce") await client.setDebounceTime(value);
+      else await client.setSleepTimeout(value);
+    },
+  });
 }
 
-async function applyProSetting(setting: "wheelAcceleration" | "angleTuning" | "profile", value: boolean | number): Promise<void> {
-  if (!(activePulsarClient instanceof PulsarProHidClient) || settingInProgress) return;
-  settingInProgress = true;
-  setText("#read-status", `Changing ${setting === "wheelAcceleration" ? "wheel acceleration" : setting === "angleTuning" ? "angle tuning" : "onboard profile"}…`);
-  recordDiagnosticCommand(`Change ${setting === "wheelAcceleration" ? "wheel acceleration" : setting === "angleTuning" ? "angle tuning" : "onboard profile"}`);
-  try {
-    if (setting === "wheelAcceleration") await activePulsarClient.setWheelAcceleration(Boolean(value));
-    if (setting === "angleTuning") await activePulsarClient.setAngleTuning(Number(value));
-    if (setting === "profile") await activePulsarClient.setProfile(Number(value));
-    showStatus(await activePulsarClient.readStatus());
-  } catch (error) {
-    recordDiagnosticError(error, "Unable to change the Pulsar Pro setting.");
-    setText("#read-status", error instanceof Error ? error.message : "Unable to change the Pulsar Pro setting.");
-  } finally {
-    settingInProgress = false;
-  }
+function applyProSetting(setting: "wheelAcceleration" | "angleTuning" | "profile", value: boolean | number): void {
+  if (!(activePulsarClient instanceof PulsarProHidClient)) return;
+  const what = setting === "wheelAcceleration" ? "wheel acceleration" : setting === "angleTuning" ? "angle tuning" : "onboard profile";
+  stageChange({
+    key: `pro-${setting}`,
+    label: setting === "wheelAcceleration"
+      ? `Wheel acceleration ${value ? "on" : "off"}`
+      : setting === "angleTuning" ? `Angle tuning ${value}°` : `Profile ${value}`,
+    command: `Change ${what}`,
+    progress: `Changing ${what}…`,
+    preview: (status) => {
+      if (setting === "wheelAcceleration") status.wheelAcceleration = Boolean(value);
+      if (setting === "angleTuning") status.angleTuning = Number(value);
+      if (setting === "profile") status.activeProfile = Number(value);
+    },
+    apply: async () => {
+      if (!(activePulsarClient instanceof PulsarProHidClient)) throw new Error("The mouse is no longer connected.");
+      if (setting === "wheelAcceleration") await activePulsarClient.setWheelAcceleration(Boolean(value));
+      if (setting === "angleTuning") await activePulsarClient.setAngleTuning(Number(value));
+      if (setting === "profile") await activePulsarClient.setProfile(Number(value));
+    },
+  });
 }
 
 function startAutomaticRefresh(): void {
@@ -1538,7 +1695,8 @@ async function refreshStatus(): Promise<void> {
   }
 }
 
-window.addEventListener("beforeunload", () => {
+window.addEventListener("beforeunload", (event) => {
+  if (hasPendingChanges()) event.preventDefault();
   if (refreshTimer !== null) window.clearInterval(refreshTimer);
   navigator.hid?.removeEventListener("connect", handleHidConnect);
   navigator.hid?.removeEventListener("disconnect", handleHidDisconnect);

--- a/src/devices/endgame/egg-controls-view.ts
+++ b/src/devices/endgame/egg-controls-view.ts
@@ -7,9 +7,9 @@ import {
 import type { MouseStatus } from "../mouse-types";
 
 export interface EggControlActions {
-  applyCpiStage(level: number, x: number, y: number): Promise<void>;
-  applyMulticlick(button: EggButtonIndex, value: number): Promise<void>;
-  applyButtonMapping(button: EggButtonIndex, mapping: EggButtonMapping): Promise<void>;
+  applyCpiStage(level: number, x: number, y: number): void;
+  applyMulticlick(button: EggButtonIndex, value: number): void;
+  applyButtonMapping(button: EggButtonIndex, mapping: EggButtonMapping): void;
 }
 
 export function renderEggControls(status: MouseStatus, actions: EggControlActions): void {

--- a/src/pending-changes.ts
+++ b/src/pending-changes.ts
@@ -1,0 +1,71 @@
+import type { MouseStatus } from "./devices/mouse-types";
+
+export interface PendingChange {
+  // Dedupe key. Staging the same key again replaces the earlier entry.
+  key: string;
+  // Short summary shown in the unsaved-changes bar, e.g. "DPI 1,600".
+  label: string;
+  // Diagnostics command text recorded when the change is flashed.
+  command: string;
+  // Live-status copy shown while this change is being written.
+  progress: string;
+  // Mirrors the staged value onto a status snapshot so the UI can render it.
+  preview(status: MouseStatus): void;
+  // Writes the staged value to the device.
+  apply(): Promise<void>;
+}
+
+const changes = new Map<string, PendingChange>();
+const listeners = new Set<() => void>();
+
+export function onPendingChanges(listener: () => void): void {
+  listeners.add(listener);
+}
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+export function stagePendingChange(change: PendingChange): void {
+  // Re-insert so the bar lists changes in the order they were last touched.
+  changes.delete(change.key);
+  changes.set(change.key, change);
+  notify();
+}
+
+export function pendingChanges(): PendingChange[] {
+  return [...changes.values()];
+}
+
+export function pendingChangeCount(): number {
+  return changes.size;
+}
+
+export function hasPendingChanges(): boolean {
+  return changes.size > 0;
+}
+
+export function isPendingChange(key: string): boolean {
+  return changes.has(key);
+}
+
+export function dropPendingChange(key: string): void {
+  if (changes.delete(key)) notify();
+}
+
+export function clearPendingChanges(): void {
+  if (changes.size === 0) return;
+  changes.clear();
+  notify();
+}
+
+/**
+ * Returns `status` with every staged value mirrored onto a copy, so background
+ * refreshes cannot snap the controls back to the values still on the device.
+ */
+export function withPendingChanges(status: MouseStatus): MouseStatus {
+  if (changes.size === 0) return status;
+  const preview = structuredClone(status);
+  for (const change of changes.values()) change.preview(preview);
+  return preview;
+}

--- a/src/ui/pending-bar.ts
+++ b/src/ui/pending-bar.ts
@@ -1,0 +1,52 @@
+import { pendingChangeCount, pendingChanges } from "../pending-changes";
+import { setText } from "./dom";
+
+// Must stay in step with the `pending-bar-sink` animation in control.css
+const HIDE_DELAY_MS = 220;
+
+let hideTimer: number | null = null;
+
+function bar(): HTMLElement | null {
+  return document.querySelector<HTMLElement>("#pending-changes-bar");
+}
+
+export function renderPendingBar(): void {
+  const element = bar();
+  if (!element) return;
+  const count = pendingChangeCount();
+  document.querySelector<HTMLElement>(".control-shell")?.classList.toggle("has-pending-changes", count > 0);
+  if (count === 0) {
+    if (element.hidden || element.classList.contains("is-leaving")) return;
+    element.classList.add("is-leaving");
+    hideTimer = window.setTimeout(() => {
+      element.hidden = true;
+      element.classList.remove("is-leaving");
+      hideTimer = null;
+    }, HIDE_DELAY_MS);
+    return;
+  }
+  if (hideTimer !== null) {
+    window.clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+  element.classList.remove("is-leaving");
+  element.hidden = false;
+  setText("#pending-changes-count", count === 1 ? "1 unsaved change" : `${count} unsaved changes`);
+  setText("#pending-changes-summary", pendingChanges().map((change) => change.label).join(" · "));
+}
+
+// Swaps the bar into its loading state while staged changes are written.
+export function setPendingBarBusy(busy: boolean): void {
+  const element = bar();
+  if (!element) return;
+  element.classList.toggle("is-flashing", busy);
+  element.querySelectorAll<HTMLButtonElement>("button").forEach((button) => {
+    button.disabled = busy;
+  });
+  setText("#pending-flash-label", busy ? "Flashing…" : "Flash");
+  if (!busy) renderPendingBar();
+}
+
+export function setPendingBarStatus(text: string): void {
+  setText("#pending-changes-summary", text);
+}


### PR DESCRIPTION
## What

Settings changes no longer write to the mouse the moment they're modified.
They're staged, listed in a bar that rises from the bottom of the screen, and written only when the user clicks **Flash** or thrown away with **Revert**.

## Why

Every `apply*` handler wrote to the device on click. That meant a flash cycle per adjustment, no way to back out of a misclick, and no chance to review a set of changes before committing them to the mouse.

## Preview
https://github.com/user-attachments/assets/25a5bc5f-9740-4dc4-895f-7620fe4b0c27

## Behaviour

**Flash** writes staged changes in order, dropping each as it lands, then re-reads the device once.
If one fails, the writes that already landed are dropped and only the remainder stays staged for retry; the error surfaces in both the bar and the live status line.

**Revert** discards everything and repaints from the last device read.

Staged changes are cleared on device switch and disconnect they belong to the mouse they were made on.
`beforeunload` warns if changes are still pending.

## Not in this PR

Several drivers pack multiple settings into one register or config packet: Logitech's feature `0x2202` function `0x60` carries both DPI axes and the lift off distance in a single payload, and the Endgame OP1 and Orbital drivers rewrite a whole config blob per setter.
Flashing those settings together currently costs one write each. Now that there's a commit point, coalescing them is worth a follow up.

## Testing

  `npx tsc   noEmit` clean
  `npm test`   19/19 pass
  `vite build` succeeds