### PR TITLE
feat(razer): Add Viper V3 Pro Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test src/*.test.ts src/devices/endgame/*.test.ts src/devices/logitech/*.test.ts src/devices/orbital/*.test.ts",
+    "test": "node --test src/*.test.ts src/devices/endgame/*.test.ts src/devices/logitech/*.test.ts src/devices/orbital/*.test.ts src/devices/razer/*.test.ts",
     "check": "npm run build && npm test",
     "preview": "vite preview"
   },

--- a/src/control.ts
+++ b/src/control.ts
@@ -115,17 +115,19 @@ function requireSettingsClient(): SupportedClient {
   return client;
 }
 
-/** Drivers that expose the shared write surface; read-only drivers are excluded. */
-type WritableClient = Extract<SupportedClient, { setDpi: unknown }>;
-
 /**
- * Read-only drivers hide the settings grid through `settingsReady`, so this is
- * a guard rather than a path the interface offers.
+ * Drivers may confirm one write before another, so each setting is checked on
+ * its own. A driver that hides the settings grid never reaches these, which
+ * makes this a guard rather than a path the interface offers.
  */
-function requireWritableClient(): WritableClient {
+function requireClientMethod<K extends string>(
+  method: K,
+  setting: string,
+): Extract<SupportedClient, Record<K, unknown>> {
   const client = requireSettingsClient();
-  if (!("setDpi" in client)) throw new Error("This mouse is supported for reading only.");
-  return client;
+  if (!(method in client)) throw new Error(`This mouse does not support changing ${setting} yet.`);
+  // `in` does not narrow through a generic key, so the union is filtered here.
+  return client as Extract<SupportedClient, Record<K, unknown>>;
 }
 
 /**
@@ -1375,7 +1377,7 @@ function applyDpiValue(dpi: number): boolean {
       if (status.dpiY !== undefined) status.dpiY = dpi;
     },
     apply: async () => {
-      await requireWritableClient().setDpi(dpi);
+      await requireClientMethod("setDpi", "DPI").setDpi(dpi);
     },
   });
   return true;
@@ -1453,7 +1455,7 @@ function applyPollingRate(rate: number): void {
       status.pollingRateHz = rate;
     },
     apply: async () => {
-      await requireWritableClient().setPollingRate(rate);
+      await requireClientMethod("setPollingRate", "the polling rate").setPollingRate(rate);
     },
   });
 }
@@ -1469,7 +1471,7 @@ function applyLiftOffDistance(lod: NonNullable<MouseStatus["liftOffDistance"]>):
       status.liftOffDistance = lod;
     },
     apply: async () => {
-      await requireWritableClient().setLiftOffDistance(lod);
+      await requireClientMethod("setLiftOffDistance", "the lift-off distance").setLiftOffDistance(lod);
     },
   });
 }

--- a/src/control.ts
+++ b/src/control.ts
@@ -56,6 +56,7 @@ import { LogitechHidppClient } from "./devices/logitech/hidpp";
 import type { MouseStatus } from "./devices/mouse-types";
 import { PulsarProHidClient } from "./devices/pulsar/pulsar-pro-hid";
 import { OrbitalHidClient } from "./devices/orbital/hid";
+import { RazerHidClient } from "./devices/razer/hid";
 import { SUPPORTED_HID_FILTERS } from "./devices/vendors";
 import { WLMouseHidClient } from "./devices/wlmouse/hid";
 
@@ -76,6 +77,7 @@ let activeEggClient: EggOp1HidClient | null = null;
 let activeEggWeClient: EggWeHidClient | null = null;
 let activeDmClient: WLMouseHidClient | LamzuHidClient | null = null;
 let activeOrbitalClient: OrbitalHidClient | null = null;
+let activeRazerClient: RazerHidClient | null = null;
 let refreshTimer: number | null = null;
 let refreshInProgress = false;
 let dpiOptions: number[] = [];
@@ -100,7 +102,7 @@ async function statusAfterWrite(client: SupportedClient): Promise<MouseStatus> {
 }
 
 function activeSettingsClient(): SupportedClient | null {
-  return activeClient ?? activePulsarClient ?? activeEggClient ?? activeEggWeClient ?? activeDmClient ?? activeOrbitalClient;
+  return activeClient ?? activePulsarClient ?? activeEggClient ?? activeEggWeClient ?? activeDmClient ?? activeOrbitalClient ?? activeRazerClient;
 }
 
 function hasActiveClient(): boolean {
@@ -110,6 +112,19 @@ function hasActiveClient(): boolean {
 function requireSettingsClient(): SupportedClient {
   const client = activeSettingsClient();
   if (!client) throw new Error("The mouse is no longer connected.");
+  return client;
+}
+
+/** Drivers that expose the shared write surface; read-only drivers are excluded. */
+type WritableClient = Extract<SupportedClient, { setDpi: unknown }>;
+
+/**
+ * Read-only drivers hide the settings grid through `settingsReady`, so this is
+ * a guard rather than a path the interface offers.
+ */
+function requireWritableClient(): WritableClient {
+  const client = requireSettingsClient();
+  if (!("setDpi" in client)) throw new Error("This mouse is supported for reading only.");
   return client;
 }
 
@@ -990,6 +1005,7 @@ async function activateClient(client: SupportedClient): Promise<void> {
   activeEggWeClient = null;
   activeDmClient = null;
   activeOrbitalClient = null;
+  activeRazerClient = null;
   activeDevice = client.device;
   recordDiagnosticCommand("Read device status");
   lastRenderedStatusKey = null;
@@ -1032,6 +1048,13 @@ async function activateClient(client: SupportedClient): Promise<void> {
     dpiOptions = client.getDpiOptions();
     configureDpiControl(status.dpi);
     showStatus(status);
+  } else if (client instanceof RazerHidClient) {
+    activeRazerClient = client;
+    const status = await client.readStatus();
+    deviceStatuses.set(client.device, status);
+    dpiOptions = client.getDpiOptions();
+    configureDpiControl(status.dpi);
+    showStatus(status);
   } else {
     activePulsarClient = client;
     await showPulsarExplorer(client);
@@ -1053,6 +1076,7 @@ function showDisconnectedState(): void {
   activeEggWeClient = null;
   activeDmClient = null;
   activeOrbitalClient = null;
+  activeRazerClient = null;
   activeDevice = null;
   lastRenderedStatusKey = null;
   clearPendingChanges();
@@ -1346,7 +1370,7 @@ function applyDpiValue(dpi: number): boolean {
       if (status.dpiY !== undefined) status.dpiY = dpi;
     },
     apply: async () => {
-      await requireSettingsClient().setDpi(dpi);
+      await requireWritableClient().setDpi(dpi);
     },
   });
   return true;
@@ -1424,7 +1448,7 @@ function applyPollingRate(rate: number): void {
       status.pollingRateHz = rate;
     },
     apply: async () => {
-      await requireSettingsClient().setPollingRate(rate);
+      await requireWritableClient().setPollingRate(rate);
     },
   });
 }
@@ -1440,7 +1464,7 @@ function applyLiftOffDistance(lod: NonNullable<MouseStatus["liftOffDistance"]>):
       status.liftOffDistance = lod;
     },
     apply: async () => {
-      await requireSettingsClient().setLiftOffDistance(lod);
+      await requireWritableClient().setLiftOffDistance(lod);
     },
   });
 }
@@ -1757,6 +1781,7 @@ window.addEventListener("beforeunload", (event) => {
   void activeEggWeClient?.close();
   void activeDmClient?.close();
   void activeOrbitalClient?.close();
+  void activeRazerClient?.close();
 });
 
 renderControl();

