### PR TITLE
Added wired/wireless for moddoMOUSE V1

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -22,6 +22,7 @@ import {
   type EggWeHidClient,
 } from "./egg-we-control";
 import { LogitechHidppClient } from "./logitech-hidpp";
+import { ModdoHidClient } from "./moddo-hid";
 import type { MouseStatus } from "./mouse-types";
 import { PulsarHidClient } from "./pulsar-hid";
 import { PulsarProHidClient } from "./pulsar-pro-hid";
@@ -49,6 +50,7 @@ let activePulsarClient: PulsarClient | null = null;
 let activeEggClient: EggOp1HidClient | null = null;
 let activeEggWeClient: EggWeHidClient | null = null;
 let activeWLMouseClient: WLMouseHidClient | null = null;
+let activeModdoClient: ModdoHidClient | null = null;
 let refreshTimer: number | null = null;
 let refreshInProgress = false;
 let dpiOptions: number[] = [];
@@ -60,10 +62,17 @@ const deviceStatuses = new Map<HIDDevice, MouseStatus>();
 let reconnectInFlight = false;
 
 type PulsarClient = PulsarHidClient | PulsarProHidClient;
-type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | WLMouseHidClient;
+type SupportedClient =
+  | LogitechHidppClient
+  | PulsarClient
+  | EggOp1HidClient
+  | EggWeHidClient
+  | WLMouseHidClient
+  | ModdoHidClient;
 
 function activeSettingsClient(): SupportedClient | null {
-  return activeClient ?? activePulsarClient ?? activeEggClient ?? activeEggWeClient ?? activeWLMouseClient;
+  return activeClient ?? activePulsarClient ?? activeEggClient ?? activeEggWeClient ?? activeWLMouseClient
+    ?? activeModdoClient;
 }
 
 function hasActiveClient(): boolean {
@@ -908,6 +917,7 @@ function createSupportedClient(device: HIDDevice): SupportedClient | null {
   if (PulsarHidClient.isSupported(device)) return new PulsarHidClient(device);
   if (LogitechHidppClient.isSupported(device)) return new LogitechHidppClient(device);
   if (WLMouseHidClient.isSupported(device)) return new WLMouseHidClient(device);
+  if (ModdoHidClient.isSupported(device)) return new ModdoHidClient(device);
   return null;
 }
 
@@ -915,6 +925,7 @@ function deviceBrand(client: SupportedClient): string {
   if (client instanceof EggOp1HidClient || isEggWeClient(client)) return "Endgame Gear";
   if (client instanceof LogitechHidppClient) return "Logitech";
   if (client instanceof WLMouseHidClient) return "WLMouse";
+  if (client instanceof ModdoHidClient) return "moddoMOUSE";
   return "Pulsar";
 }
 
@@ -993,6 +1004,7 @@ async function activateClient(client: SupportedClient): Promise<void> {
   activeEggClient = null;
   activeEggWeClient = null;
   activeWLMouseClient = null;
+  activeModdoClient = null;
   activeDevice = client.device;
   lastRenderedStatusKey = null;
   if (client instanceof WLMouseHidClient) {
@@ -1027,6 +1039,13 @@ async function activateClient(client: SupportedClient): Promise<void> {
     dpiOptions = await client.getDpiOptions();
     configureDpiControl(status.dpi);
     showStatus(status);
+  } else if (client instanceof ModdoHidClient) {
+    activeModdoClient = client;
+    const status = await client.readStatus();
+    deviceStatuses.set(client.device, status);
+    dpiOptions = client.getDpiOptions();
+    configureDpiControl(status.dpi);
+    showStatus(status);
   } else {
     activePulsarClient = client;
     await showPulsarExplorer(client);
@@ -1047,6 +1066,7 @@ function showDisconnectedState(): void {
   activeEggClient = null;
   activeEggWeClient = null;
   activeWLMouseClient = null;
+  activeModdoClient = null;
   activeDevice = null;
   lastRenderedStatusKey = null;
   resetDeviceSpecificPanels();
@@ -1172,6 +1192,7 @@ function clientSupportScore(device: HIDDevice): number {
   if (PulsarProHidClient.isSupported(device)) return 8;
   if (PulsarHidClient.isSupported(device)) return 7;
   if (LogitechHidppClient.isSupported(device)) return 6;
+  if (ModdoHidClient.isSupported(device)) return 5;
   return 0;
 }
 
@@ -1699,6 +1720,7 @@ window.addEventListener("beforeunload", () => {
   void activeEggClient?.close();
   void activeEggWeClient?.close();
   void activeWLMouseClient?.close();
+  void activeModdoClient?.close();
 });
 
 renderControl();

--- a/src/moddo-hid.ts
+++ b/src/moddo-hid.ts
@@ -1,0 +1,304 @@
+import type { MouseStatus } from "./mouse-types";
+
+/**
+ * moddoMOUSE (moddo.io) vendor HID control.
+ *
+ * Transport: vendor usage page 0xFF, usage 0x01 (or legacy 0x02) under VID 0x2FE3.
+ * Settings live in one packed feature report (id 0x02) — no CBOR:
+ *   [ pollingHz u16le | lift u8 | dpiX u16le | dpiY u16le | invert/swap u8 | angle i16le | deepSleep u8 ]
+ * Battery is feature report 0x04; firmware version + connection path (wireless
+ * dongle vs. wired) come from feature report 0x03. Only documented settings are
+ * touched here — no firmware flashing, wireless pairing, or button remapping.
+ *
+ * Report layout mirrors moddoHUB-Web (js/main.js, js/battery.js, js/firmware.js).
+ */
+
+const MODDO_VENDOR_ID = 0x2fe3;
+const USAGE_PAGE_VENDOR = 0xff;
+const USAGE_VENDOR_CONFIG = 0x01;
+const USAGE_VENDOR_CONFIG_LEGACY = 0x02;
+
+const REPORT_CONFIG = 0x02;
+const REPORT_FW_INFO = 0x03;
+const REPORT_BATTERY = 0x04;
+
+/** Packed config-report field offsets (into the payload, i.e. after the report-id byte). */
+const CONFIG = {
+  polling: 0, // u16 LE — report rate in Hz
+  lift: 2, // u8 — 1 = 1 mm, 2 = 2 mm
+  dpiX: 3, // u16 LE
+  dpiY: 5, // u16 LE
+  invertSwap: 7, // u8 — preserved across writes
+  angle: 8, // i16 LE — preserved across writes
+  deepSleep: 10, // u8 — preserved across writes
+} as const;
+const CONFIG_REPORT_SIZE = 11;
+
+const SUPPORTED_POLLING_RATES = [125, 250, 500, 1000] as const;
+const DPI_MIN = 50;
+const DPI_MAX = 26000;
+const DPI_STEP = 50;
+
+// The firmware applies config writes fire-and-forget, so a read-back can briefly
+// still show the old value (especially over the 2.4 GHz dongle). Settle and retry
+// before deciding a write failed.
+const WRITE_SETTLE_MS = 60;
+const WRITE_CONFIRM_ATTEMPTS = 5;
+
+// Battery status codes and charger flags (js/battery.js).
+const BATTERY_CHARGING = 0x44;
+const BATTERY_DISCHARGING = 0x45;
+const BATTERY_FULLY_CHARGED = 0x46;
+const BATTERY_FULLY_DISCHARGED = 0x47;
+const CHARGER_BATTERY_PRESENT_BIT = 1 << 0;
+
+interface ModdoConfig {
+  polling: number;
+  lift: number;
+  dpiX: number;
+  dpiY: number;
+  invertSwap: number;
+  angle: number;
+  deepSleep: number;
+}
+
+interface ModdoFirmware {
+  mouse: string | null;
+  dongle: string | null;
+  dongleConnected: boolean;
+}
+
+export class ModdoHidClient {
+  constructor(readonly device: HIDDevice) {}
+
+  static isSupported(device: HIDDevice): boolean {
+    if (device.vendorId !== MODDO_VENDOR_ID) return false;
+    const hasVendorConfig = (collections: readonly HIDCollectionInfo[]): boolean =>
+      collections.some((collection) =>
+        (collection.usagePage === USAGE_PAGE_VENDOR
+          && (collection.usage === USAGE_VENDOR_CONFIG || collection.usage === USAGE_VENDOR_CONFIG_LEGACY))
+        || hasVendorConfig(collection.children));
+    return hasVendorConfig(device.collections);
+  }
+
+  get supportedPollingRates(): number[] {
+    return [...SUPPORTED_POLLING_RATES];
+  }
+
+  getDpiOptions(): number[] {
+    const values: number[] = [];
+    for (let dpi = DPI_MIN; dpi <= DPI_MAX; dpi += DPI_STEP) values.push(dpi);
+    return values;
+  }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) await this.device.open();
+  }
+
+  async close(): Promise<void> {
+    if (this.device.opened) await this.device.close();
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    await this.open();
+    // readConfig rejects a zeroed/asleep report, so a null here means "not ready"
+    // and the grid stays hidden instead of showing 0 DPI / 0 Hz.
+    const config = await this.readConfig().catch(() => null);
+    const battery = await this.readBattery().catch(
+      () => ({ percent: null, state: "Unknown" as MouseStatus["batteryState"] }),
+    );
+    const firmware = await this.readFirmware().catch(() => null);
+    const wireless = firmware?.dongleConnected ?? false;
+
+    return {
+      brand: "moddoMOUSE",
+      name: "moddoMOUSE",
+      ui: {
+        family: "moddo",
+        settingsReady: config !== null,
+        hideLodLow: true,
+        hideUnsupportedPollingRates: true,
+        hideProcessingCard: true,
+        defaultDisplayName: "moddoMOUSE",
+      },
+      batteryPercent: battery.percent,
+      batteryState: battery.state,
+      dpi: config?.dpiX ?? 1600,
+      dpiY: config?.dpiY ?? config?.dpiX ?? 1600,
+      pollingRateHz: config?.polling ?? 1000,
+      supportedPollingRates: this.supportedPollingRates,
+      activeProfile: null,
+      connectionType: wireless ? "Wireless" : "Wired",
+      connectionDetail: wireless ? "2.4 GHz receiver" : "USB",
+      liftOffDistance: this.decodeLift(config?.lift),
+      firmware: this.firmwareLines(firmware),
+    };
+  }
+
+  async setDpi(dpi: number, dpiY: number = dpi): Promise<number> {
+    for (const value of [dpi, dpiY]) {
+      if (!this.isValidDpi(value)) {
+        throw new Error(
+          `moddoMOUSE DPI must be ${DPI_MIN}–${DPI_MAX.toLocaleString()} in ${DPI_STEP} DPI steps.`,
+        );
+      }
+    }
+    await this.open();
+    const config = await this.readConfig();
+    await this.writeConfig({ ...config, dpiX: dpi, dpiY });
+    const confirmed = await this.confirmConfig((c) => c.dpiX === dpi && c.dpiY === dpiY);
+    if (confirmed.dpiX !== dpi || confirmed.dpiY !== dpiY) {
+      throw new Error(`The mouse kept ${confirmed.dpiX.toLocaleString()} DPI instead of ${dpi.toLocaleString()}.`);
+    }
+    return confirmed.dpiX;
+  }
+
+  async setPollingRate(rate: number): Promise<number> {
+    if (!(SUPPORTED_POLLING_RATES as readonly number[]).includes(rate)) {
+      throw new Error("moddoMOUSE supports 125, 250, 500, or 1000 Hz report rate.");
+    }
+    await this.open();
+    const config = await this.readConfig();
+    await this.writeConfig({ ...config, polling: rate });
+    const confirmed = await this.confirmConfig((c) => c.polling === rate);
+    if (confirmed.polling !== rate) {
+      throw new Error(
+        `The mouse kept ${confirmed.polling.toLocaleString()} Hz instead of ${rate.toLocaleString()} Hz.`,
+      );
+    }
+    return confirmed.polling;
+  }
+
+  async setLiftOffDistance(value: NonNullable<MouseStatus["liftOffDistance"]>): Promise<void> {
+    if (value === "Low") {
+      throw new Error("The moddoMOUSE supports 1 mm (Medium) or 2 mm (High) lift-off distance.");
+    }
+    const encoded = value === "Medium" ? 1 : 2;
+    await this.open();
+    const config = await this.readConfig();
+    await this.writeConfig({ ...config, lift: encoded });
+    const confirmed = await this.confirmConfig((c) => c.lift === encoded);
+    if (confirmed.lift !== encoded) {
+      throw new Error(
+        `The mouse kept ${this.decodeLift(confirmed.lift) ?? "an unknown"} lift-off distance instead of ${value}.`,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Report helpers
+  // ---------------------------------------------------------------------------
+
+  private isValidDpi(dpi: number): boolean {
+    return Number.isInteger(dpi) && dpi >= DPI_MIN && dpi <= DPI_MAX && dpi % DPI_STEP === 0;
+  }
+
+  private decodeLift(raw: number | undefined): MouseStatus["liftOffDistance"] {
+    if (raw === 1) return "Medium";
+    if (raw === 2) return "High";
+    return null;
+  }
+
+  private async readConfig(): Promise<ModdoConfig> {
+    const view = this.payload(await this.device.receiveFeatureReport(REPORT_CONFIG));
+    // Need at least polling + lift + both DPI axes (through offset 6).
+    if (view.byteLength < 7) throw new Error("moddoMOUSE returned a truncated config report.");
+    const u8 = (offset: number): number => (offset < view.byteLength ? view.getUint8(offset) : 0);
+    const i16 = (offset: number): number => (offset + 2 <= view.byteLength ? view.getInt16(offset, true) : 0);
+    const config: ModdoConfig = {
+      polling: view.getUint16(CONFIG.polling, true),
+      lift: view.getUint8(CONFIG.lift),
+      dpiX: view.getUint16(CONFIG.dpiX, true),
+      dpiY: view.getUint16(CONFIG.dpiY, true),
+      invertSwap: u8(CONFIG.invertSwap),
+      angle: i16(CONFIG.angle),
+      deepSleep: u8(CONFIG.deepSleep),
+    };
+    // An asleep/off wireless mouse answers with a zeroed report. Reject it so the
+    // UI never shows 0 DPI / 0 Hz and a read-modify-write can't persist zeros.
+    if (config.polling <= 0 || config.dpiX < DPI_MIN || config.dpiX > DPI_MAX) {
+      throw new Error("moddoMOUSE settings are not ready yet — wake the mouse and try again.");
+    }
+    return config;
+  }
+
+  /** Re-read the config until it matches, tolerating fire-and-forget write latency. */
+  private async confirmConfig(matches: (config: ModdoConfig) => boolean): Promise<ModdoConfig> {
+    let config = await this.readConfig();
+    for (let attempt = 1; attempt < WRITE_CONFIRM_ATTEMPTS && !matches(config); attempt += 1) {
+      await this.delay(WRITE_SETTLE_MS);
+      config = await this.readConfig();
+    }
+    return config;
+  }
+
+  private delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+  }
+
+  private async writeConfig(config: ModdoConfig): Promise<void> {
+    const buffer = new ArrayBuffer(CONFIG_REPORT_SIZE);
+    const view = new DataView(buffer);
+    view.setUint16(CONFIG.polling, config.polling, true);
+    view.setUint8(CONFIG.lift, config.lift);
+    view.setUint16(CONFIG.dpiX, config.dpiX, true);
+    view.setUint16(CONFIG.dpiY, config.dpiY, true);
+    view.setUint8(CONFIG.invertSwap, config.invertSwap);
+    view.setInt16(CONFIG.angle, config.angle, true);
+    view.setUint8(CONFIG.deepSleep, config.deepSleep);
+    await this.device.sendFeatureReport(REPORT_CONFIG, new Uint8Array(buffer));
+  }
+
+  private async readBattery(): Promise<{ percent: number | null; state: MouseStatus["batteryState"] }> {
+    const view = this.payload(await this.device.receiveFeatureReport(REPORT_BATTERY));
+    if (view.byteLength < 4) return { percent: null, state: "Unknown" };
+    const remaining = view.getUint8(0);
+    const status = view.getUint8(2);
+    const chargerStatus = view.getUint8(3);
+    if ((chargerStatus & CHARGER_BATTERY_PRESENT_BIT) === 0) {
+      // No cell present (e.g. a wired mouse) — surface an empty battery column.
+      return { percent: null, state: "Unknown" };
+    }
+    const percent = remaining > 100 ? null : remaining;
+    const state: MouseStatus["batteryState"] = status === BATTERY_CHARGING
+      ? "Charging"
+      : status === BATTERY_FULLY_CHARGED
+        ? "Full"
+        : status === BATTERY_DISCHARGING || status === BATTERY_FULLY_DISCHARGED
+          ? "Discharging"
+          : "Unknown";
+    return { percent, state };
+  }
+
+  private async readFirmware(): Promise<ModdoFirmware> {
+    const view = this.payload(await this.device.receiveFeatureReport(REPORT_FW_INFO));
+    // First 8 bytes: dongle (rx) then mouse (tx) major.minor.patch.build.
+    if (view.byteLength < 8) return { mouse: null, dongle: null, dongleConnected: false };
+    const version = (offset: number): { text: string; present: boolean } => {
+      const major = view.getUint8(offset);
+      const minor = view.getUint8(offset + 1);
+      const patch = view.getUint8(offset + 2);
+      const build = view.getUint8(offset + 3);
+      const present = !(major === 0 && minor === 0 && patch === 0 && build === 0);
+      return { text: `${major}.${minor}.${patch}`, present };
+    };
+    const dongle = version(0);
+    const mouse = version(4);
+    return {
+      mouse: mouse.present ? mouse.text : null,
+      dongle: dongle.present ? dongle.text : null,
+      dongleConnected: dongle.present,
+    };
+  }
+
+  private firmwareLines(firmware: ModdoFirmware | null): string[] {
+    const lines = [firmware?.mouse ? `Mouse v${firmware.mouse}` : "Mouse firmware unavailable"];
+    if (firmware?.dongle) lines.push(`Dongle v${firmware.dongle}`);
+    return lines;
+  }
+
+  /** WebHID feature reports carry the report id as byte 0; return a view past it. */
+  private payload(view: DataView): DataView {
+    return new DataView(view.buffer, view.byteOffset + 1, Math.max(0, view.byteLength - 1));
+  }
+}

--- a/src/mouse-types.ts
+++ b/src/mouse-types.ts
@@ -23,7 +23,7 @@ export interface MouseUiHints {
 }
 
 export interface MouseStatus {
-  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse";
+  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "moddoMOUSE";
   name: string;
   /** Driver-supplied UI policy (optional; keeps control.ts brand-agnostic). */
   ui?: MouseUiHints;

--- a/src/vendors.ts
+++ b/src/vendors.ts
@@ -5,7 +5,14 @@ export const VENDOR_ID = {
   endgameGear: 0x3367,
   wlmouse: 0x36a7,
   logitech: 0x046d,
+  moddo: 0x2fe3,
 } as const;
+
+/** moddoMOUSE exposes its config interface on vendor usage 0xFF01 (legacy 0xFF02). */
+export const MODDO_HID_FILTERS: HIDDeviceFilter[] = [
+  { vendorId: VENDOR_ID.moddo, usagePage: 0xff, usage: 0x01 },
+  { vendorId: VENDOR_ID.moddo, usagePage: 0xff, usage: 0x02 },
+];
 
 export const LOGITECH_RECEIVER_FILTER: HIDDeviceFilter = {
   vendorId: VENDOR_ID.logitech,
@@ -49,5 +56,6 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.endgameGear },
   { vendorId: VENDOR_ID.wlmouse },
   ...EGG_WE_HID_FILTERS,
+  ...MODDO_HID_FILTERS,
   LOGITECH_RECEIVER_FILTER,
 ];


### PR DESCRIPTION
Added basic wired/wireless support for moddoMOUSE V1 (https://moddo.io/pages/moddomouse-v1). Future "nice to have" will include angle rotation, support for 64 additional keys, and custom acceleration profile.

<img width="1764" height="555" alt="image" src="https://github.com/user-attachments/assets/54163c45-9852-4cdf-a866-4cf35293df2c" />

<img width="1761" height="580" alt="image" src="https://github.com/user-attachments/assets/889a7cb0-3869-4446-979d-336541de098a" />
