### PR TITLE
Add Logitech G402 support

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -11,6 +11,7 @@ import {
   type SupportedClient,
 } from "./device-clients";
 import { renderDeviceSidebar as renderDeviceSidebarView } from "./device-sidebar";
+import { closestDpiOption, dpiPresetValues } from "./dpi-presets";
 import { renderEggControls } from "./devices/endgame/egg-controls-view";
 import { hidTraffic, isMark, markHidActivity, startHidCapture, type HidTrafficEntry } from "./hid-diagnostics";
 import {
@@ -1299,7 +1300,7 @@ function configureDpiControl(currentDpi: number): void {
   const presets = document.querySelector<HTMLElement>("#dpi-presets");
   const custom = document.querySelector<HTMLButtonElement>("#custom-dpi");
   if (!presets || !custom || dpiOptions.length === 0) return;
-  const common = [400, 800, 1600, 3200, 6400, 8000].filter((dpi) => dpiOptions.includes(dpi));
+  const common = dpiPresetValues(dpiOptions);
   const values = common.includes(currentDpi) ? common : [...common, currentDpi].sort((a, b) => a - b);
   presets.innerHTML = values.map((dpi) => `<button type="button" data-dpi="${dpi}" class="${dpi === currentDpi ? "selected" : ""}">${dpi.toLocaleString()}</button>`).join("");
   presets.querySelectorAll<HTMLButtonElement>("[data-dpi]").forEach((button) => {
@@ -1323,7 +1324,12 @@ function chooseCustomDpi(): void {
   }
   const dpi = Number(input.value.replace(/[^\d]/g, ""));
   if (!Number.isInteger(dpi) || !dpiOptions.includes(dpi)) {
-    setText("#read-status", "That DPI value is not supported by this mouse.");
+    // Naming the closest step saves guessing on mice whose grid does not land
+    // on round numbers, where every obvious value looks unsupported.
+    const closest = Number.isInteger(dpi) && dpi > 0 ? closestDpiOption(dpiOptions, dpi) : null;
+    setText("#read-status", closest === null
+      ? "That DPI value is not supported by this mouse."
+      : `This mouse cannot do ${dpi.toLocaleString()} DPI. The closest step it supports is ${closest.toLocaleString()}.`);
     input.focus();
     input.select();
     return;

--- a/src/control.ts
+++ b/src/control.ts
@@ -789,7 +789,8 @@ function showStatus(deviceStatus: MouseStatus): void {
     const hideListed = (status.brand === "Logitech" || ui?.hideUnsupportedPollingRates) && unsupportedForListed;
     const hide = unsupportedForEgg8k || hideListed || settingsPending;
     button.hidden = hide;
-    button.disabled = hide || settingsPending;
+    // A read-only rate still shows which one is active, it just cannot be staged.
+    button.disabled = hide || settingsPending || ui?.pollingReadOnly === true;
   });
   document.querySelectorAll<HTMLButtonElement>("[data-lod]").forEach((button) => {
     const supportedLods = status.supportedLiftOffDistances;
@@ -824,6 +825,15 @@ function showStatus(deviceStatus: MouseStatus): void {
     button.classList.toggle("selected", button.dataset.gamingSurface === status.gamingSurfaceMode);
     button.disabled = settingsPending || !status.gamingSurfaceMode;
   });
+  // A driver that reports no gaming surface and an explicitly empty lift-off
+  // list has nothing to put in the sensor card, so hide the card itself rather
+  // than leaving an empty heading behind.
+  const sensorCard = document.querySelector<HTMLElement>("#lod-note")?.closest<HTMLElement>(".setting-card");
+  if (sensorCard) {
+    sensorCard.hidden = !status.gamingSurfaceMode
+      && Array.isArray(status.supportedLiftOffDistances)
+      && status.supportedLiftOffDistances.length === 0;
+  }
   const lightforceCard = document.querySelector<HTMLElement>("#lightforce-card");
   if (lightforceCard) lightforceCard.hidden = !status.lightforceSwitchMode;
   document.querySelectorAll<HTMLButtonElement>("[data-lightforce]").forEach((button) => {

--- a/src/devices/logitech/TESTING.md
+++ b/src/devices/logitech/TESTING.md
@@ -1,0 +1,49 @@
+# Logitech hardware test checklist
+
+Test in Chrome or Edge over HTTPS. Close Logitech G HUB and Logitech Gaming
+Software first — they hold the same vendor interface open and the mouse will
+stop answering. Select the vendor collection (`usagePage 0xff00`, `usage
+0x0001`), not the plain pointer collection.
+
+Supported identifiers:
+
+- `046d:c54d`, `046d:c547` — Lightspeed receivers
+- `046d:c539` — HERO-era Lightspeed receiver
+- `046d:c0a8` — PRO X 2 Superstrike (USB)
+- `046d:c07e` — G402 / G402 Hyperion Fury (wired)
+
+## Receiver-attached and Superstrike devices
+
+1. Confirm the model, battery, connection type, DPI, polling rate, and
+   lift-off distance are read correctly.
+2. Change one setting at a time and confirm each write, then reload and confirm
+   it persisted.
+
+## G402 (direct-connect, HID++ device index `0xFF`)
+
+The G402 is addressed as the mouse itself rather than a receiver slot, and it
+exposes only the legacy feature set: Adjustable DPI `0x2201` and Report Rate
+`0x8060`. It has no lift-off, gaming-surface, battery, or hall-effect controls,
+so those cards stay hidden.
+
+1. Confirm the sidebar and title show the mouse, and that the connection reads
+   **Wired**.
+2. Confirm the firmware list and the HID++ device details section populate.
+3. Confirm the DPI presets offer 400 / 800 / 1600 / 3200 and that the reported
+   DPI matches what Logitech Gaming Software shows.
+4. Stage a DPI change and flash it. The driver writes `0x2201` function 3 as a
+   short request and re-reads the value; a mismatch is reported as an error
+   rather than being assumed to have worked.
+5. Confirm the sensor card (lift-off distance) is hidden — the G402 has no
+   `0x2202` feature to drive it.
+6. Confirm the polling-rate buttons show the active rate but are **disabled**,
+   with the note explaining the rate lives in the onboard profile.
+7. Confirm the mouse stays in onboard mode: its own DPI-stage buttons must keep
+   working after OpenMouse writes a DPI value. The driver deliberately does not
+   switch the G402 into host-control mode.
+8. Reload the page and confirm the DPI written in step 4 is still reported.
+
+Persistent polling-rate and DPI-stage changes need a CRC-checked rewrite of the
+1024-byte profile sector and are intentionally not implemented. Record the
+device identifier, protocol version, and any failing setting in the issue or
+pull request. Do not use factory reset during initial testing.

--- a/src/devices/logitech/hidpp.test.ts
+++ b/src/devices/logitech/hidpp.test.ts
@@ -1,7 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { withSoftwareId } from "./protocol.ts";
+import {
+  DEVICE_INDEX_DIRECT,
+  DEVICE_INDEX_RECEIVER,
+  decodeReportRateBitmap,
+  hidppDeviceIndex,
+  hidppErrorMessage,
+  isDirectConnectProduct,
+  legacyDpiFallback,
+  withSoftwareId,
+} from "./protocol.ts";
+
+const G402 = 0xc07e;
+const LIGHTSPEED_RECEIVER = 0xc54d;
+const SUPERSTRIKE_USB = 0xc0a8;
 
 test("HID++ requests use a nonzero software ID", () => {
   assert.equal(withSoftwareId(0x00), 0x05);
@@ -11,4 +24,49 @@ test("HID++ requests use a nonzero software ID", () => {
 
 test("HID++ software ID replaces an existing low nibble", () => {
   assert.equal(withSoftwareId(0x1e), 0x15);
+});
+
+test("the G402 is addressed as the mouse itself, not a receiver slot", () => {
+  assert.equal(isDirectConnectProduct(G402), true);
+  assert.equal(hidppDeviceIndex(G402), DEVICE_INDEX_DIRECT);
+  assert.equal(hidppDeviceIndex(G402), 0xff);
+});
+
+test("receiver-attached and USB Superstrike devices keep index 0x01", () => {
+  for (const productId of [LIGHTSPEED_RECEIVER, 0xc539, 0xc547, SUPERSTRIKE_USB]) {
+    assert.equal(isDirectConnectProduct(productId), false);
+    assert.equal(hidppDeviceIndex(productId), DEVICE_INDEX_RECEIVER);
+  }
+});
+
+test("the legacy report-rate bitmap decodes the G402's advertised rates", () => {
+  // 0x8b = bits 0, 1, 3 and 7 => 1, 2, 4 and 8 ms.
+  assert.deepEqual(decodeReportRateBitmap(0x8b), [125, 250, 500, 1000]);
+});
+
+test("report-rate bitmap bits map to (bit + 1) ms, not 1 << (interval - 1)", () => {
+  assert.deepEqual(decodeReportRateBitmap(0x01), [1000]);
+  assert.deepEqual(decodeReportRateBitmap(0x02), [500]);
+  assert.deepEqual(decodeReportRateBitmap(0x08), [250]);
+  assert.deepEqual(decodeReportRateBitmap(0x80), [125]);
+  assert.deepEqual(decodeReportRateBitmap(0x00), []);
+});
+
+test("HID++ error responses are reported with their documented reason", () => {
+  // The code returned when 0x8060's setter is asked to change the rate live.
+  assert.match(hidppErrorMessage(0x02), /invalid argument/);
+  assert.match(hidppErrorMessage(0x09), /unsupported/);
+});
+
+test("an unrecognised HID++ error still reports its raw code", () => {
+  assert.match(hidppErrorMessage(0x7f), /0x7f/);
+});
+
+test("the legacy DPI fallback covers the G402's documented sensor range", () => {
+  const options = legacyDpiFallback();
+  assert.equal(options[0], 240);
+  assert.equal(options.at(-1), 4000);
+  assert.equal(options.every((dpi, index) => index === 0 || dpi - options[index - 1] === 80), true);
+  // The presets the control panel offers must be reachable from the fallback.
+  for (const preset of [400, 800, 1600, 3200]) assert.equal(options.includes(preset), true);
 });

--- a/src/devices/logitech/hidpp.test.ts
+++ b/src/devices/logitech/hidpp.test.ts
@@ -62,11 +62,13 @@ test("an unrecognised HID++ error still reports its raw code", () => {
   assert.match(hidppErrorMessage(0x7f), /0x7f/);
 });
 
-test("the legacy DPI fallback covers the G402's documented sensor range", () => {
+test("the legacy DPI fallback matches the grid G402 hardware advertises", () => {
+  // Captured from hardware: getSensorDpiList replied 00 FC | E0 54 | 0F C0,
+  // meaning minimum 252, range step 84, maximum 4032.
   const options = legacyDpiFallback();
-  assert.equal(options[0], 240);
-  assert.equal(options.at(-1), 4000);
-  assert.equal(options.every((dpi, index) => index === 0 || dpi - options[index - 1] === 80), true);
-  // The presets the control panel offers must be reachable from the fallback.
-  for (const preset of [400, 800, 1600, 3200]) assert.equal(options.includes(preset), true);
+  assert.equal(options[0], 252);
+  assert.equal(options.at(-1), 4032);
+  assert.equal(options.every((dpi, index) => index === 0 || dpi - options[index - 1] === 84), true);
+  // The value the mouse reports while vendor software displays "2400".
+  assert.equal(options.includes(2436), true);
 });

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -1,5 +1,12 @@
 import type { MouseStatus } from "../mouse-types";
-import { withSoftwareId } from "./protocol";
+import {
+  decodeReportRateBitmap,
+  hidppDeviceIndex,
+  hidppErrorMessage,
+  isDirectConnectProduct,
+  legacyDpiFallback,
+  withSoftwareId,
+} from "./protocol";
 import {
   MODE_STATUS,
   buildModeStatusWrite,
@@ -14,7 +21,6 @@ const LOGITECH_VENDOR_ID = 0x046d;
 const LOGITECH_RECEIVER_PRODUCT_IDS = new Set([0xc54d, 0xc539, 0xc0a8, 0xc547]);
 const SHORT_REPORT_ID = 0x10;
 const LONG_REPORT_ID = 0x11;
-const DEVICE_INDEX = 0x01;
 const FEATURE = {
   deviceName: 0x0005,
   firmware: 0x0003,
@@ -91,7 +97,7 @@ export class LogitechHidppClient {
     }
 
     const report = new Uint8Array(event.data.buffer.slice(event.data.byteOffset, event.data.byteOffset + event.data.byteLength));
-    if (report[0] === DEVICE_INDEX && report[1] === this.reportRateFeatureIndex && report[2] === 0x00 && report[3] === 0x01) {
+    if (report[0] === this.deviceIndex && report[1] === this.reportRateFeatureIndex && report[2] === 0x00 && report[3] === 0x01) {
       const rate = REPORT_RATE_HZ[report[4] ?? -1];
       if (rate) {
         this.livePollingRateHz = rate;
@@ -101,7 +107,7 @@ export class LogitechHidppClient {
       }
     }
     const matchingIndex = this.waiters.findIndex(
-      (waiter) => report[0] === DEVICE_INDEX
+      (waiter) => report[0] === this.deviceIndex
         && report[1] === waiter.featureIndex
         && report[2] === withSoftwareId(waiter.functionId),
     );
@@ -112,12 +118,12 @@ export class LogitechHidppClient {
 
     // HID++ can emit a status notification between a write acknowledgement and
     // the matching read response. Leave the pending request in place and wait.
-    if (report[0] === DEVICE_INDEX && report[1] === 0xff) {
+    if (report[0] === this.deviceIndex && report[1] === 0xff) {
       const failedIndex = this.waiters.findIndex(
         (waiter) => report[2] === waiter.featureIndex && report[3] === withSoftwareId(waiter.functionId),
       );
       if (failedIndex >= 0) {
-        this.waiters.splice(failedIndex, 1)[0].reject(new Error("The mouse rejected that setting."));
+        this.waiters.splice(failedIndex, 1)[0].reject(new Error(hidppErrorMessage(report[4] ?? 0)));
       }
     }
   };
@@ -131,8 +137,23 @@ export class LogitechHidppClient {
 
   constructor(readonly device: HIDDevice) {}
 
+  /**
+   * True when the vendor interface belongs to the mouse itself (G402) instead
+   * of a receiver. Written as a getter because `useDefineForClassFields` runs
+   * field initializers before the `device` parameter property is assigned.
+   */
+  private get isDirectConnect(): boolean {
+    return isDirectConnectProduct(this.device.productId);
+  }
+
+  /** HID++ device index: the receiver's first slot, or the mouse itself. */
+  private get deviceIndex(): number {
+    return hidppDeviceIndex(this.device.productId);
+  }
+
   static isSupported(device: HIDDevice): boolean {
-    if (device.vendorId !== LOGITECH_VENDOR_ID || !LOGITECH_RECEIVER_PRODUCT_IDS.has(device.productId)) {
+    if (device.vendorId !== LOGITECH_VENDOR_ID
+      || !(LOGITECH_RECEIVER_PRODUCT_IDS.has(device.productId) || isDirectConnectProduct(device.productId))) {
       return false;
     }
     const hasHidppCollection = (collections: readonly HIDCollectionInfo[]): boolean =>
@@ -219,7 +240,7 @@ export class LogitechHidppClient {
     const modeStatus = modeStatusFeature.index ? await this.readModeStatus(modeStatusFeature.index) : null;
     const isSuperstrike = this.isSuperstrike(identity);
     this.isSuperstrikeDevice = isSuperstrike;
-    const wired = this.device.productId === 0xc0a8;
+    const wired = this.device.productId === 0xc0a8 || this.isDirectConnect;
 
     return {
       brand: "Logitech",
@@ -228,6 +249,12 @@ export class LogitechHidppClient {
         family: "logitech-hidpp",
         // Logitech allows Lift-off Distance modification only when Gaming Surface Mode is set to "on" or "auto"
         lodRequiresSurface: true,
+        // Direct-connect mice report their rate but keep the writable copy in
+        // the onboard profile, so show it without offering to change it.
+        pollingReadOnly: this.isDirectConnect ? true : undefined,
+        pollingNote: this.isDirectConnect
+          ? "This mouse stores its polling rate in the onboard profile, so OpenMouse reads it without changing it."
+          : undefined,
       },
       batteryPercent: battery.percent,
       batteryVoltageMv: battery.voltageMv ?? null,
@@ -245,8 +272,14 @@ export class LogitechHidppClient {
       supportedPollingRates: isSuperstrike && wired
         ? supportedPollingRates.filter((rate) => rate <= 1000)
         : supportedPollingRates,
-      supportedLiftOffDistances: isSuperstrike ? ["Low", "High"] : undefined,
+      // Lift-off distance is only reachable through extended DPI (0x2202). On a
+      // mouse that exposes just legacy 0x2201 there is nothing to drive, so
+      // report an empty set rather than offering buttons that can only fail.
+      supportedLiftOffDistances: dpiFeature.legacy ? [] : isSuperstrike ? ["Low", "High"] : undefined,
       connectionType: wired ? "Wired" : "Wireless",
+      // Without this the shell falls back to its "2.4 GHz receiver" wording,
+      // which is wrong for a mouse plugged straight into USB.
+      connectionDetail: this.isDirectConnect ? "Wired USB" : undefined,
       activeProfile: profileState.activeProfile,
       deviceMode: profileState.deviceMode,
       unitId: identity.unitId,
@@ -264,6 +297,12 @@ export class LogitechHidppClient {
   }
 
   async setPollingRate(pollingRateHz: number): Promise<number> {
+    if (this.isDirectConnect) {
+      // 0x8060's setter rejects live writes on this generation (HID++ error
+      // 0x02). The persistent rate lives in the onboard profile, which needs a
+      // CRC-checked sector rewrite that is not implemented here.
+      throw new Error("This mouse stores its polling rate in the onboard profile. Change it in Logitech Gaming Software; OpenMouse can only read it.");
+    }
     if (this.isSuperstrikeDevice && this.device.productId === 0xc0a8 && pollingRateHz > 1000) {
       throw new Error("The Superstrike USB connection supports up to 1000 Hz. Use the Lightspeed receiver for higher rates.");
     }
@@ -296,7 +335,14 @@ export class LogitechHidppClient {
       throw new Error("This mouse does not expose DPI controls.");
     }
     if (resolved.legacy) {
-      this.dpiOptionsCache = await this.readLegacyDpiList(resolved.index);
+      const advertised = await this.readLegacyDpiList(resolved.index);
+      // A mouse that answers the DPI list with nothing usable would otherwise
+      // leave the panel with no DPI control at all. The G402's documented
+      // sensor range is a safe stand-in; every value is still verified by the
+      // read-back in setLegacyDpi.
+      this.dpiOptionsCache = advertised.length === 0 && this.isDirectConnect
+        ? legacyDpiFallback()
+        : advertised;
       return this.dpiOptionsCache;
     }
     const feature = { index: resolved.index };
@@ -542,8 +588,14 @@ export class LogitechHidppClient {
 
   private async setLegacyDpi(featureIndex: number, dpi: number): Promise<number> {
     await this.ensureHostControl();
-    // setSensorDpi(sensor 0, dpi): params = [sensorIdx, dpiHi, dpiLo].
-    await this.requestLong(featureIndex, 0x30, [0x00, dpi >> 8, dpi & 0xff]);
+    // setSensorDpi(sensor 0, dpi): params = [sensorIdx, dpiHi, dpiLo]. Three
+    // bytes fit a short request, which is the form the G402 was verified with;
+    // receiver-attached HERO mice have always been driven with the long form.
+    if (this.isDirectConnect) {
+      await this.request(featureIndex, 0x30, 0x00, dpi >> 8, dpi & 0xff);
+    } else {
+      await this.requestLong(featureIndex, 0x30, [0x00, dpi >> 8, dpi & 0xff]);
+    }
     const confirmed = await this.readLegacyDpi(featureIndex);
     if (confirmed.dpi !== dpi) {
       throw new Error(`The mouse kept ${confirmed.dpi} DPI instead of ${dpi} DPI.`);
@@ -558,12 +610,7 @@ export class LogitechHidppClient {
     if (!featureIndex) return [];
     // getReportRateList: reply data byte 0 is a bitmap where bit i => (i + 1) ms.
     const reply = await this.request(featureIndex, 0x00);
-    const bitflags = reply[3] ?? 0;
-    const rates: number[] = [];
-    for (let bit = 0; bit < 8; bit += 1) {
-      if ((bitflags & (1 << bit)) !== 0) rates.push(Math.round(1000 / (bit + 1)));
-    }
-    return rates.sort((left, right) => left - right);
+    return decodeReportRateBitmap(reply[3] ?? 0);
   }
 
   private async readLegacyReportRate(featureIndex: number): Promise<number> {
@@ -806,6 +853,11 @@ export class LogitechHidppClient {
   }
 
   private async ensureHostControl(): Promise<void> {
+    // Direct-connect mice accept live 0x2201 DPI writes while still in onboard
+    // mode. Switching them to host control is a persistent state change that
+    // would leave the onboard profile bypassed after the tab closes, so leave
+    // the mouse in whichever mode the user's own software left it in.
+    if (this.isDirectConnect) return;
     const profiles = await this.getFeature(FEATURE.onboardProfiles);
     if (!profiles.index) return;
     const mode = await this.request(profiles.index, 0x20);
@@ -843,7 +895,7 @@ export class LogitechHidppClient {
     }
 
     const report = new Uint8Array([
-      DEVICE_INDEX,
+      this.deviceIndex,
       featureIndex,
       withSoftwareId(functionId),
       parameters[0] ?? 0,
@@ -864,7 +916,7 @@ export class LogitechHidppClient {
       throw new Error("HID++ long requests support at most 16 parameter bytes.");
     }
     const report = new Uint8Array(19);
-    report[0] = DEVICE_INDEX;
+    report[0] = this.deviceIndex;
     report[1] = featureIndex;
     report[2] = withSoftwareId(functionId);
     report.set(parameters, 3);
@@ -881,7 +933,9 @@ export class LogitechHidppClient {
         if (index >= 0) {
           this.waiters.splice(index, 1);
         }
-        reject(new Error("The mouse did not answer. Move it or click a button, then try again."));
+        reject(new Error(this.isDirectConnect
+          ? "The mouse did not answer. Close Logitech G HUB or Logitech Gaming Software, then try again."
+          : "The mouse did not answer. Move it or click a button, then try again."));
       }, 6000);
 
       this.waiters.push({

--- a/src/devices/logitech/protocol.ts
+++ b/src/devices/logitech/protocol.ts
@@ -6,3 +6,65 @@ const SOFTWARE_ID = 0x05;
 export function withSoftwareId(functionId: number): number {
   return (functionId & 0xf0) | SOFTWARE_ID;
 }
+
+/** Receiver-attached mice answer on the receiver's first pairing slot. */
+export const DEVICE_INDEX_RECEIVER = 0x01;
+/** A mouse addressed over its own USB interface answers on 0xFF. */
+export const DEVICE_INDEX_DIRECT = 0xff;
+
+/**
+ * Logitech mice whose vendor interface is the mouse itself rather than a
+ * receiver. They answer HID++ on device index 0xFF and keep their writable
+ * settings in an onboard profile. 0xc07e is the wired G402 / G402 Hyperion Fury.
+ */
+export const LOGITECH_DIRECT_PRODUCT_IDS: ReadonlySet<number> = new Set([0xc07e]);
+
+export function isDirectConnectProduct(productId: number): boolean {
+  return LOGITECH_DIRECT_PRODUCT_IDS.has(productId);
+}
+
+export function hidppDeviceIndex(productId: number): number {
+  return isDirectConnectProduct(productId) ? DEVICE_INDEX_DIRECT : DEVICE_INDEX_RECEIVER;
+}
+
+/** HID++ 2.0 error codes, reported in byte 4 of a 0xFF error response. */
+const HIDPP_ERRORS: Readonly<Record<number, string>> = {
+  0x01: "unknown request",
+  0x02: "invalid argument",
+  0x03: "value out of range",
+  0x04: "hardware error",
+  0x05: "Logitech internal error",
+  0x06: "invalid feature index",
+  0x07: "invalid function",
+  0x08: "device busy",
+  0x09: "unsupported",
+};
+
+export function hidppErrorMessage(code: number): string {
+  const reason = HIDPP_ERRORS[code];
+  return reason
+    ? `The mouse rejected that setting (${reason}).`
+    : `The mouse rejected that setting (HID++ error 0x${code.toString(16).padStart(2, "0")}).`;
+}
+
+/**
+ * Decode the legacy Report Rate (0x8060) supported-rate bitmap, where bit i
+ * marks an interval of (i + 1) ms. The G402 generation reports 0x8b, meaning
+ * 1, 2, 4 and 8 ms — 1000, 500, 250 and 125 Hz.
+ */
+export function decodeReportRateBitmap(bitflags: number): number[] {
+  const rates: number[] = [];
+  for (let bit = 0; bit < 8; bit += 1) {
+    if ((bitflags & (1 << bit)) !== 0) rates.push(Math.round(1000 / (bit + 1)));
+  }
+  return rates.sort((left, right) => left - right);
+}
+
+/**
+ * The G402's documented sensor range, used only when the mouse answers the
+ * legacy DPI-list request with nothing usable. Every value is still confirmed
+ * by the read-back after a write.
+ */
+export function legacyDpiFallback(): number[] {
+  return Array.from({ length: 48 }, (_, step) => 240 + step * 80);
+}

--- a/src/devices/logitech/protocol.ts
+++ b/src/devices/logitech/protocol.ts
@@ -16,11 +16,16 @@ export const DEVICE_INDEX_DIRECT = 0xff;
  * Logitech mice whose vendor interface is the mouse itself rather than a
  * receiver. They answer HID++ on device index 0xFF and keep their writable
  * settings in an onboard profile. 0xc07e is the wired G402 / G402 Hyperion Fury.
+ *
+ * This module deliberately imports nothing, so both the driver and the WebHID
+ * filters in ../vendors can read it without a cycle.
  */
-export const LOGITECH_DIRECT_PRODUCT_IDS: ReadonlySet<number> = new Set([0xc07e]);
+export const LOGITECH_DIRECT_PRODUCT_IDS = [0xc07e] as const;
+
+const DIRECT_PRODUCT_ID_SET: ReadonlySet<number> = new Set(LOGITECH_DIRECT_PRODUCT_IDS);
 
 export function isDirectConnectProduct(productId: number): boolean {
-  return LOGITECH_DIRECT_PRODUCT_IDS.has(productId);
+  return DIRECT_PRODUCT_ID_SET.has(productId);
 }
 
 export function hidppDeviceIndex(productId: number): number {
@@ -61,10 +66,12 @@ export function decodeReportRateBitmap(bitflags: number): number[] {
 }
 
 /**
- * The G402's documented sensor range, used only when the mouse answers the
- * legacy DPI-list request with nothing usable. Every value is still confirmed
- * by the read-back after a write.
+ * The G402's real sensor grid, used only when the mouse answers the legacy
+ * DPI-list request with nothing usable. Hardware advertises 252 to 4032 in
+ * steps of 84 — not the 240/80 quoted by vendor software, which rounds these
+ * to marketing numbers (2436 is displayed as 2400). Every value is still
+ * confirmed by the read-back after a write.
  */
 export function legacyDpiFallback(): number[] {
-  return Array.from({ length: 48 }, (_, step) => 240 + step * 80);
+  return Array.from({ length: 46 }, (_, step) => 252 + step * 84);
 }

--- a/src/devices/mouse-types.ts
+++ b/src/devices/mouse-types.ts
@@ -14,6 +14,8 @@ export interface MouseUiHints {
   lodRequiresSurface?: boolean;
   /** Hide poll rates not listed in supportedPollingRates. */
   hideUnsupportedPollingRates?: boolean;
+  /** Show the polling rate the mouse reports, but refuse to stage a change. */
+  pollingReadOnly?: boolean;
   /** Hide Motion Sync / angle snap / ripple card. */
   hideProcessingCard?: boolean;
   /** Always show battery column (even wired with null %). */

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -10,9 +10,9 @@ export const VENDOR_ID = {
 } as const;
 
 // Logitech HID++ control interfaces. 0xc54d and 0xc547 are newer Lightspeed
-// receivers, 0xc539 is HERO-era Lightspeed, and 0xc0a8 is the PRO X 2
-// Superstrike USB interface.
-export const LOGITECH_RECEIVER_PRODUCT_IDS = [0xc54d, 0xc539, 0xc0a8, 0xc547] as const;
+// receivers, 0xc539 is HERO-era Lightspeed, 0xc0a8 is the PRO X 2 Superstrike
+// USB interface, and 0xc07e is the wired G402 Hyperion Fury.
+export const LOGITECH_RECEIVER_PRODUCT_IDS = [0xc54d, 0xc539, 0xc0a8, 0xc547, 0xc07e] as const;
 
 export const LOGITECH_RECEIVER_FILTERS: HIDDeviceFilter[] = LOGITECH_RECEIVER_PRODUCT_IDS.map(
   (productId) => ({ vendorId: VENDOR_ID.logitech, productId, usagePage: 0xff00, usage: 0x0001 }),

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -1,4 +1,5 @@
 import { EGG_WE_HID_FILTERS } from "./endgame/egg-we-control";
+import { LOGITECH_DIRECT_PRODUCT_IDS } from "./logitech/protocol";
 
 export const VENDOR_ID = {
   pulsar: 0x3710,
@@ -9,12 +10,20 @@ export const VENDOR_ID = {
   orbital: 0x1915,
 } as const;
 
-// Logitech HID++ control interfaces. 0xc54d and 0xc547 are newer Lightspeed
-// receivers, 0xc539 is HERO-era Lightspeed, 0xc0a8 is the PRO X 2 Superstrike
-// USB interface, and 0xc07e is the wired G402 Hyperion Fury.
-export const LOGITECH_RECEIVER_PRODUCT_IDS = [0xc54d, 0xc539, 0xc0a8, 0xc547, 0xc07e] as const;
+// Logitech HID++ control interfaces addressed through a receiver slot (HID++
+// device index 0x01). 0xc54d and 0xc547 are newer Lightspeed receivers, 0xc539
+// is HERO-era Lightspeed, and 0xc0a8 is the PRO X 2 Superstrike USB interface.
+export const LOGITECH_RECEIVER_PRODUCT_IDS = [0xc54d, 0xc539, 0xc0a8, 0xc547] as const;
 
-export const LOGITECH_RECEIVER_FILTERS: HIDDeviceFilter[] = LOGITECH_RECEIVER_PRODUCT_IDS.map(
+// Every Logitech product with an HID++ control interface, receiver-addressed or
+// not. Direct-connect product IDs live in ./logitech/protocol so the driver and
+// these filters cannot disagree about which index a mouse answers on.
+export const LOGITECH_PRODUCT_IDS = [
+  ...LOGITECH_RECEIVER_PRODUCT_IDS,
+  ...LOGITECH_DIRECT_PRODUCT_IDS,
+] as const;
+
+export const LOGITECH_RECEIVER_FILTERS: HIDDeviceFilter[] = LOGITECH_PRODUCT_IDS.map(
   (productId) => ({ vendorId: VENDOR_ID.logitech, productId, usagePage: 0xff00, usage: 0x0001 }),
 );
 

--- a/src/dpi-presets.test.ts
+++ b/src/dpi-presets.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { closestDpiOption, dpiPresetValues } from "./dpi-presets.ts";
+
+/** A mouse advertising a fine grid that contains every round number. */
+const FINE_GRID = Array.from({ length: 600 }, (_, step) => 50 + step * 50);
+/** The G402's real grid, captured from hardware: 252 to 4032 in steps of 84. */
+const G402_GRID = Array.from({ length: 46 }, (_, step) => 252 + step * 84);
+
+test("a mouse that lists the round numbers keeps them exactly", () => {
+  assert.deepEqual(dpiPresetValues(FINE_GRID), [400, 800, 1600, 3200, 6400, 8000]);
+});
+
+test("presets beyond a mouse's range are dropped, not snapped to its maximum", () => {
+  // Maximum 4000, so 6400 and 8000 have no believable stand-in.
+  const upTo4000 = Array.from({ length: 80 }, (_, step) => 50 + step * 50);
+  assert.deepEqual(dpiPresetValues(upTo4000), [400, 800, 1600, 3200]);
+});
+
+test("a sparse advertised list still yields only values the mouse holds", () => {
+  const sparse = [400, 800, 1600, 3200];
+  assert.deepEqual(dpiPresetValues(sparse), sparse);
+});
+
+test("the G402's 84-step grid produces a usable preset row", () => {
+  const presets = dpiPresetValues(G402_GRID);
+  // Without snapping this row collapsed to a single button.
+  assert.equal(presets.length, 4);
+  assert.deepEqual(presets, [420, 840, 1596, 3192]);
+  // Every offered value must be one the mouse actually advertises.
+  for (const preset of presets) assert.equal(G402_GRID.includes(preset), true);
+});
+
+test("a coarse list with no near matches offers nothing rather than guessing", () => {
+  // 1000 is 25% away from 800 and 2000 is 25% away from 1600, so neither is a
+  // believable stand-in. The row then shows only the mouse's current DPI.
+  assert.deepEqual(dpiPresetValues([1000, 2000]), []);
+});
+
+test("snapped presets never repeat a value", () => {
+  for (const grid of [G402_GRID, FINE_GRID, [1500, 1510, 1520]]) {
+    const presets = dpiPresetValues(grid);
+    assert.equal(new Set(presets).size, presets.length);
+  }
+});
+
+test("a mouse with no advertised DPI values offers no presets", () => {
+  assert.deepEqual(dpiPresetValues([]), []);
+  assert.equal(closestDpiOption([], 800), null);
+});
+
+test("the closest step is reported for a value the mouse cannot reach", () => {
+  // Vendor software shows 2400; the mouse can only hold 2436.
+  assert.equal(closestDpiOption(G402_GRID, 2400), 2436);
+  assert.equal(closestDpiOption(G402_GRID, 100), 252);
+  assert.equal(closestDpiOption(G402_GRID, 99999), 4032);
+});

--- a/src/dpi-presets.ts
+++ b/src/dpi-presets.ts
@@ -1,0 +1,35 @@
+/** Round numbers the DPI row offers when a mouse can reach them. */
+export const COMMON_DPI_PRESETS = [400, 800, 1600, 3200, 6400, 8000] as const;
+
+/**
+ * How far a nominal preset may be snapped onto a mouse's own DPI grid before it
+ * stops being a believable stand-in for the round number on the button.
+ */
+const DPI_SNAP_TOLERANCE = 0.1;
+
+/** Closest DPI the mouse can actually reach, or null when it advertises none. */
+export function closestDpiOption(options: readonly number[], target: number): number | null {
+  let closest: number | null = null;
+  for (const option of options) {
+    if (closest === null || Math.abs(option - target) < Math.abs(closest - target)) closest = option;
+  }
+  return closest;
+}
+
+/**
+ * Presets snapped onto the mouse's advertised grid. Mice that list the round
+ * numbers exactly — most of them — get those values back untouched. Mice with
+ * an unusual step (the G402 counts in 84s from 252, so vendor software shows
+ * "2400" for a mouse actually holding 2436) get the nearest value they can
+ * really hold, instead of a preset row that collapses to a single button.
+ *
+ * A preset with no option within the tolerance is dropped, so a mouse that
+ * simply cannot reach 8000 DPI still does not get a button for it.
+ */
+export function dpiPresetValues(options: readonly number[]): number[] {
+  const snapped = COMMON_DPI_PRESETS.map((preset) => {
+    const option = closestDpiOption(options, preset);
+    return option !== null && Math.abs(option - preset) <= preset * DPI_SNAP_TOLERANCE ? option : null;
+  }).filter((dpi): dpi is number => dpi !== null);
+  return [...new Set(snapped)].sort((left, right) => left - right);
+}


### PR DESCRIPTION
Adds support for the G402.
Tested with G402 Firmware U 90.03
Primary implementation references:
1. libratbag HID++ implementation  
   https://github.com/libratbag/libratbag/blob/master/src/hidpp20.c
2. libratbag HID++ structures and feature definitions  
   https://github.com/libratbag/libratbag/blob/master/src/hidpp20.h
3. G402 HID++ feature enumeration and profile description  
   https://github.com/cvuchener/hidpp/issues/1
4. Linux Logitech HID++ driver  
   https://github.com/torvalds/linux/blob/master/drivers/hid/hid-logitech-hidpp.c
Implementation work was assisted with Claude Code & Codex (For Research)
![image](https://i.ibb.co/gMkHD0RR/image.png)

Tests results (45/45)
```
ℹ tests 45
ℹ suites 0
ℹ pass 45
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 153.2993
```