--- a/src/control.ts
+++ b/src/control.ts
@@ -784,13 +784,14 @@ function showStatus(deviceStatus: MouseStatus): void {
   // Same banner copy as other brands — no RE/debug messaging in the chrome.
   setText("#connection-banner", "Connected directly through WebHID. Supported settings can be adjusted here.");
   if (settingsPending) {
-    // A driver may read more than it can write yet, so report the values even
-    // though the grid that would edit them stays hidden.
-    setText("#read-status", [
-      deviceStatus.batteryPercent === null ? "Connected" : `Battery ${deviceStatus.batteryPercent}%`,
-      `${deviceStatus.dpi.toLocaleString()} DPI`,
-      `${deviceStatus.pollingRateHz.toLocaleString()} Hz`,
-    ].join(" · "));
+    // A driver may read more than it can write yet. Only drivers that read
+    // these values report them; the rest fall back to a placeholder here.
+    const battery = deviceStatus.batteryPercent === null
+      ? "Connected"
+      : `Battery ${deviceStatus.batteryPercent}%`;
+    setText("#read-status", ui?.valuesVerified
+      ? [battery, `${deviceStatus.dpi.toLocaleString()} DPI`, `${deviceStatus.pollingRateHz.toLocaleString()} Hz`].join(" · ")
+      : battery);
   } else if (!hasPendingChanges()) {
     setText("#read-status", `Current: ${deviceStatus.dpi.toLocaleString()} DPI · ${deviceStatus.pollingRateHz.toLocaleString()} Hz`);
   }

--- a/src/control.ts
+++ b/src/control.ts
@@ -784,9 +784,13 @@ function showStatus(deviceStatus: MouseStatus): void {
   // Same banner copy as other brands — no RE/debug messaging in the chrome.
   setText("#connection-banner", "Connected directly through WebHID. Supported settings can be adjusted here.");
   if (settingsPending) {
-    setText("#read-status", deviceStatus.batteryPercent === null
-      ? "Connected"
-      : `Battery ${deviceStatus.batteryPercent}%`);
+    // A driver may read more than it can write yet, so report the values even
+    // though the grid that would edit them stays hidden.
+    setText("#read-status", [
+      deviceStatus.batteryPercent === null ? "Connected" : `Battery ${deviceStatus.batteryPercent}%`,
+      `${deviceStatus.dpi.toLocaleString()} DPI`,
+      `${deviceStatus.pollingRateHz.toLocaleString()} Hz`,
+    ].join(" · "));
   } else if (!hasPendingChanges()) {
     setText("#read-status", `Current: ${deviceStatus.dpi.toLocaleString()} DPI · ${deviceStatus.pollingRateHz.toLocaleString()} Hz`);
   }

--- a/src/devices/mouse-types.ts
+++ b/src/devices/mouse-types.ts
@@ -8,6 +8,11 @@ export interface MouseUiHints {
   family?: string;
   /** When false, core settings grid stays hidden. Default true. */
   settingsReady?: boolean;
+  /**
+   * DPI and polling in this status were read from the mouse rather than filled
+   * in, so they are worth reporting even while `settingsReady` hides the grid.
+   */
+  valuesVerified?: boolean;
   /** Hide 0.7 mm LOD option. */
   hideLodLow?: boolean;
   /** Disable LOD controls while gamingSurfaceMode is "Off". */

--- a/src/devices/mouse-types.ts
+++ b/src/devices/mouse-types.ts
@@ -25,7 +25,7 @@ export interface MouseUiHints {
 }
 
 export interface MouseStatus {
-  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "Lamzu" | "Orbital";
+  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "Lamzu" | "Orbital" | "Razer";
   name: string;
   /** Driver-supplied UI policy (optional; keeps control.ts brand-agnostic). */
   ui?: MouseUiHints;

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -25,8 +25,8 @@ The cable and the receiver are separate devices with separate product IDs, so
 each needs its own browser permission. Granting one does not grant the other,
 and switching between them the first time means adding the device again.
 
-This driver is read-only. It sends no write command, and the settings grid stays
-hidden through `settingsReady`.
+DPI and polling rate can be written. Every other control is withheld because no
+command for it has been confirmed.
 
 1. Connect the mouse over the cable and confirm the model, wired state, battery,
    charging state, DPI, and polling rate are correct.
@@ -34,9 +34,15 @@ hidden through `settingsReady`.
    should read false, and the polling rate should match Synapse.
 3. Confirm the reported polling rate tracks a change made in Synapse on both
    connections, including an 8000 Hz setting on the receiver.
-4. Leave the panel open for a few minutes and confirm the background refresh
+4. Change the DPI and confirm the pointer speed changes with it, then reload and
+   confirm the new value persisted.
+5. Change the polling rate on each connection and confirm it persists. The cable
+   offers 125/500/1000 and the receiver adds 2000/4000/8000; no other rate
+   should appear.
+6. Confirm no lift-off distance buttons and no sensor processing card appear.
+7. Leave the panel open for a few minutes and confirm the background refresh
    keeps reporting without stalling or throwing.
-5. Record the device identifier, firmware version, and any failing read in the
+8. Record the device identifier, firmware version, and any failing setting in the
    issue or pull request.
 
 ## Verified against firmware 1.12
@@ -52,17 +58,33 @@ hidden through `settingsReady`.
 | Polling, legacy | `0x00` / `0x85` | divisor of 1000; **wired only** |
 | Polling, extended | `0x00` / `0xc0` | divisor of 8000; **receiver only** |
 
-Transaction ID `0x1f` answered every command on both connections.
+Each write clears the high bit of the matching read.
+
+| Write | Class / ID | Notes |
+| --- | --- | --- |
+| DPI | `0x04` / `0x05` | storage byte, then big-endian X and Y |
+| Polling, legacy | `0x00` / `0x05` | divisor of 1000; **wired only** |
+| Polling, extended | `0x00` / `0x40` | leading `0x00`, then divisor of 8000 |
+
+Transaction ID `0x1f` answered every command on both connections. Writes were
+confirmed by effect, not only by read-back: a DPI change altered pointer speed,
+and a 500 Hz write measured 499 Hz through `pointerrawupdate`.
+
+The cable is limited to 1000 Hz on this model, which is also the ceiling the
+legacy encoding can express, so no HyperPolling command is missing there.
 
 ## Unresolved
 
-- Wired reports polling only through the legacy command, which cannot express
-  rates above 1000 Hz. The command the wired connection uses for HyperPolling
-  rates has not been found, so `supportedPollingRates` is left unset rather than
-  advertising a range that has not been confirmed.
-- No write command has been verified. DPI, polling rate, and lift-off distance
-  writes are out of scope until each is confirmed against hardware.
+- No lift-off distance command has been found, so no lift-off control is
+  offered and `supportedLiftOffDistances` stays empty.
+- No sensor processing commands (motion sync, angle snapping, ripple control)
+  have been found, so that card stays hidden.
 - The 35000 DPI ceiling comes from the published sensor specification, not from
-  the mouse. The stages read only proves the 400–6400 ladder. Nothing consumes
-  the ceiling while the settings grid is hidden, but confirm it before the first
-  write lands.
+  the mouse; the stages read only proves the 400–6400 ladder. A write past the
+  real ceiling fails its read-back and reports a mismatch rather than silently
+  misreporting, but the ceiling itself is still unconfirmed.
+- DPI step granularity is assumed to be 50. Values off that grid are rejected
+  before they reach the mouse, so a finer or coarser real step would only mean
+  the control offers the wrong choices.
+- The DPI stage table (`0x04`/`0x06`) is decoded and tested but never written.
+  A wrong length there is the one realistic way to corrupt stored settings.

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -52,3 +52,7 @@ Transaction ID `0x1f` answered every command on both connections.
   advertising a range that has not been confirmed.
 - No write command has been verified. DPI, polling rate, and lift-off distance
   writes are out of scope until each is confirmed against hardware.
+- The 35000 DPI ceiling comes from the published sensor specification, not from
+  the mouse. The stages read only proves the 400–6400 ladder. Nothing consumes
+  the ceiling while the settings grid is hidden, but confirm it before the first
+  write lands.

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -73,6 +73,33 @@ and a 500 Hz write measured 499 Hz through `pointerrawupdate`.
 The cable is limited to 1000 Hz on this model, which is also the ceiling the
 legacy encoding can express, so no HyperPolling command is missing there.
 
+## Confirmed but not exposed
+
+| Setting | Read | Write | Encoding |
+| --- | --- | --- | --- |
+| Idle sleep | `0x07` / `0x83` | `0x07` / `0x03` | seconds, big-endian; 60–900 |
+| Low battery | `0x07` / `0x81` | `0x07` / `0x01` | level out of 255, so 77 is 30% |
+
+Both round-trip on hardware and agree with the vendor software. Neither is wired
+to the interface: the sleep and debounce controls are filled per brand rather
+than per capability, so exposing them means changing how the shell picks those
+controls rather than adding a driver method.
+
+Note the low-battery threshold shares the battery level's 0–255 scale. Reading
+it as a percentage gives the wrong number.
+
+## Lift-off distance
+
+Not found. Class `0x0b` answers at `0x80`, `0x85`, `0x8b`, `0x8e`, `0x90`–`0x92`,
+`0x94`, `0x95` and `0xa4`, and class `0x04` holds only DPI commands, but none
+carries the values the vendor software shows. `0x0b`/`0x85` tracks the
+asymmetric cut-off toggle in its third byte: `01` symmetric, `02` asymmetric.
+
+The vendor software exposes lift-off as a continuous slider, and asymmetric mode
+splits it into separate lift-off and landing values where landing cannot exceed
+lift-off. That does not fit the three-value `liftOffDistance` field, so this
+needs a richer type before it can be exposed even once the command is found.
+
 ## Unresolved
 
 - No lift-off distance command has been found, so no lift-off control is

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -1,0 +1,54 @@
+# Razer hardware test checklist
+
+Test in Chrome or Edge over HTTPS. Quit Razer Synapse first — it holds the
+control interface open and reads then time out.
+
+Supported identifiers:
+
+- `1532:00c0` — Viper V3 Pro, wired
+- `1532:00c1` — Viper V3 Pro, HyperSpeed receiver
+
+Razer does not declare its control channel in the HID descriptor, so no
+interface advertises a feature report. The exchange still works because WebHID
+does not check report IDs against the descriptor. The interface that answers is
+the one whose **only** collection is Generic Desktop Mouse (`usagePage 0x01`,
+`usage 0x02`); the browser lists several other Razer interfaces that never
+answer, so pick that one when prompted.
+
+This driver is read-only. It sends no write command, and the settings grid stays
+hidden through `settingsReady`.
+
+1. Connect the mouse over the cable and confirm the model, wired state, battery,
+   charging state, DPI, and polling rate are correct.
+2. Repeat on the receiver. Battery should read a plausible level, charging
+   should read false, and the polling rate should match Synapse.
+3. Confirm the reported polling rate tracks a change made in Synapse on both
+   connections, including an 8000 Hz setting on the receiver.
+4. Leave the panel open for a few minutes and confirm the background refresh
+   keeps reporting without stalling or throwing.
+5. Record the device identifier, firmware version, and any failing read in the
+   issue or pull request.
+
+## Verified against firmware 1.12
+
+| Read | Class / ID | Notes |
+| --- | --- | --- |
+| Firmware | `0x00` / `0x81` | |
+| Serial | `0x00` / `0x82` | ASCII, null terminated |
+| Battery | `0x07` / `0x80` | level out of 255 |
+| Charging | `0x07` / `0x84` | |
+| DPI | `0x04` / `0x85` | big-endian X and Y |
+| DPI stages | `0x04` / `0x86` | seven-byte records; decoded but not yet shown |
+| Polling, legacy | `0x00` / `0x85` | divisor of 1000; **wired only** |
+| Polling, extended | `0x00` / `0xc0` | divisor of 8000; **receiver only** |
+
+Transaction ID `0x1f` answered every command on both connections.
+
+## Unresolved
+
+- Wired reports polling only through the legacy command, which cannot express
+  rates above 1000 Hz. The command the wired connection uses for HyperPolling
+  rates has not been found, so `supportedPollingRates` is left unset rather than
+  advertising a range that has not been confirmed.
+- No write command has been verified. DPI, polling rate, and lift-off distance
+  writes are out of scope until each is confirmed against hardware.

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -12,8 +12,14 @@ Razer does not declare its control channel in the HID descriptor, so no
 interface advertises a feature report. The exchange still works because WebHID
 does not check report IDs against the descriptor. The interface that answers is
 the one whose **only** collection is Generic Desktop Mouse (`usagePage 0x01`,
-`usage 0x02`); the browser lists several other Razer interfaces that never
-answer, so pick that one when prompted.
+`usage 0x02`).
+
+The mouse presents four interfaces on each connection. The vendor filter
+narrows the picker to one of them when wired, and to two on the receiver, where
+a second interface carries a mouse collection alongside others. Both are named
+`Razer Viper V3 Pro` and cannot be told apart in the picker, so on the receiver
+the first choice may be the interface that never answers. It is then skipped in
+the device list; add the device again and choose the other entry.
 
 This driver is read-only. It sends no write command, and the settings grid stays
 hidden through `settingsReady`.

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -78,7 +78,9 @@ legacy encoding can express, so no HyperPolling command is missing there.
 - No lift-off distance command has been found, so no lift-off control is
   offered and `supportedLiftOffDistances` stays empty.
 - No sensor processing commands (motion sync, angle snapping, ripple control)
-  have been found, so that card stays hidden.
+  have been found, so that card stays hidden. The vendor software does not
+  expose them for this model either, so they are more likely absent from the
+  mouse than missing from this driver.
 - The 35000 DPI ceiling comes from the published sensor specification, not from
   the mouse; the stages read only proves the 400–6400 ladder. A write past the
   real ceiling fails its read-back and reports a mismatch rather than silently

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -21,6 +21,10 @@ a second interface carries a mouse collection alongside others. Both are named
 the first choice may be the interface that never answers. It is then skipped in
 the device list; add the device again and choose the other entry.
 
+The cable and the receiver are separate devices with separate product IDs, so
+each needs its own browser permission. Granting one does not grant the other,
+and switching between them the first time means adding the device again.
+
 This driver is read-only. It sends no write command, and the settings grid stays
 hidden through `settingsReady`.
 

--- a/src/devices/razer/hid.ts
+++ b/src/devices/razer/hid.ts
@@ -36,7 +36,9 @@ const PRODUCTS: ReadonlyMap<number, RazerProduct> = new Map([
   [0x00c1, { model: "Viper V3 Pro", wireless: true, pollingRates: RATES_RECEIVER }],
 ]);
 
-const DPI_STEP = 50;
+// The sensor takes any whole DPI in this range, per axis, and the vendor
+// software exposes the same bounds.
+const DPI_MIN = 100;
 const DPI_MAX = 35000;
 const RESPONSE_DELAY_MS = 100;
 const RESPONSE_ATTEMPTS = 6;
@@ -93,9 +95,10 @@ export class RazerHidClient {
     return [...(this.profile()?.pollingRates ?? RATES_WIRED)];
   }
 
+  /** Every whole value, because the control validates entries against this list. */
   getDpiOptions(): number[] {
     const options: number[] = [];
-    for (let dpi = DPI_STEP; dpi <= this.maxDpi(); dpi += DPI_STEP) options.push(dpi);
+    for (let dpi = DPI_MIN; dpi <= this.maxDpi(); dpi += 1) options.push(dpi);
     return options;
   }
 
@@ -127,6 +130,7 @@ export class RazerHidClient {
       batteryState: charging ? "Charging" : "Discharging",
       dpi: dpi.x,
       dpiY: dpi.y,
+      supportsSeparateDpiAxes: true,
       pollingRateHz,
       supportedPollingRates: this.getSupportedPollingRates(),
       activeProfile: null,
@@ -142,8 +146,8 @@ export class RazerHidClient {
   async setDpi(dpi: number, dpiY: number = dpi): Promise<number> {
     const ceiling = this.maxDpi();
     for (const value of [dpi, dpiY]) {
-      if (!Number.isInteger(value) || value < DPI_STEP || value > ceiling || value % DPI_STEP !== 0) {
-        throw new Error(`${value.toLocaleString()} is not a supported DPI value.`);
+      if (!Number.isInteger(value) || value < DPI_MIN || value > ceiling) {
+        throw new Error(`DPI must be a whole number between ${DPI_MIN} and ${ceiling.toLocaleString()}.`);
       }
     }
     await this.request(razerSetDpiCommand(dpi, dpiY));

--- a/src/devices/razer/hid.ts
+++ b/src/devices/razer/hid.ts
@@ -120,12 +120,18 @@ export class RazerHidClient {
     };
   }
 
-  /** Wireless answers only the extended command, wired only the legacy one. */
+  /**
+   * Wired answers only the legacy command and the receiver only the extended
+   * one, so ask for the expected one first and keep the other as a fallback.
+   * Asking in the wrong order costs a failed exchange on every refresh.
+   */
   private async readPollingRateHz(): Promise<number> {
-    const extended = await this.request(RAZER_READ.pollingRateExtended).catch(() => null);
-    if (extended) return decodeExtendedPollingRate(extended);
-    const legacy = await this.request(RAZER_READ.pollingRate).catch(() => null);
-    if (legacy) return decodeLegacyPollingRate(legacy);
+    const extended = [RAZER_READ.pollingRateExtended, decodeExtendedPollingRate] as const;
+    const legacy = [RAZER_READ.pollingRate, decodeLegacyPollingRate] as const;
+    for (const [command, decode] of this.isWireless() ? [extended, legacy] : [legacy, extended]) {
+      const reply = await this.request(command).catch(() => null);
+      if (reply) return decode(reply);
+    }
     throw new Error("The mouse did not report a polling rate.");
   }
 

--- a/src/devices/razer/hid.ts
+++ b/src/devices/razer/hid.ts
@@ -15,17 +15,25 @@ import {
   decodeSerial,
   encodeRazerRequest,
   razerSetDpiCommand,
+  razerSetExtendedPollingCommand,
+  razerSetLegacyPollingCommand,
   type RazerCommand,
 } from "./protocol";
 
 interface RazerProduct {
   model: string;
   wireless: boolean;
+  pollingRates: readonly number[];
 }
 
+// The cable tops out at 1000 Hz on this model, which is also the ceiling the
+// legacy polling command can encode. HyperPolling rates need the receiver.
+const RATES_WIRED: readonly number[] = [125, 500, 1000];
+const RATES_RECEIVER: readonly number[] = [125, 500, 1000, 2000, 4000, 8000];
+
 const PRODUCTS: ReadonlyMap<number, RazerProduct> = new Map([
-  [0x00c0, { model: "Viper V3 Pro", wireless: false }],
-  [0x00c1, { model: "Viper V3 Pro", wireless: true }],
+  [0x00c0, { model: "Viper V3 Pro", wireless: false, pollingRates: RATES_WIRED }],
+  [0x00c1, { model: "Viper V3 Pro", wireless: true, pollingRates: RATES_RECEIVER }],
 ]);
 
 const DPI_STEP = 50;
@@ -81,6 +89,10 @@ export class RazerHidClient {
     return DPI_MAX;
   }
 
+  getSupportedPollingRates(): number[] {
+    return [...(this.profile()?.pollingRates ?? RATES_WIRED)];
+  }
+
   getDpiOptions(): number[] {
     const options: number[] = [];
     for (let dpi = DPI_STEP; dpi <= this.maxDpi(); dpi += DPI_STEP) options.push(dpi);
@@ -102,9 +114,12 @@ export class RazerHidClient {
       name: this.displayName(),
       ui: {
         family: "razer",
-        // Reads are verified; no write command has been confirmed yet.
-        settingsReady: false,
+        settingsReady: true,
         valuesVerified: true,
+        hideUnsupportedPollingRates: true,
+        // No lift-off or sensor-processing command is confirmed, so neither
+        // control is offered rather than offered and left inert.
+        hideProcessingCard: true,
         forceShowBattery: true,
         defaultDisplayName: this.profile()?.model,
       },
@@ -113,11 +128,13 @@ export class RazerHidClient {
       dpi: dpi.x,
       dpiY: dpi.y,
       pollingRateHz,
+      supportedPollingRates: this.getSupportedPollingRates(),
       activeProfile: null,
       connectionType: wireless ? "Wireless" : "Wired",
       connectionDetail: wireless ? "HyperSpeed receiver" : "Wired USB",
       unitId: serial ? decodeSerial(serial) : null,
       liftOffDistance: null,
+      supportedLiftOffDistances: [],
       firmware: [`Mouse ${decodeFirmwareVersion(firmware)}`],
     };
   }
@@ -135,6 +152,20 @@ export class RazerHidClient {
       throw new Error(`The mouse kept ${confirmed.x.toLocaleString()} DPI instead of ${dpi.toLocaleString()}.`);
     }
     return confirmed.x;
+  }
+
+  async setPollingRate(pollingRateHz: number): Promise<number> {
+    if (!this.getSupportedPollingRates().includes(pollingRateHz)) {
+      throw new Error(`This mouse does not support ${pollingRateHz.toLocaleString()} Hz on this connection.`);
+    }
+    await this.request(this.isWireless()
+      ? razerSetExtendedPollingCommand(pollingRateHz)
+      : razerSetLegacyPollingCommand(pollingRateHz));
+    const confirmed = await this.readPollingRateHz();
+    if (confirmed !== pollingRateHz) {
+      throw new Error(`The mouse kept ${confirmed.toLocaleString()} Hz instead of ${pollingRateHz.toLocaleString()} Hz.`);
+    }
+    return confirmed;
   }
 
   /**

--- a/src/devices/razer/hid.ts
+++ b/src/devices/razer/hid.ts
@@ -1,0 +1,170 @@
+import type { MouseStatus } from "../mouse-types";
+import { VENDOR_ID } from "../vendors";
+import {
+  RAZER_READ,
+  RAZER_REPORT_ID,
+  RAZER_STATUS,
+  RazerProtocolError,
+  decodeBatteryPercent,
+  decodeCharging,
+  decodeDpi,
+  decodeExtendedPollingRate,
+  decodeFirmwareVersion,
+  decodeLegacyPollingRate,
+  decodeRazerResponse,
+  decodeSerial,
+  encodeRazerRequest,
+  type RazerCommand,
+} from "./protocol";
+
+interface RazerProduct {
+  model: string;
+  wireless: boolean;
+}
+
+const PRODUCTS: ReadonlyMap<number, RazerProduct> = new Map([
+  [0x00c0, { model: "Viper V3 Pro", wireless: false }],
+  [0x00c1, { model: "Viper V3 Pro", wireless: true }],
+]);
+
+const DPI_STEP = 50;
+const DPI_MAX = 35000;
+const RESPONSE_DELAY_MS = 100;
+const RESPONSE_ATTEMPTS = 6;
+
+/**
+ * Razer exposes its control channel on the interface whose only collection is
+ * Generic Desktop Mouse. Every other interface either belongs to a different
+ * function or is a protected collection the browser will not talk to.
+ */
+function isControlInterface(device: HIDDevice): boolean {
+  const [collection, ...rest] = device.collections;
+  return rest.length === 0 && collection?.usagePage === 0x01 && collection?.usage === 0x02;
+}
+
+export class RazerHidClient {
+  private queue: Promise<unknown> = Promise.resolve();
+  private readonly staticReads = new Map<string, Promise<Uint8Array | null>>();
+
+  constructor(readonly device: HIDDevice) {}
+
+  static isSupported(device: HIDDevice): boolean {
+    return device.vendorId === VENDOR_ID.razer
+      && PRODUCTS.has(device.productId)
+      && isControlInterface(device);
+  }
+
+  private profile(): RazerProduct | undefined {
+    return PRODUCTS.get(this.device.productId);
+  }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) await this.device.open();
+  }
+
+  async close(): Promise<void> {
+    this.staticReads.clear();
+    if (this.device.opened) await this.device.close();
+  }
+
+  displayName(): string {
+    const known = this.profile();
+    return known ? `Razer ${known.model}` : this.device.productName || "Razer";
+  }
+
+  isWireless(): boolean {
+    return this.profile()?.wireless ?? false;
+  }
+
+  maxDpi(): number {
+    return DPI_MAX;
+  }
+
+  getDpiOptions(): number[] {
+    const options: number[] = [];
+    for (let dpi = DPI_STEP; dpi <= this.maxDpi(); dpi += DPI_STEP) options.push(dpi);
+    return options;
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    await this.open();
+    const wireless = this.isWireless();
+    const firmware = await this.once("firmware", () => this.request(RAZER_READ.firmware));
+    if (!firmware) throw new Error("The mouse did not report a firmware version.");
+    const serial = await this.once("serial", () => this.request(RAZER_READ.serial).catch(() => null));
+    const battery = await this.request(RAZER_READ.battery);
+    const charging = decodeCharging(await this.request(RAZER_READ.charging));
+    const dpi = decodeDpi(await this.request(RAZER_READ.dpi));
+    const pollingRateHz = await this.readPollingRateHz();
+    return {
+      brand: "Razer",
+      name: this.displayName(),
+      ui: {
+        family: "razer",
+        // Reads are verified; no write command has been confirmed yet.
+        settingsReady: false,
+        forceShowBattery: true,
+        defaultDisplayName: this.profile()?.model,
+      },
+      batteryPercent: decodeBatteryPercent(battery),
+      batteryState: charging ? "Charging" : "Discharging",
+      dpi: dpi.x,
+      dpiY: dpi.y,
+      pollingRateHz,
+      activeProfile: null,
+      connectionType: wireless ? "Wireless" : "Wired",
+      connectionDetail: wireless ? "HyperSpeed receiver" : "Wired USB",
+      unitId: serial ? decodeSerial(serial) : null,
+      liftOffDistance: null,
+      firmware: [`Mouse ${decodeFirmwareVersion(firmware)}`],
+    };
+  }
+
+  /** Wireless answers only the extended command, wired only the legacy one. */
+  private async readPollingRateHz(): Promise<number> {
+    const extended = await this.request(RAZER_READ.pollingRateExtended).catch(() => null);
+    if (extended) return decodeExtendedPollingRate(extended);
+    const legacy = await this.request(RAZER_READ.pollingRate).catch(() => null);
+    if (legacy) return decodeLegacyPollingRate(legacy);
+    throw new Error("The mouse did not report a polling rate.");
+  }
+
+  private once(key: string, read: () => Promise<Uint8Array | null>): Promise<Uint8Array | null> {
+    const pending = this.staticReads.get(key);
+    if (pending) return pending;
+    const started = read();
+    this.staticReads.set(key, started);
+    started.catch(() => this.staticReads.delete(key));
+    return started;
+  }
+
+  private async request(command: RazerCommand): Promise<Uint8Array> {
+    const run = this.queue.then(() => this.exchange(command), () => this.exchange(command));
+    this.queue = run.catch(() => undefined);
+    return await run;
+  }
+
+  private async exchange(command: RazerCommand): Promise<Uint8Array> {
+    await this.open();
+    await this.device.sendFeatureReport(RAZER_REPORT_ID, encodeRazerRequest(command));
+    for (let attempt = 0; attempt < RESPONSE_ATTEMPTS; attempt += 1) {
+      await this.delay(RESPONSE_DELAY_MS);
+      const reply = this.copyDataView(await this.device.receiveFeatureReport(RAZER_REPORT_ID));
+      try {
+        return decodeRazerResponse(reply, command);
+      } catch (error) {
+        if (error instanceof RazerProtocolError && error.status === RAZER_STATUS.busy) continue;
+        throw error;
+      }
+    }
+    throw new Error("The mouse stayed busy — it may be asleep or out of range.");
+  }
+
+  private copyDataView(view: DataView): Uint8Array {
+    return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+  }
+
+  private delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+  }
+}

--- a/src/devices/razer/hid.ts
+++ b/src/devices/razer/hid.ts
@@ -103,6 +103,7 @@ export class RazerHidClient {
         family: "razer",
         // Reads are verified; no write command has been confirmed yet.
         settingsReady: false,
+        valuesVerified: true,
         forceShowBattery: true,
         defaultDisplayName: this.profile()?.model,
       },

--- a/src/devices/razer/hid.ts
+++ b/src/devices/razer/hid.ts
@@ -14,6 +14,7 @@ import {
   decodeRazerResponse,
   decodeSerial,
   encodeRazerRequest,
+  razerSetDpiCommand,
   type RazerCommand,
 } from "./protocol";
 
@@ -119,6 +120,21 @@ export class RazerHidClient {
       liftOffDistance: null,
       firmware: [`Mouse ${decodeFirmwareVersion(firmware)}`],
     };
+  }
+
+  async setDpi(dpi: number, dpiY: number = dpi): Promise<number> {
+    const ceiling = this.maxDpi();
+    for (const value of [dpi, dpiY]) {
+      if (!Number.isInteger(value) || value < DPI_STEP || value > ceiling || value % DPI_STEP !== 0) {
+        throw new Error(`${value.toLocaleString()} is not a supported DPI value.`);
+      }
+    }
+    await this.request(razerSetDpiCommand(dpi, dpiY));
+    const confirmed = decodeDpi(await this.request(RAZER_READ.dpi));
+    if (confirmed.x !== dpi || confirmed.y !== dpiY) {
+      throw new Error(`The mouse kept ${confirmed.x.toLocaleString()} DPI instead of ${dpi.toLocaleString()}.`);
+    }
+    return confirmed.x;
   }
 
   /**

--- a/src/devices/razer/protocol.test.ts
+++ b/src/devices/razer/protocol.test.ts
@@ -6,6 +6,7 @@ import {
   RAZER_READ,
   RAZER_STATUS,
   RAZER_TRANSACTION_ID,
+  RAZER_WRITE,
   RazerProtocolError,
   decodeBatteryPercent,
   decodeCharging,
@@ -18,6 +19,7 @@ import {
   decodeSerial,
   encodeRazerRequest,
   razerChecksum,
+  razerSetDpiCommand,
 } from "./protocol.ts";
 
 /**
@@ -144,6 +146,28 @@ test("legacy polling decodes as a divisor of 1000", () => {
   const args = decodeRazerResponse(reply("02 1f 00 00 00 01 00 85 01"), RAZER_READ.pollingRate);
 
   assert.equal(decodeLegacyPollingRate(args), 1000);
+});
+
+test("a DPI write carries both axes big-endian after the storage byte", () => {
+  const packet = encodeRazerRequest(razerSetDpiCommand(1600, 800));
+
+  assert.equal(packet[5], 0x07);
+  assert.equal(packet[6], 0x04);
+  assert.equal(packet[7], 0x05);
+  assert.deepEqual([...packet.slice(8, 15)], [0x01, 0x06, 0x40, 0x03, 0x20, 0x00, 0x00]);
+  assert.equal(packet[88], razerChecksum(packet));
+});
+
+test("a DPI write clears the high bit of the matching read", () => {
+  assert.equal(RAZER_WRITE.dpi.commandClass, RAZER_READ.dpi.commandClass);
+  assert.equal(RAZER_WRITE.dpi.commandId, RAZER_READ.dpi.commandId & 0x7f);
+});
+
+test("a DPI write reads back through the same storage", () => {
+  const written = encodeRazerRequest(razerSetDpiCommand(1600, 1600));
+  const read = encodeRazerRequest(RAZER_READ.dpi);
+
+  assert.equal(written[8], read[8]);
 });
 
 test("extended polling decodes as a divisor of 8000", () => {

--- a/src/devices/razer/protocol.test.ts
+++ b/src/devices/razer/protocol.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RAZER_PACKET_LENGTH,
+  RAZER_READ,
+  RAZER_STATUS,
+  RAZER_TRANSACTION_ID,
+  RazerProtocolError,
+  decodeBatteryPercent,
+  decodeCharging,
+  decodeDpi,
+  decodeDpiStages,
+  decodeExtendedPollingRate,
+  decodeFirmwareVersion,
+  decodeLegacyPollingRate,
+  decodeRazerResponse,
+  decodeSerial,
+  encodeRazerRequest,
+  razerChecksum,
+} from "./protocol.ts";
+
+/**
+ * Fixtures are Viper V3 Pro (firmware 1.12) captures. Only the firmware reply
+ * was logged with its trailing checksum intact, so it is the one fixture that
+ * pins the checksum to hardware; the rest re-derive it.
+ */
+function reply(bytes: string, checksum?: number): Uint8Array {
+  const packet = new Uint8Array(RAZER_PACKET_LENGTH);
+  packet.set(bytes.trim().split(/\s+/).map((byte) => Number.parseInt(byte, 16)));
+  packet[88] = checksum ?? razerChecksum(packet);
+  return packet;
+}
+
+test("the checksum matches a reply captured from the mouse", () => {
+  const captured = reply("02 1f 00 00 00 02 00 81 01 0c", 0x8e);
+
+  assert.equal(razerChecksum(captured), 0x8e);
+});
+
+test("requests carry the transaction id, command and checksum", () => {
+  const packet = encodeRazerRequest(RAZER_READ.firmware);
+
+  assert.equal(packet.length, RAZER_PACKET_LENGTH);
+  assert.equal(packet[1], RAZER_TRANSACTION_ID);
+  assert.equal(packet[5], 0x02);
+  assert.equal(packet[6], 0x00);
+  assert.equal(packet[7], 0x81);
+  assert.equal(packet[88], 0x83);
+  assert.equal(packet[88], razerChecksum(packet));
+});
+
+test("request arguments are placed after the header", () => {
+  const packet = encodeRazerRequest(RAZER_READ.dpiStages);
+
+  assert.equal(packet[5], 0x26);
+  assert.equal(packet[8], 0x00);
+});
+
+test("replies decode to their arguments", () => {
+  const args = decodeRazerResponse(reply("02 1f 00 00 00 02 00 81 01 0c"), RAZER_READ.firmware);
+
+  assert.equal(args.length, 2);
+  assert.equal(decodeFirmwareVersion(args), "1.12");
+});
+
+test("an unsupported command is rejected with its status", () => {
+  // Wireless answers the legacy polling command this way.
+  const unsupported = reply("05 1f 00 00 00 01 00 85");
+
+  assert.throws(
+    () => decodeRazerResponse(unsupported, RAZER_READ.pollingRate),
+    (error: RazerProtocolError) => error.status === RAZER_STATUS.unsupported,
+  );
+});
+
+test("a reply from a different command is rejected", () => {
+  const mismatched = reply("02 1f 00 00 00 02 07 80 00 fa");
+
+  assert.throws(() => decodeRazerResponse(mismatched, RAZER_READ.firmware), RazerProtocolError);
+});
+
+test("a corrupted reply is rejected", () => {
+  const corrupted = reply("02 1f 00 00 00 02 00 81 01 0c", 0x00);
+
+  assert.throws(() => decodeRazerResponse(corrupted, RAZER_READ.firmware), RazerProtocolError);
+});
+
+test("battery scales the reported level to a percentage", () => {
+  const wired = decodeRazerResponse(reply("02 1f 00 00 00 02 07 80 00 fa"), RAZER_READ.battery);
+  const wireless = decodeRazerResponse(reply("02 1f 00 00 00 02 07 80 00 fd"), RAZER_READ.battery);
+
+  assert.equal(decodeBatteryPercent(wired), 98);
+  assert.equal(decodeBatteryPercent(wireless), 99);
+});
+
+test("charging is reported only while cabled", () => {
+  const cabled = decodeRazerResponse(reply("02 1f 00 00 00 02 07 84 00 01"), RAZER_READ.charging);
+  const onDongle = decodeRazerResponse(reply("02 1f 00 00 00 02 07 84 00 00"), RAZER_READ.charging);
+
+  assert.equal(decodeCharging(cabled), true);
+  assert.equal(decodeCharging(onDongle), false);
+});
+
+test("DPI decodes as big-endian pairs", () => {
+  const args = decodeRazerResponse(reply("02 1f 00 00 00 07 04 85 00 06 40 06 40 00 00"), RAZER_READ.dpi);
+
+  assert.deepEqual(decodeDpi(args), { x: 1600, y: 1600 });
+});
+
+test("DPI stages decode as seven-byte records", () => {
+  const args = decodeRazerResponse(
+    reply(
+      "02 1f 00 00 00 26 04 86 00 03 05 01 01 90 01 90 00 00 02 03 20 03 20 00 00"
+      + " 03 06 40 06 40 00 00 04 0c 80 0c 80 00 00 05 19 00 19 00 00 00",
+    ),
+    RAZER_READ.dpiStages,
+  );
+  const { active, stages } = decodeDpiStages(args);
+
+  assert.equal(args.length, 38);
+  assert.equal(active, 3);
+  assert.deepEqual(stages.map((stage) => stage.x), [400, 800, 1600, 3200, 6400]);
+  assert.deepEqual(stages.map((stage) => stage.y), [400, 800, 1600, 3200, 6400]);
+});
+
+test("the active stage agrees with the separately reported DPI", () => {
+  const dpi = decodeDpi(decodeRazerResponse(
+    reply("02 1f 00 00 00 07 04 85 00 06 40 06 40 00 00"),
+    RAZER_READ.dpi,
+  ));
+  const { active, stages } = decodeDpiStages(decodeRazerResponse(
+    reply(
+      "02 1f 00 00 00 26 04 86 00 03 05 01 01 90 01 90 00 00 02 03 20 03 20 00 00"
+      + " 03 06 40 06 40 00 00 04 0c 80 0c 80 00 00 05 19 00 19 00 00 00",
+    ),
+    RAZER_READ.dpiStages,
+  ));
+
+  assert.deepEqual(stages[active - 1], dpi);
+});
+
+test("legacy polling decodes as a divisor of 1000", () => {
+  const args = decodeRazerResponse(reply("02 1f 00 00 00 01 00 85 01"), RAZER_READ.pollingRate);
+
+  assert.equal(decodeLegacyPollingRate(args), 1000);
+});
+
+test("extended polling decodes as a divisor of 8000", () => {
+  const args = decodeRazerResponse(reply("02 1f 00 00 00 02 00 c0 00 04"), RAZER_READ.pollingRateExtended);
+
+  assert.equal(decodeExtendedPollingRate(args), 2000);
+});
+
+test("extended polling ignores the echoed request argument", () => {
+  const asZero = decodeRazerResponse(reply("02 1f 00 00 00 02 00 c0 00 04"), RAZER_READ.pollingRateExtended);
+  const asOne = decodeRazerResponse(reply("02 1f 00 00 00 02 00 c0 01 04"), RAZER_READ.pollingRateExtended);
+
+  assert.equal(decodeExtendedPollingRate(asZero), decodeExtendedPollingRate(asOne));
+});
+
+test("serial text stops at the terminator", () => {
+  const args = decodeRazerResponse(
+    reply("02 1f 00 00 00 16 00 82 50 4d 30 30 30 30 48 30 30 30 30 30 30 30 30 00"),
+    RAZER_READ.serial,
+  );
+
+  assert.equal(decodeSerial(args), "PM0000H00000000");
+});

--- a/src/devices/razer/protocol.test.ts
+++ b/src/devices/razer/protocol.test.ts
@@ -20,6 +20,8 @@ import {
   encodeRazerRequest,
   razerChecksum,
   razerSetDpiCommand,
+  razerSetExtendedPollingCommand,
+  razerSetLegacyPollingCommand,
 } from "./protocol.ts";
 
 /**
@@ -168,6 +170,30 @@ test("a DPI write reads back through the same storage", () => {
   const read = encodeRazerRequest(RAZER_READ.dpi);
 
   assert.equal(written[8], read[8]);
+});
+
+test("polling writes encode the divisor each transport expects", () => {
+  const legacy = encodeRazerRequest(razerSetLegacyPollingCommand(500));
+  const extended = encodeRazerRequest(razerSetExtendedPollingCommand(500));
+
+  assert.deepEqual([legacy[6], legacy[7], legacy[8]], [0x00, 0x05, 2]);
+  assert.deepEqual([extended[6], extended[7], extended[8], extended[9]], [0x00, 0x40, 0x00, 16]);
+});
+
+test("polling writes round-trip through their matching decoder", () => {
+  for (const hz of [125, 500, 1000]) {
+    const request = encodeRazerRequest(razerSetLegacyPollingCommand(hz));
+    assert.equal(decodeLegacyPollingRate(request.slice(8)), hz);
+  }
+  for (const hz of [125, 500, 1000, 2000, 4000, 8000]) {
+    const request = encodeRazerRequest(razerSetExtendedPollingCommand(hz));
+    assert.equal(decodeExtendedPollingRate(request.slice(8)), hz);
+  }
+});
+
+test("a rate the encoding cannot express is rejected", () => {
+  assert.throws(() => razerSetLegacyPollingCommand(2000), RazerProtocolError);
+  assert.throws(() => razerSetExtendedPollingCommand(3000), RazerProtocolError);
 });
 
 test("extended polling decodes as a divisor of 8000", () => {

--- a/src/devices/razer/protocol.ts
+++ b/src/devices/razer/protocol.ts
@@ -65,6 +65,8 @@ export const RAZER_READ = {
  */
 export const RAZER_WRITE = {
   dpi: { commandClass: 0x04, commandId: 0x05, dataSize: 0x07 },
+  pollingRate: { commandClass: 0x00, commandId: 0x05, dataSize: 0x01 },
+  pollingRateExtended: { commandClass: 0x00, commandId: 0x40, dataSize: 0x02 },
 } as const satisfies Record<string, Omit<RazerCommand, "args">>;
 
 export function razerSetDpiCommand(x: number, y: number): RazerCommand {
@@ -72,6 +74,23 @@ export function razerSetDpiCommand(x: number, y: number): RazerCommand {
     ...RAZER_WRITE.dpi,
     args: [RAZER_STORAGE, (x >> 8) & 0xff, x & 0xff, (y >> 8) & 0xff, y & 0xff, 0x00, 0x00],
   };
+}
+
+function pollingDivisor(ceiling: number, pollingRateHz: number): number {
+  const divisor = ceiling / pollingRateHz;
+  if (!Number.isInteger(divisor) || divisor < 1 || divisor > 0xff) {
+    throw new RazerProtocolError(`${pollingRateHz} Hz is not a rate this mouse can encode.`);
+  }
+  return divisor;
+}
+
+export function razerSetLegacyPollingCommand(pollingRateHz: number): RazerCommand {
+  return { ...RAZER_WRITE.pollingRate, args: [pollingDivisor(1000, pollingRateHz)] };
+}
+
+/** The receiver takes the same leading argument its read echoes back. */
+export function razerSetExtendedPollingCommand(pollingRateHz: number): RazerCommand {
+  return { ...RAZER_WRITE.pollingRateExtended, args: [0x00, pollingDivisor(8000, pollingRateHz)] };
 }
 
 export class RazerProtocolError extends Error {

--- a/src/devices/razer/protocol.ts
+++ b/src/devices/razer/protocol.ts
@@ -1,0 +1,175 @@
+/**
+ * Razer control protocol: 90-byte feature reports exchanged on report ID 0.
+ *
+ * Razer does not declare this report in its HID descriptor, so the collection
+ * carries no feature report of its own; the exchange still succeeds because
+ * WebHID does not validate report IDs against the descriptor. The control
+ * interface is the one whose only collection is Generic Desktop Mouse.
+ */
+
+export const RAZER_REPORT_ID = 0;
+export const RAZER_PACKET_LENGTH = 90;
+
+/** Verified against Viper V3 Pro firmware 1.12 on both transports. */
+export const RAZER_TRANSACTION_ID = 0x1f;
+
+const ARGS_OFFSET = 8;
+const CHECKSUM_INDEX = 88;
+const CHECKSUM_FIRST = 2;
+const CHECKSUM_LAST = 88;
+const STAGE_OFFSET = 3;
+const STAGE_LENGTH = 7;
+const BATTERY_SCALE = 255;
+
+export const RAZER_STATUS = {
+  busy: 0x01,
+  ok: 0x02,
+  failure: 0x03,
+  timeout: 0x04,
+  unsupported: 0x05,
+} as const;
+
+export interface RazerCommand {
+  commandClass: number;
+  commandId: number;
+  dataSize: number;
+  args?: readonly number[];
+}
+
+/** Read-only commands confirmed against Viper V3 Pro firmware 1.12. */
+export const RAZER_READ = {
+  firmware: { commandClass: 0x00, commandId: 0x81, dataSize: 0x02 },
+  serial: { commandClass: 0x00, commandId: 0x82, dataSize: 0x16 },
+  battery: { commandClass: 0x07, commandId: 0x80, dataSize: 0x02 },
+  charging: { commandClass: 0x07, commandId: 0x84, dataSize: 0x02 },
+  dpi: { commandClass: 0x04, commandId: 0x85, dataSize: 0x07, args: [0x00] },
+  dpiStages: { commandClass: 0x04, commandId: 0x86, dataSize: 0x26, args: [0x00] },
+  pollingRate: { commandClass: 0x00, commandId: 0x85, dataSize: 0x01 },
+  pollingRateExtended: { commandClass: 0x00, commandId: 0xc0, dataSize: 0x02, args: [0x00] },
+} as const satisfies Record<string, RazerCommand>;
+
+export class RazerProtocolError extends Error {
+  readonly status: number | null;
+
+  constructor(message: string, status: number | null = null) {
+    super(message);
+    this.name = "RazerProtocolError";
+    this.status = status;
+  }
+}
+
+export function razerChecksum(packet: Uint8Array): number {
+  let checksum = 0;
+  for (let index = CHECKSUM_FIRST; index < CHECKSUM_LAST; index += 1) checksum ^= packet[index];
+  return checksum;
+}
+
+export function encodeRazerRequest(
+  command: RazerCommand,
+  transactionId: number = RAZER_TRANSACTION_ID,
+): Uint8Array<ArrayBuffer> {
+  const packet = new Uint8Array(RAZER_PACKET_LENGTH);
+  packet[1] = transactionId;
+  packet[5] = command.dataSize;
+  packet[6] = command.commandClass;
+  packet[7] = command.commandId;
+  packet.set(command.args ?? [], ARGS_OFFSET);
+  packet[CHECKSUM_INDEX] = razerChecksum(packet);
+  return packet;
+}
+
+function describe(command: RazerCommand, problem: string): string {
+  const hex = (value: number) => `0x${value.toString(16).padStart(2, "0")}`;
+  return `Class ${hex(command.commandClass)} command ${hex(command.commandId)} ${problem}.`;
+}
+
+/** Returns the reply arguments, or throws with the reported status. */
+export function decodeRazerResponse(packet: Uint8Array, command: RazerCommand): Uint8Array {
+  if (packet.length !== RAZER_PACKET_LENGTH) {
+    throw new RazerProtocolError(describe(command, `returned ${packet.length} bytes instead of ${RAZER_PACKET_LENGTH}`));
+  }
+  if (packet[CHECKSUM_INDEX] !== razerChecksum(packet)) {
+    throw new RazerProtocolError(describe(command, "returned a reply with a bad checksum"));
+  }
+  const status = packet[0];
+  if (status === RAZER_STATUS.unsupported) {
+    throw new RazerProtocolError(describe(command, "is not supported by this mouse"), status);
+  }
+  if (status !== RAZER_STATUS.ok) {
+    throw new RazerProtocolError(describe(command, `returned status ${`0x${status.toString(16).padStart(2, "0")}`}`), status);
+  }
+  if (packet[6] !== command.commandClass || packet[7] !== command.commandId) {
+    throw new RazerProtocolError(describe(command, "was answered by a different command"), status);
+  }
+  const length = Math.min(packet[5], RAZER_PACKET_LENGTH - ARGS_OFFSET);
+  return packet.slice(ARGS_OFFSET, ARGS_OFFSET + length);
+}
+
+export function decodeFirmwareVersion(args: Uint8Array): string {
+  return `${args[0]}.${args[1]}`;
+}
+
+export function decodeSerial(args: Uint8Array): string {
+  let text = "";
+  for (const byte of args) {
+    if (byte === 0) break;
+    text += String.fromCharCode(byte);
+  }
+  return text.trim();
+}
+
+export function decodeBatteryPercent(args: Uint8Array): number {
+  return Math.round((args[1] * 100) / BATTERY_SCALE);
+}
+
+export function decodeCharging(args: Uint8Array): boolean {
+  return args[1] === 1;
+}
+
+export interface RazerDpi {
+  x: number;
+  y: number;
+}
+
+export function decodeDpi(args: Uint8Array): RazerDpi {
+  return { x: (args[1] << 8) | args[2], y: (args[3] << 8) | args[4] };
+}
+
+export interface RazerDpiStages {
+  /** One-based index into `stages`, as reported by the mouse. */
+  active: number;
+  stages: RazerDpi[];
+}
+
+export function decodeDpiStages(args: Uint8Array): RazerDpiStages {
+  const count = args[2];
+  const stages: RazerDpi[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const offset = STAGE_OFFSET + index * STAGE_LENGTH;
+    if (offset + 4 >= args.length) break;
+    stages.push({
+      x: (args[offset + 1] << 8) | args[offset + 2],
+      y: (args[offset + 3] << 8) | args[offset + 4],
+    });
+  }
+  return { active: args[1], stages };
+}
+
+/**
+ * Legacy polling encodes the rate as a divisor of 1000, so it cannot express
+ * the HyperPolling rates. Wireless answers this command as unsupported.
+ */
+export function decodeLegacyPollingRate(args: Uint8Array): number {
+  if (!args[0]) throw new RazerProtocolError("The mouse reported an unknown polling rate.");
+  return Math.round(1000 / args[0]);
+}
+
+/**
+ * HyperPolling rates encode as a divisor of 8000. The first reply byte echoes
+ * the request argument, so the rate lives in the second. Wired answers this
+ * command as unsupported.
+ */
+export function decodeExtendedPollingRate(args: Uint8Array): number {
+  if (!args[1]) throw new RazerProtocolError("The mouse reported an unknown polling rate.");
+  return Math.round(8000 / args[1]);
+}

--- a/src/devices/razer/protocol.ts
+++ b/src/devices/razer/protocol.ts
@@ -36,17 +36,43 @@ export interface RazerCommand {
   args?: readonly number[];
 }
 
+/**
+ * Razer selects a value store per command. Firmware 1.12 reports the same DPI
+ * from either store, and writes were confirmed against this one, so reads and
+ * writes both use it rather than risking a stale read from the other.
+ */
+const RAZER_STORAGE = 0x01;
+
 /** Read-only commands confirmed against Viper V3 Pro firmware 1.12. */
 export const RAZER_READ = {
   firmware: { commandClass: 0x00, commandId: 0x81, dataSize: 0x02 },
   serial: { commandClass: 0x00, commandId: 0x82, dataSize: 0x16 },
   battery: { commandClass: 0x07, commandId: 0x80, dataSize: 0x02 },
   charging: { commandClass: 0x07, commandId: 0x84, dataSize: 0x02 },
-  dpi: { commandClass: 0x04, commandId: 0x85, dataSize: 0x07, args: [0x00] },
+  dpi: { commandClass: 0x04, commandId: 0x85, dataSize: 0x07, args: [RAZER_STORAGE] },
   dpiStages: { commandClass: 0x04, commandId: 0x86, dataSize: 0x26, args: [0x00] },
   pollingRate: { commandClass: 0x00, commandId: 0x85, dataSize: 0x01 },
   pollingRateExtended: { commandClass: 0x00, commandId: 0xc0, dataSize: 0x02, args: [0x00] },
 } as const satisfies Record<string, RazerCommand>;
+
+/**
+ * Write commands confirmed against Viper V3 Pro firmware 1.12.
+ *
+ * Razer pairs each read with a write that clears the high bit of the command
+ * id. Only commands verified on hardware belong here — in particular the DPI
+ * stage table (`0x04`/`0x06`) is absent on purpose, because a wrong length
+ * there is the one realistic way to corrupt stored settings.
+ */
+export const RAZER_WRITE = {
+  dpi: { commandClass: 0x04, commandId: 0x05, dataSize: 0x07 },
+} as const satisfies Record<string, Omit<RazerCommand, "args">>;
+
+export function razerSetDpiCommand(x: number, y: number): RazerCommand {
+  return {
+    ...RAZER_WRITE.dpi,
+    args: [RAZER_STORAGE, (x >> 8) & 0xff, x & 0xff, (y >> 8) & 0xff, y & 0xff, 0x00, 0x00],
+  };
+}
 
 export class RazerProtocolError extends Error {
   readonly status: number | null;

--- a/src/devices/registry.ts
+++ b/src/devices/registry.ts
@@ -5,10 +5,11 @@ import { LogitechHidppClient } from "./logitech/hidpp";
 import { OrbitalHidClient } from "./orbital/hid";
 import { PulsarHidClient } from "./pulsar/pulsar-hid";
 import { PulsarProHidClient } from "./pulsar/pulsar-pro-hid";
+import { RazerHidClient } from "./razer/hid";
 import { WLMouseHidClient } from "./wlmouse/hid";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient;
 
 interface DeviceDriver {
   brand: string;
@@ -26,6 +27,7 @@ const DEVICE_DRIVERS: readonly DeviceDriver[] = [
   { brand: "WLMouse", supports: (device) => WLMouseHidClient.isSupported(device), create: (device) => new WLMouseHidClient(device), score: () => 5 },
   { brand: "Lamzu", supports: (device) => LamzuHidClient.isSupported(device), create: (device) => new LamzuHidClient(device), score: () => 5 },
   { brand: "Orbital", supports: (device) => OrbitalHidClient.isSupported(device), create: (device) => new OrbitalHidClient(device), score: () => 6 },
+  { brand: "Razer", supports: (device) => RazerHidClient.isSupported(device), create: (device) => new RazerHidClient(device), score: () => 6 },
 ];
 
 function driverFor(device: HIDDevice): DeviceDriver | undefined {

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -7,7 +7,17 @@ export const VENDOR_ID = {
   lamzu: 0x373e,
   logitech: 0x046d,
   orbital: 0x1915,
+  razer: 0x1532,
 } as const;
+
+// Razer does not declare its control channel in the HID descriptor; the
+// interface that answers it is the one whose only collection is Generic
+// Desktop Mouse, so the filter matches on that collection.
+export const RAZER_CONTROL_FILTER: HIDDeviceFilter = {
+  vendorId: VENDOR_ID.razer,
+  usagePage: 0x01,
+  usage: 0x02,
+};
 
 // Logitech HID++ control interfaces. 0xc54d and 0xc547 are newer Lightspeed
 // receivers, 0xc539 is HERO-era Lightspeed, and 0xc0a8 is the PRO X 2
@@ -57,6 +67,7 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.wlmouse },
   { vendorId: VENDOR_ID.lamzu },
   { vendorId: VENDOR_ID.orbital, usagePage: 0xff0a, usage: 1 },
+  RAZER_CONTROL_FILTER,
   ...EGG_WE_HID_FILTERS,
   ...LOGITECH_RECEIVER_FILTERS,
 ];


### PR DESCRIPTION
Adds Razer Viper V3 Pro support over both the cable (`1532:00c0`) and the
HyperSpeed receiver (`1532:00c1`).

## Why this looks impossible at first

Razer never declares its control channel in the HID descriptor, so **no Razer
interface advertises a feature report** — every collection the browser reports
comes back with `featureReports: []`. The reference implementation (OpenRazer)
gets around this by issuing raw USB control transfers straight at the
interface, which WebHID cannot do.

The exchange works anyway: WebHID does not validate report IDs against the
descriptor, so `sendFeatureReport(0, …)` reaches the device even though report
ID 0 is undeclared. The interface that answers is the one whose **only**
collection is Generic Desktop Mouse (`usagePage 0x01`, `usage 0x02`) — a
protected usage, which makes it look like the least likely candidate of the
four interfaces the mouse presents.

I am writing that down because the descriptor dump on its own reads as "this
device cannot be supported", and the next person to try will hit the same wall.

## What it does for now (to be updated to support for features)

Reads firmware, serial, battery, charging state, DPI and polling rate. Writes
DPI and polling rate.

DPI takes any whole value from 100 to 35000, per axis. Polling splits by
transport, which is the one real asymmetry:

| | polling command | encoding | rates |
| --- | --- | --- | --- |
| wired | `0x00`/`0x85` read, `0x00`/`0x05` write | divisor of 1000 | 125/500/1000 |
| receiver | `0x00`/`0xc0` read, `0x00`/`0x40` write | divisor of 8000 | + 2000/4000/8000 |

Each transport answers `0x05` (unsupported) to the other's command, so the
driver asks for the one that transport answers. The cable is limited to 1000 Hz
on this model, which is also the ceiling the legacy encoding can express, so
nothing is missing there. Transaction ID `0x1f` answered every command on both
connections.

Writes follow the existing pattern — write, read back, throw on mismatch — so a
value the mouse refuses or clamps surfaces as an error rather than a wrong
reading.

## How it was verified

Every command in this driver was confirmed against hardware before it landed,
and the writes were checked by effect rather than only by read-back:

- a DPI change altered pointer speed
- a 500 Hz write measured 499 Hz through `pointerrawupdate`
- `1337 x 900` read back exactly, which is what proves both the 1 DPI step and
  independent axes
- the packet checksum is pinned in a test to a reply captured from the device

## Things that are not included (yet)

Lift-off distance and the sensor processing controls are not offered, because
no command for either is confirmed. The vendor software does not expose the
processing controls for this model either, so those are more likely absent from
the mouse than missing here.

The idle sleep and low battery commands **are** confirmed in both directions and
are written up in `TESTING.md`, but nothing is wired to them: the sleep and
debounce controls are filled per brand rather than per capability, and changing
that dispatch felt out of scope for a driver PR.

`TESTING.md` also records which command classes the lift-off search already
covered and why the vendor's continuous lift-off/landing pair does not fit the
three-value `liftOffDistance` field, so the next attempt does not start over.

## Changes outside the vendor folder

Three in `control.ts`, all needed rather than incidental:

- `requireClientMethod()` — the shell assumed every client exposes `setDpi`,
  `setPollingRate` and `setLiftOffDistance`. A driver that confirms one write
  but not another would not type check. Each setting is now checked on its own,
  as a capability check rather than an `instanceof` branch.
- The status line reported battery alone whenever `settingsReady` was false, so
  values a driver had already read went unreported. It now reports them behind a
  new `ui.valuesVerified` hint. Opt-in, because OP1we hides the grid precisely
  when its profile read fails and falls back to 800 CPI and 1000 Hz — reporting
  unconditionally would have shown those placeholders as though the mouse had
  sent them.
- A `RazerHidClient` branch in `activateClient`, whose `else` otherwise falls
  through to the Pulsar explorer.

Plus the four integration points from the README (`registry.ts`, `vendors.ts`,
the `mouse-types.ts` brand union, and the `test` script).

## Testing

`npm run check` passes: build clean, 52 tests.

Protocol tests are built from packets captured off the device, including a
cross-check that the reported active DPI stage matches the independently read
DPI. Fixtures use a synthetic serial.

Hardware tested against firmware 1.12 on both connections: model, wired and
wireless state, battery, charging, DPI, polling, firmware version, DPI and
polling writes, and that no control appears for anything unconfirmed.

## Note for reviewers

On the receiver the picker shows two entries both named `Razer Viper V3 Pro`,
and only one answers; the other is skipped by `isSupported`. If the first pick
does not appear in the device list, add the device again and choose the other
entry. WebHID filters cannot tell them apart, so this is documented rather than
fixed.

The cable and the receiver are separate product IDs and so need separate browser
permissions — switching between them the first time means adding the device
again.

## Development note

Claude Code was used while building this, for the protocol research, the driver
code and the tests. All hardware verification was mine, on my own Viper V3 Pro,
and nothing reached the driver until it was confirmed against the device.

<img width="1914" height="964" alt="image" src="https://github.com/user-attachments/assets/7b680d34-0d6a-4dfb-bc41-5b46e4087951" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/fdc3a1c9-fd39-4b71-983a-3479782010a0" />
