### PR TITLE
feat(logitech): Add support for every single Logitech mice and dev previews for every brand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@ supabase/migrations/
 .env
 .env.*
 !.env.example
-logidec
-probe.*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ supabase/migrations/
 .env
 .env.*
 !.env.example
+logidec
+probe.*

--- a/build/check-bundle-size.ts
+++ b/build/check-bundle-size.ts
@@ -3,7 +3,10 @@ import { join } from "node:path";
 
 const BUDGET_BYTES: Record<string, number> = {
   ".css": 45_000,
-  ".js": 280_000,
+  // Raised from 280 kB for the production Logitech onboard-profile codec,
+  // guarded flash editor, verification exporter, and upstream Finalmouse
+  // driver merged in the same release. Preview fixtures remain dev-only.
+  ".js": 310_000,
 };
 
 const ASSETS = join("dist", "assets");

--- a/docs/logitech-onboard-profiles.md
+++ b/docs/logitech-onboard-profiles.md
@@ -250,11 +250,25 @@ The Pro X Superlight 2 offers three levels in G HUB and its profile bytes count
 from one, so format 7 now uses `{ Low: 1, Medium: 2, High: 3 }` and advertises
 all three.
 
-**Still open:** whether other formats share it. 0x2202 and profile flash remain
-different transports, and format 8's two levels were never rechecked against the
-encoding, so every other format keeps counting from zero until someone captures
-the same diff on one. `capabilitiesForFormat` holds the encoding per format for
-that reason.
+**Settled for every format.** The remaining doubt was whether 0x2202 shared the
+profile's numbering, since they are different transports. It does:
+[OpenLogi](https://github.com/AprilNEA/OpenLogi) implements 0x2202 with
+
+```rust
+pub enum Lod { NotSupported = 0, Low = 1, Medium = 2, High = 3 }
+```
+
+which is the same count-from-one scheme, arrived at independently. So `0` is
+the feature's "this sensor has no lift-off control" value rather than a level,
+and the driver now uses one encoding everywhere instead of keeping a
+count-from-zero fallback for unrecognised formats.
+
+What stays per format is which *levels* a device offers — a genuine hardware
+difference — not how they are numbered.
+
+OpenLogi's `DpiParameters` field order (`sensor_index, dpi_x, default_dpi_x,
+dpi_y, default_dpi_y, lod`) also confirms this repo's byte offsets: with the
+3-byte header, x at `[4..5]`, y at `[8..9]`, lod at `[12]`.
 
 ## Profile layouts
 

--- a/docs/logitech-onboard-profiles.md
+++ b/docs/logitech-onboard-profiles.md
@@ -1,0 +1,667 @@
+# Logitech onboard profiles (HID++ 0x8100)
+
+Reference notes for implementing onboard profile support. Everything here is
+recorded with its provenance so it can be re-derived rather than trusted.
+
+**Status: protocol recovered, unverified on hardware.** All eight profile format
+layouts and the checksum algorithm are documented below, read out of Logitech's
+native code. Nothing here has been confirmed against a real device. See
+[What is still unknown](#what-is-still-unknown) and
+[Verifying before writing](#verifying-before-writing).
+
+## Provenance
+
+Recovered from Logitech's Onboard Memory Manager 2.6.1749, a .NET/C# WPF app
+whose metadata is unobfuscated. It embeds its protocol library as a resource,
+`OnboardMemoryManager.embeddeddlls.logi_nethidppio.dll` (3.8 MB, mixed-mode
+C++/CLI), which contains the profile model.
+
+The `logidec/` tool in this repo extracts and decompiles both. Reverse
+engineering for interoperability, as libratbag and Solaar do.
+
+Names, enums and struct layouts below are quoted from that library. Anything
+marked *inferred* is reasoning from behaviour, not a direct quote.
+
+## Two persistence models
+
+Logitech mice expose settings through two unrelated mechanisms, and confusing
+them explains most "my setting reset itself" reports:
+
+| | Onboard profiles (0x8100) | Device-level features |
+|---|---|---|
+| Storage | profile flash | firmware NVM |
+| Examples | DPI, LOD, report rate, buttons, lighting | gaming surface, LightForce (0x8090) |
+| Survives power cycle | yes | yes |
+| Survives host-mode writes | **no** — reloaded from flash | unaffected |
+
+OpenMouse currently writes DPI, LOD and report rate in **host mode**, which is
+volatile: the values live in device RAM only, and are lost on power cycle or as
+soon as anything switches the mouse back to onboard mode (G HUB starting, for
+instance). Persisting them means writing profile flash, which is what this
+document is groundwork for.
+
+Notably, neither gaming surface nor LightForce appears in the component list
+below — confirming from the vendor's own model that they are device-level, not
+profile state.
+
+## Feature 0x8100 enums
+
+Quoted from `logi.hidppio.Feature8100`. Values are enum ordinals starting at 0.
+
+### ONBOARD_MODE
+
+```
+0  ONBOARD_MODE_INVALID
+1  ONBOARD          device runs from profile flash
+2  HOST             software drives settings live
+```
+
+Matches what the driver already sends: `ensureHostControl` writes `0x02`.
+
+### MEMORY_MODEL
+
+```
+0  MEMORY_MODEL_INVALID
+1  MEMORY_MODEL_PROTOSS_HYJAL
+```
+
+### PROFILE_FORMAT
+
+```
+0  PROFILE_FORMAT_INVALID
+1  PROFILE_FORMAT_PROTOSS_HYJAL
+2  PROFILE_FORMAT_LOGAN
+3  PROFILE_FORMAT_HEAT
+4  PROFILE_FORMAT_HARPY
+5  PROFILE_FORMAT_HOST_LAYER
+6  PROFILE_FORMAT_BAYMAX
+```
+
+A device reports its format via `getOnboardProfilesInfo` (function `0x00`).
+Layout differs per format, so this value selects which offsets apply.
+
+### SECTOR_COUNT_RULE
+
+```
+0  LEGACY
+1  RESTRICTED
+2  SECTOR_COUNT_RULE_INVALID
+```
+
+### FUNCTION_OPCODES
+
+Button assignment opcodes:
+
+```
+0  NO_ACTION                          9  SELECT_PREVIOUS_PROFILE
+1  TILT_LEFT                         10  CYCLE_PROFILES
+2  TILT_RIGHT                        11  G_SHIFT
+3  SELECT_NEXT_DPI                   12  BATTERY_LIFE_INDICATOR
+4  SELECT_PREVIOUS_DPI               13  ENABLED_PROFILE_SPECIFIC_NUMBER
+5  CYCLE_DPIS                        14  TOGGLE_PERFORMANCE_MODE
+6  DEFAULT_DPI                       15  HOST_BUTTON
+7  DPI_SHIFT                         16  SCROLL_DOWN
+8  SELECT_NEXT_PROFILE               17  SCROLL_UP
+```
+
+## Profile directory
+
+Sector `0x0000` holds the directory. Each entry (`OnboardProfileDirectoryEntry`)
+is **4 bytes**, verified on hardware:
+
+```
+00 01 00 ff    sector 0x0001, flag 0x00
+00 02 00 ff    sector 0x0002, flag 0x00
+00 03 01 ff    sector 0x0003, flag 0x01   <- the active profile
+00 04 00 ff
+00 05 00 ff
+ff ff ff ff    end of list
+```
+
+- bytes 0–1: sector, big-endian
+- byte 2: flag — `0x01` on the profile that `getCurrentProfile` reports, so it
+  reads as "active" rather than the `enabled` the field name suggests
+- byte 3: reserved, `0xff`
+
+Terminated by an all-`0xff` entry.
+
+## Sector size
+
+`getOnboardProfilesInfo` reports **255**, and that is a true length, not a max
+offset: the format-7 layout ends with `lighting_flag` at `0xfc`, leaving
+`0xfd`–`0xfe` for the checksum. 0-254 inclusive.
+
+`memoryRead` returns 16 bytes per call and **rejects any read that would run
+past the end of the sector** with `INVALID_ARGUMENT`, so the final chunk cannot
+start at `0xf0`. Read the tail from `length - 16` instead and accept the
+one-byte overlap with the previous chunk.
+
+## Component model
+
+A profile is not a fixed struct. `profile_memory_manager` holds a set of
+*components*, each owning a region of the profile buffer:
+
+- component index table at `+32`, indexed by `component_id`
+- vector of `shared_ptr<profile_component>` at `+8`
+- `get_component<T>(manager, id)` looks up the index, then `__RTDynamicCast`s
+- absent components return index `-1` → `"Component does not exist in this ..."`
+
+Every accessor takes the raw buffer as an argument:
+
+```c
+get_report_rate(report_rate_component* self, vector<unsigned char>* buffer)
+```
+
+so each component resolves its own offset into the buffer at runtime. This is
+why the offsets are not constants anywhere in the binary.
+
+### ComponentId
+
+```
+0   report_rate            12  power_off_timeout
+1   dpi_v1                 13  logo_power_save
+2   color                  14  side_power_save
+3   power_mode             15  cluster_0_active
+4   angle_snapping         16  cluster_0_passive
+5   button_functions       17  cluster_1_active
+6   g_shift_function       18  cluster_1_passive
+7   profile_name           19  lighting_flag
+8   logo                   20  report_rate_wireless
+9   side                   21  report_rate_wired
+10  write_counter          22  dpi_v6
+11  power_save_timeout     23  dpi_delta
+                           24  MAX_ID
+```
+
+### Component accessors
+
+What each component exposes, from the library's method table:
+
+| Component | Accessors |
+|---|---|
+| `report_rate` | `get/set_report_rate` |
+| `report_rate_wired` | `get/set_report_rate_wired` |
+| `report_rate_wireless` | `get/set_report_rate_wireless` |
+| `dpi_v1` | `get/set_dpi_table`, `get/set_default_resolution`, `get/set_g_shift_resolution` |
+| `dpi_v6` | `get/set_dpi_table`, `get/set_default_index`, `get/set_g_shift_index` |
+| `profile_name` | `get/set_utf8_profile_name` |
+| `angle_snapping` | `get/set_angle_snapping` |
+| `button_fn` | `get/set_buttons` |
+| `color` | `get/set_color` |
+| `power_mode` | `get_power_mode` |
+| `bunny_hopping` | `get/set_bunny_hopping_timeout` |
+| `analog_button` | `get/set_actuation_point`, `get/set_rapid_trigger_sensitivity`, `get/set_rapid_trigger_enable`, `get/set_haptic_level` |
+| `lighting_x8070` / `x8071` | `get/set_effect_data` |
+| `lighting_flags` | `get/set_lighting_flags` |
+| `write_counter` | flash write counter |
+| `power_save_timeout` / `power_off_timeout` | timeouts |
+
+**Profile names are stored on the device** — `profile_name` is a real component
+with `get/set_utf8_profile_name`. Despite the name, the bytes on hardware are
+**UTF-16LE**: a profile named `myp` reads `6d 00 79 00 70 00` at `0xa0`, padded
+with `0x00` (or `0xff` when never set).
+
+## DPI stage record
+
+`Feature8100.AdvancedDpi`, the per-stage record used by `dpi_v6`:
+
+```c
+ushort dpi_x;   // 2 bytes
+ushort dpi_y;   // 2 bytes
+byte   lod;     // 1 byte
+```
+
+Five bytes per stage: `XX XX YY YY LL`.
+
+### LOD encoding
+
+`lod == 0` means **the stage is unused**, not a lift-off level. In
+`HIDProfile.cs` the disabled-stage branch zeroes `dpi_x`, `dpi_y` and `lod`
+together, and `Models.DPI.InitializeDPI` substitutes `2` when it reads `0`:
+
+```csharp
+public void InitializeDPI(int dpi, int dpiy = 0, int lod = 0)
+{
+    if (lod == 0) { lod = 2; }
+```
+
+**Confirmed on hardware.** Captured from G HUB writing the profile on a Pro X
+Superlight 2 (format 7), diffed at profile offset `0x08` (`dpi_v6 +6`):
+
+| Change made in G HUB | Byte |
+|---|---|
+| Medium to Low | `02` → `01` |
+| Low to High | `01` → `03` |
+
+So `1 = low, 2 = medium, 3 = high`, with `0` reserved for "stage unused" —
+which is why `InitializeDPI` substitutes `2` when it reads `0`.
+
+This also explains a report that OMM "rebuilds DPI stage records with LOD=02".
+It does write `2`, but only for stages whose stored `lod` is `0`; the write path
+otherwise preserves the loaded value.
+
+**Resolved for format 7.** `logitech/hidpp.ts` used to map feature 0x2202's LOD
+byte as `{ Low: 0, Medium: 1, High: 2 }` for every Logitech mouse, and hid `Low`
+on everything but the Superstrike. That was the off-by-one above: counting from
+zero, writing `0` is rejected and the third level is unreachable, which is
+exactly the two-level behaviour the driver hardcoded around.
+
+The Pro X Superlight 2 offers three levels in G HUB and its profile bytes count
+from one, so format 7 now uses `{ Low: 1, Medium: 2, High: 3 }` and advertises
+all three.
+
+**Still open:** whether other formats share it. 0x2202 and profile flash remain
+different transports, and format 8's two levels were never rechecked against the
+encoding, so every other format keeps counting from zero until someone captures
+the same diff on one. `capabilitiesForFormat` holds the encoding per format for
+that reason.
+
+## Profile layouts
+
+Recovered with Ghidra from the native registration code. Each component is
+registered with a literal `(offset, size)` pair and a component id:
+
+```c
+prototype = { vftable, offset, size, ...component-specific fields }
+add_<component>(manager, &prototype, component_id)
+```
+
+The registration function validates regions against each other — the error
+string is *"Component's memory overlaps with other ones"* — so within a format
+these ranges are guaranteed disjoint.
+
+All offsets are relative to the start of the profile buffer. Sizes in bytes.
+
+### Format selection
+
+A dispatcher (`FUN_1800e7810`) switches on a format byte and composes builders:
+
+| Format id | Builders | Notes |
+|---|---|---|
+| 1 | base v1 | |
+| 2, 3 | base v1 + x8070 lighting | |
+| 4 | base v1 + x8070 lighting + extras | |
+| 5 | base v1 + x8071 lighting + counters | |
+| 6 | base v6 | |
+| 7 | base v6 + bunny hopping | |
+| 8 | base v6 + bunny hopping + analog buttons | HITS / Superstrike |
+
+*Inferred:* the switch byte is the `profileFormatId` from
+`getOnboardProfilesInfo`. Note there are **8 cases but only 6 names** in the
+managed `PROFILE_FORMAT` enum, so ids 7 and 8 are newer formats the managed
+wrapper was never updated for. Treat the id→name mapping beyond 6 as unknown and
+key off the numeric id.
+
+### Base v1 layout
+
+Builder `FUN_1800ea2b0`. Used by format ids 1–5.
+
+| Offset | Size | Id | Component |
+|---|---|---|---|
+| `0x00` | 1 | 0 | `report_rate` |
+| `0x01` | `0x0a` | 1 | `dpi_v1` |
+| `0x0d` | 3 | 2 | `color` |
+| `0x10` | 1 | 3 | `power_mode` |
+| `0x11` | 1 | 4 | `angle_snapping` |
+| `0x20` | `0x40` | 5 | `button_functions` |
+| `0x60` | `0x40` | 6 | `g_shift_function` |
+| `0xa0` | `0x30` | 7 | `profile_name` |
+
+### Base v6 layout
+
+Builder `FUN_1800ea780`. Used by format ids 6–8. Does **not** include base v1 —
+it is a separate layout, not an extension.
+
+| Offset | Size | Id | Component |
+|---|---|---|---|
+| `0x00` | 1 | `0x14` | `report_rate_wireless` — index into the rate table† |
+| `0x01` | 1 | `0x15` | `report_rate_wired` |
+| `0x02` | `0x19`* | `0x16` | `dpi_v6` — see below |
+| `0x1d` | 4 | `0x17` | `dpi_delta` |
+| `0x21` | 1 | 3 | `power_mode` |
+| `0x22` | 1 | 4 | `angle_snapping` |
+| `0x23` | 2 | 10 | `write_counter` |
+| `0x2c` | 2 | `0x0b` | `power_save_timeout` |
+| `0x2e` | 2 | `0x0c` | `power_off_timeout` |
+| `0x30` | `0x30` | 5 | `button_functions` |
+| `0x70` | `0x30` | 6 | `g_shift_function` |
+| `0xa0` | `0x30` | 7 | `profile_name` |
+| `0xd0` | `0x0b` | `0x0f` | `lighting_x8071` cluster 0 active |
+| `0xdb` | `0x0b` | `0x11` | `lighting_x8071` cluster 1 active |
+| `0xe6` | `0x0b` | `0x10` | `lighting_x8071` cluster 0 passive |
+| `0xf1` | `0x0b` | `0x12` | `lighting_x8071` cluster 1 passive |
+| `0xfc` | 1 | `0x13` | `lighting_flag` |
+
+† **Report rate verified on hardware, both links.** The byte indexes
+`[125, 250, 500, 1000, 2000, 4000, 8000]`, matching 0x8061's ordering, and the
+two links are stored separately — `0x00` wireless, `0x01` wired.
+
+| Capture | Byte | Change |
+|---|---|---|
+| Wireless 8000 → 1000 Hz | `0x00` | `06` → `03`, checksum `0x6e7c` → `0x20c7` |
+| Wireless → 8000 Hz | `0x00` | `03` → `06` |
+| Wired → 250 Hz | `0x01` | `03` → `01` |
+
+All reproduced by our encoder, and the second capture confirms writing one link
+leaves the other's byte untouched.
+
+**Ceilings are per link and per mouse.** A Pro X Superlight 2 runs to 8 kHz over
+Lightspeed but only 1 kHz over the cable, which is a charging connection rather
+than a full-rate wired mode. That pair lives in `capabilitiesForFormat` as
+`reportRates`, null for any format whose ceilings were never captured — the byte
+can index 8000 for either link, so nothing in the encoding itself prevents
+offering a rate the hardware cannot reach.
+
+\* **`dpi_v6` verified on hardware.** The registered `(0x02, 0x19)` does not
+describe the whole region. A real format-7 profile reads:
+
+```
+0x02  default resolution index
+0x03  g-shift resolution index
+0x04  stage 1   20 03 20 03 01   ->  800/800   lod 1
+0x09  stage 2   b0 04 b0 04 02   -> 1200/1200  lod 2
+0x0e  stage 3   40 06 40 06 02   -> 1600/1600  lod 2
+0x13  stage 4   60 09 60 09 02   -> 2400/2400  lod 2
+0x18  stage 5   80 0c 80 0c 02   -> 3200/3200  lod 2
+```
+
+So the region really spans `0x02`–`0x1c`, and `dpi_delta` follows at `0x1d`.
+**DPI values are little-endian** — `AdvancedDpi.dpi_x` is a `ushort` in native
+byte order, not the big-endian used elsewhere in HID++.
+
+Stage offsets `0x04, 0x09, 0x0e, 0x13, 0x18` with LOD at `0x08, 0x0d, 0x12,
+0x17, 0x1c`. The `0x19` in the registration is presumably the table size alone
+(5 × 5), with the two index bytes tracked by the component's extra fields.
+
+### Format-keyed setting limits
+
+Limits that used to be decided by a model check now hang off the reported
+format, in `capabilitiesForFormat`. The mouse announces its format through
+`getInfo`, so a new model on a known format inherits the limits without being
+named in the driver.
+
+| Format | LOD levels | Encoding | DPI slots | DPI range | Source |
+|---|---|---|---|---|---|
+| 7 | Low, Medium, High | 1, 2, 3 | 5 | 100–32000, step 50 | Captured from G HUB on a Pro X Superlight 2 |
+| 8 | Low, High | 0, 1, 2 | — | — | Observed on a PRO X 2 Superstrike |
+| everything else, and unknown | Medium, High | 0, 1, 2 | — | — | Prior driver default |
+
+Slot count and DPI range are properties of the mouse, not of the app: an older
+format can hold fewer slots over a much narrower range, and base v1 has no
+stage table at all. `dpiStages` is therefore `null` for every format whose
+numbers were never captured, and the UI hides the slot editor rather than
+borrowing format 7's limits. Format 8 almost certainly holds five slots, since
+it shares the v6 stage table, but its sensor range is unknown — so it is left
+null rather than half-guessed.
+
+Format 8 is taken to be the Superstrike format because it is the only one
+carrying the analog-button block, which is that mouse's distinguishing feature.
+That is an inference from the layout, not a reading off the device.
+
+The fallback is the behaviour the driver had for every non-Superstrike mouse. On
+format 7 that turned out to be an off-by-one rather than a hardware limit (see
+the LOD encoding section), so treat the fallback as unconfirmed rather than as
+fact: capture the same G HUB diff on another format before trusting it.
+
+Transport limits stay where they are. The Superstrike's 1 kHz cap over USB is a
+property of that USB interface, not of its profile format, so it is still keyed
+on the product id.
+
+### Per-format additions
+
+**Ids 2, 3** (`FUN_1800ea4b0`) — base v1 plus:
+
+| Offset | Size | Id | Component |
+|---|---|---|---|
+| `0xd0` | `0x0b` | 8 | `lighting_x8070` (logo) |
+| `0xdb` | `0x0b` | 9 | `lighting_x8070` (side) |
+
+**Id 4** — the above plus:
+
+| Offset | Size | Id | Component |
+|---|---|---|---|
+| `0x12` | 2 | 10 | `write_counter` |
+| `0x1c` | 2 | `0x0b` | `power_save_timeout` |
+| `0x1e` | 2 | `0x0c` | `power_off_timeout` |
+| `0xe6` | `0x0b` | `0x0d` | `lighting_x8071` |
+| `0xf1` | `0x0b` | `0x0e` | `lighting_x8071` |
+
+**Id 5** (`FUN_1800ea590`) — base v1 plus:
+
+| Offset | Size | Id | Component |
+|---|---|---|---|
+| `0x12` | 2 | 10 | `write_counter` |
+| `0x1c` | 2 | `0x0b` | `power_save_timeout` |
+| `0x1e` | 2 | `0x0c` | `power_off_timeout` |
+| `0xd0` | `0x0b` | `0x0f` | `lighting_x8071` cluster 0 active |
+| `0xdb` | `0x0b` | `0x11` | `lighting_x8071` cluster 1 active |
+| `0xe6` | `0x0b` | `0x10` | `lighting_x8071` cluster 0 passive |
+| `0xf1` | `0x0b` | `0x12` | `lighting_x8071` cluster 1 passive |
+| `0xfc` | 1 | `0x13` | `lighting_flag` |
+
+**Id 7** (`FUN_1800eab60`) — base v6 plus:
+
+| Offset | Size | Id | Component |
+|---|---|---|---|
+| `0x25` | 1 | `0x18` | `bunny_hopping` — timeout in ms ÷ 10‡ |
+
+‡ **Verified on hardware.** G HUB exposes a 100–1000 ms bunny-hop time, stored
+as milliseconds ÷ 10, with `0x00` meaning off:
+
+| G HUB | Byte | Sector 3 checksum |
+|---|---|---|
+| off | `0x00` | `0x6e7c` |
+| 100 ms | `0x0a` | `0xd92c` |
+| 200 ms | `0x14` | `0x10fd` |
+
+So the range maps to `0x0a`–`0x64`. Each transition was reproduced byte for
+byte by OpenMouse's encoder, including regenerating the checksum, and turning
+it off returns the sector to its earlier state exactly.
+
+**Id 8** — the above plus:
+
+| Offset | Size | Id | Component |
+|---|---|---|---|
+| `0x26` | 6 | `0x19` | `analog_button` |
+
+### Component ids beyond the managed enum
+
+The native code uses ids the managed `ComponentId` enum does not name — it stops
+at `23 dpi_delta` / `24 MAX_ID`, while the native registration uses:
+
+```
+0x18  (24)  bunny_hopping
+0x19  (25)  analog_button
+```
+
+So the managed enum is stale relative to native, exactly as the format enum is.
+Prefer the ids observed in the registration code.
+
+## Profile checksum
+
+**CRC-16/CCITT-FALSE**: polynomial `0x1021`, init `0xFFFF`, no input or output
+reflection, no final XOR.
+
+- computed over the buffer **excluding its last two bytes**
+- stored in those last two bytes, **big-endian** (`buf[n-2]` high, `buf[n-1]` low)
+
+From the validator (`FUN_1800e3f70`), which reports `"CRC Checksum Failed"`:
+
+```c
+uVar1 = _Dst[len - 2];
+uVar2 = _Dst[len - 1];
+sVar5 = compute_crc(&buffer);
+if (sVar5 != CONCAT11(uVar1, uVar2)) { /* CRC Checksum Failed */ }
+```
+
+and the algorithm (`FUN_1800e76f0`), unrolled eight times per byte:
+
+```c
+crc = 0xffff;
+for (i = 0; i < len - 2; i++) {
+    crc ^= buf[i] << 8;
+    for (bit = 0; bit < 8; bit++)
+        crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : crc << 1;
+}
+```
+
+Reference implementation:
+
+```ts
+function profileCrc(bytes: Uint8Array): number {
+  let crc = 0xffff;
+  for (let i = 0; i < bytes.length - 2; i += 1) {
+    crc ^= bytes[i] << 8;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc & 0x8000) ? ((crc << 1) ^ 0x1021) & 0xffff : (crc << 1) & 0xffff;
+    }
+  }
+  return crc;
+}
+```
+
+Note the earlier assumption of init `0x0000` in this document's history was
+wrong; it is `0xFFFF`. `HIDPP_PROTO_LIGHTSPEED_2_CA_CRC24` is unrelated, as are
+the `crc32` symbols (zip/deflate).
+
+## The write sequence is verified
+
+`probeProfileWriteSequence` proved `memoryAddrWrite` → `memoryWrite` →
+`memoryWriteEnd` on a Pro X Superlight 2 (format 7), so
+`PROFILE_DPI_WRITES_ENABLED` is on.
+
+A no-op rewrite would not have settled it: writing a sector's own bytes back
+reads identical whether the write landed **or was silently dropped**. The probe
+therefore makes a detectable change and undoes it, and both halves must pass.
+
+Result on format 7, sector `0x0002` (255 bytes), padding byte `0x00cf`:
+
+| Step | Read-back | Checksum |
+|---|---|---|
+| `0xff` → `0xfe` | matched byte-for-byte | valid |
+| `0xfe` → `0xff` (restore) | matched byte-for-byte | valid |
+
+The probe picks a **disabled** sector that is not the active profile, refuses if
+there isn't one, checks the checksum before writing, and holds the original
+bytes for restore. Run it again before trusting a format it has not been run on.
+
+### Settings sharing a sector are written together
+
+Flash erases a whole sector, so `writeActiveProfile` takes every changed
+setting at once and writes once. Applying bunny hop and the DPI table
+separately would cost two erase cycles, and the second write would be built
+from a read the first had already invalidated — losing one of the two. The UI
+stages them into a single pending-change group for the same reason.
+
+## What is still unknown
+
+**Which format id each device reports.** Read `profileFormatId` from
+`getOnboardProfilesInfo` per device. Format 8 is the analog-button (HITS)
+layout, so it is the Superstrike; a Superlight 2 is most likely 7, but that is a
+guess until read from hardware.
+
+**Names for format ids 7 and 8**, and the meaning of the extra
+component-specific prototype fields (for example `dpi_v6` carries
+`0, 1, 2, 5, 5, 0, 2, 4` after offset and size — plausibly stage count, stride
+and sub-field offsets, but not decoded).
+
+**A reported stage layout that does not match.** One account described DPI stage
+offsets `0x04, 0x09, 0x0e, 0x13, 0x18` with LOD at `0x08` etc. The 5-byte stride
+agrees, but base v6 puts `dpi_v6` at `0x02`, giving `0x02, 0x07, 0x0c, ...`.
+Either that account covers a different format, or its offsets are relative to
+something other than the profile start. Unresolved — verify against a real dump
+before trusting either.
+
+## Verifying before writing
+
+These offsets are read from vendor code, not from hardware. Confirm against a
+real device before writing anything:
+
+1. Read a profile sector with `memoryRead` and check that decoded values match
+   what G HUB or OMM shows
+2. `profile_memory_manager::to_string(self, out_string, buffer)` is Logitech's
+   own profile decoder — hosting the DLL in a .NET Framework 4.8 harness (it is
+   mixed-mode C++/CLI and cannot load in .NET 9) gives an independent decode to
+   diff against
+3. Cross-check by capturing OMM writing a single changed field
+
+## Flash wear and write safety
+
+### Reads cost nothing
+
+Flash reads involve no erase cycle. `memoryRead` can be called freely; the only
+cost is time — roughly 16 round trips per sector, which is why the UI caches
+profiles rather than reading them in the status refresh loop.
+
+### Writes are whole-sector
+
+`memoryAddrWrite` → `memoryWrite` × N → `memoryWriteEnd`. There is no partial
+write: changing a single DPI value rewrites all 255 bytes, so **every save costs
+one erase/write cycle** no matter how little changed.
+
+`memoryWriteEnd` validates the checksum, so a bad CRC should be rejected rather
+than committed. That protects against corruption, not against wear.
+
+### Endurance
+
+The exact flash part and its rating are unknown, so no cycle count should be
+quoted as fact. Embedded flash is typically in the 10k–100k erase-cycle range.
+
+What *is* known: the profile format contains a dedicated **`write_counter`**
+component (id 10, `0x23` in the v6 layout). Logitech built a per-profile write
+odometer into the format, which is not something you add unless wear matters.
+On a factory device it reads `ff ff` — erased, never maintained.
+
+A handful of saves per session is irrelevant even at the pessimistic end.
+Automated writing is what destroys flash.
+
+### Rules for any write path
+
+1. **Explicit Save only.** Never write on drag, change, or focus loss.
+2. **Diff before writing.** Build the new sector, compare against what was read,
+   skip if identical. This alone prevents the most common accidental wear —
+   a Save button pressed twice.
+3. **Rate-limit in the driver**, not in the UI, so no caller can bypass it.
+4. **Never write on connect, sync or restore.** Re-applying stored settings at
+   startup is exactly how a write path turns into thousands of cycles.
+5. **Maintain `write_counter`** and surface it. It is the format's own wear
+   odometer.
+
+### Power loss mid-write
+
+On a wireless mouse the device can sleep, be switched off, or leave range
+between `memoryAddrWrite` and `memoryWriteEnd`, leaving a sector half-written.
+The CRC means it reads as invalid rather than silently wrong, and G HUB or OMM
+can rewrite it — but check battery and connection before committing, and keep
+the write window short.
+
+### Prefer host mode for experimentation
+
+Host mode (`setOnboardMode` → `0x02`) is live and volatile: it costs **zero**
+flash cycles. It is the right place to try DPI and lift-off settings. Onboard is
+for committing something already settled on.
+
+This is also the honest fix for "my DPI reset itself": rather than making every
+DPI change write flash, let the user experiment in host mode and offer one
+explicit "save to onboard profile".
+
+### Device-level settings (0x8090)
+
+Gaming surface and LightForce are **not** profile state — they are not in the
+component list and do not touch profile flash. Where the firmware persists them
+is unknown:
+
+- they survive app restarts, G HUB restarts and reconnects (observed)
+- whether they survive a power cycle has **not** been tested
+
+If they are NVM-backed they carry some write cost; if they are RAM-only there is
+none. Either way `setModeStatusField` skips the write when the requested value
+is already set, so re-selecting the current option is free. These are
+user-driven toggles clicked occasionally, so wear is not a practical concern —
+but nothing should ever write them in a loop or on a restore path.
+
+### Other formats
+
+Offsets are format-specific; never apply one format's layout to another. Only
+ship writes for devices tested on real hardware. Decoding and dumping other
+formats is safe; writing on inference is not.

--- a/src/capture-format.test.ts
+++ b/src/capture-format.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CAPTURE_ACTIONS,
+  actionById,
+  diffSectors,
+  formatCaptureMarkdown,
+  formatProfileVerificationMarkdown,
+  type CaptureExport,
+} from "./capture-format.ts";
+
+function capture(overrides: Partial<CaptureExport> = {}): CaptureExport {
+  return {
+    device: "PRO X 2",
+    profileFormat: "7 · unnamed (v6 + bunny hopping)",
+    actions: [],
+    notes: "",
+    diffs: [],
+    ...overrides,
+  };
+}
+
+test("every action has a unique id and colour", () => {
+  const ids = new Set(CAPTURE_ACTIONS.map((action) => action.id));
+  const colors = new Set(CAPTURE_ACTIONS.map((action) => action.color));
+  assert.equal(ids.size, CAPTURE_ACTIONS.length, "ids must be unique");
+  assert.equal(colors.size, CAPTURE_ACTIONS.length, "colours must be distinguishable");
+});
+
+test("actions resolve by id", () => {
+  assert.equal(actionById("polling")?.label, "Polling rate");
+  assert.equal(actionById("nope"), undefined);
+});
+
+test("a sector diff reports only changed bytes, with their field", () => {
+  const before = new Uint8Array([0x06, 0x03, 0x00]);
+  const after = new Uint8Array([0x03, 0x03, 0x00]);
+  const changes = diffSectors(before, after, (offset) => (offset === 0 ? "report_rate_wireless +0" : null));
+
+  assert.deepEqual(changes, [
+    { offset: 0, before: 0x06, after: 0x03, field: "report_rate_wireless +0" },
+  ]);
+});
+
+test("identical sectors produce no diff", () => {
+  const bytes = new Uint8Array([1, 2, 3]);
+  assert.deepEqual(diffSectors(bytes, bytes.slice(), () => null), []);
+});
+
+/** The real capture that confirmed the report-rate encoding: 8000 Hz -> 1000 Hz. */
+test("exports a confirmed change with its actions", () => {
+  const markdown = formatCaptureMarkdown(capture({
+    actions: ["polling"],
+    diffs: [{
+      sector: 3,
+      changes: [
+        { offset: 0x00, before: 0x06, after: 0x03, field: "report_rate_wireless +0" },
+        { offset: 0xfd, before: 0x6e, after: 0x20, field: "checksum" },
+        { offset: 0xfe, before: 0x7c, after: 0xc7, field: "checksum" },
+      ],
+    }],
+  }));
+
+  assert.match(markdown, /- Changed: Polling rate/);
+  assert.match(markdown, /### Sector 3 — 3 byte\(s\) changed/);
+  assert.match(markdown, /\| 0x00 \| 0x06 \| 0x03 \| report_rate_wireless \+0 \|/);
+  assert.match(markdown, /\| 0xfd \| 0x6e \| 0x20 \| checksum \|/);
+});
+
+test("multiple actions are listed together", () => {
+  const markdown = formatCaptureMarkdown(capture({ actions: ["polling", "dpi"] }));
+  assert.match(markdown, /- Changed: DPI, Polling rate/);
+});
+
+test("an empty comparison says so rather than implying nothing changed", () => {
+  assert.match(formatCaptureMarkdown(capture()), /No comparison was run/);
+  assert.match(
+    formatCaptureMarkdown(capture({ diffs: [{ sector: 3, changes: [] }] })),
+    /not stored in a profile/,
+  );
+});
+
+test("raw sectors are exported for changed sectors so a fixture can be built", () => {
+  const markdown = formatCaptureMarkdown(capture({
+    diffs: [{ sector: 3, changes: [{ offset: 0, before: 6, after: 3, field: null }], unreproduced: [] }],
+    sectors: [
+      { sector: 3, before: new Uint8Array([0x06, 0x03]), after: new Uint8Array([0x03, 0x03]) },
+      { sector: 4, before: new Uint8Array([0x01]), after: new Uint8Array([0x01]) },
+    ],
+  }));
+
+  assert.match(markdown, /### Raw sectors/);
+  assert.match(markdown, /<details><summary>Sector 3<\/summary>/);
+  assert.match(markdown, /06 03/);
+  assert.doesNotMatch(markdown, /Sector 4/, "unchanged sectors are noise");
+  assert.match(markdown, /\*\*Write path verified\*\*/);
+});
+
+test("notes are included only when present", () => {
+  assert.doesNotMatch(formatCaptureMarkdown(capture()), /### Notes/);
+  assert.match(formatCaptureMarkdown(capture({ notes: "8000 -> 1000" })), /### Notes\n\n8000 -> 1000/);
+});
+
+test("profile verification exports geometry, raw replies, directory and every format", () => {
+  const markdown = formatProfileVerificationMarkdown({
+    device: "PRO X 2 Superstrike",
+    profileFormat: "8 · FORMAT 8",
+    info: { memoryModelId: 2, profileFormatId: 8, profileCount: 2, sectorCount: 4, sectorSize: 8 },
+    infoReply: new Uint8Array([0x11, 0xff, 0x00, 0x02, 0x08]),
+    mode: "Onboard",
+    modeValue: 1,
+    modeReply: new Uint8Array([0x11, 0xff, 0x20, 0x01]),
+    currentSector: 2,
+    currentProfileReply: new Uint8Array([0x11, 0xff, 0x40, 0x00, 0x02]),
+    directory: new Uint8Array([0x00, 0x02, 0x01, 0x00, 0xff, 0xff, 0xff, 0xff]),
+    directoryCrcValid: true,
+    profiles: [{
+      sector: 2,
+      enabled: true,
+      isCurrent: true,
+      crcValid: true,
+      decoded: { name: "Gaming", reportRateWireless: 8000 },
+      bytes: new Uint8Array([0x06, 0x03, 0, 0, 0, 0, 0xaa, 0xbb]),
+    }],
+  });
+
+  assert.match(markdown, /Profile format: 8 · FORMAT 8/);
+  assert.match(markdown, /Sector geometry: 4 × 8 bytes/);
+  assert.match(markdown, /### Directory sector 0/);
+  assert.match(markdown, /### Profile sector 0x0002/);
+  assert.match(markdown, /"reportRateWireless": 8000/);
+  assert.match(markdown, /no profile flash was written/);
+});
+
+test("verification formatting accepts every recovered profile format", () => {
+  for (let profileFormatId = 1; profileFormatId <= 8; profileFormatId += 1) {
+    const markdown = formatProfileVerificationMarkdown({
+      device: "Logitech test mouse",
+      profileFormat: `${profileFormatId} · test`,
+      info: { memoryModelId: 1, profileFormatId, profileCount: 0, sectorCount: 1, sectorSize: 4 },
+      infoReply: new Uint8Array([0, 0, 0, 1, profileFormatId]),
+      mode: "Host",
+      modeValue: 2,
+      modeReply: new Uint8Array([0, 0, 0, 2]),
+      currentSector: 0,
+      currentProfileReply: new Uint8Array([0, 0, 0, 0, 0]),
+      directory: new Uint8Array([0xff, 0xff, 0, 0]),
+      directoryCrcValid: true,
+      profiles: [],
+    });
+    assert.match(markdown, new RegExp(`Profile format: ${profileFormatId} · test`));
+  }
+});

--- a/src/capture-format.ts
+++ b/src/capture-format.ts
@@ -1,0 +1,270 @@
+/**
+ * Export format for profile-layout confirmations.
+ *
+ * The useful signal is not raw HID traffic — most of it is routine polling, and
+ * a vendor app's writes are invisible to us anyway. What confirms a layout is
+ * the *result*: snapshot the profiles, change one setting in the vendor app,
+ * and diff. The bytes that moved are what that setting maps to.
+ */
+
+export interface CaptureAction {
+  id: string;
+  label: string;
+  /** Distinct colour so selected changes stay readable side by side. */
+  color: string;
+}
+
+export const CAPTURE_ACTIONS: readonly CaptureAction[] = [
+  { id: "dpi", label: "DPI", color: "#6fd3a0" },
+  { id: "lod", label: "Lift-off distance", color: "#7fb2f0" },
+  { id: "polling", label: "Polling rate", color: "#d9a45b" },
+  { id: "surface", label: "Gaming surface", color: "#c08cf0" },
+  { id: "lightforce", label: "LightForce switches", color: "#e8798f" },
+  { id: "profile", label: "Profile switch", color: "#5fc9c9" },
+  { id: "onboard", label: "Onboard/host mode", color: "#b0b84f" },
+  { id: "buttons", label: "Button assignment", color: "#f0925b" },
+  { id: "lighting", label: "Lighting", color: "#9d8cf0" },
+  { id: "name", label: "Profile name", color: "#8fd0e8" },
+  { id: "other", label: "Other", color: "#8b8b90" },
+] as const;
+
+export function actionById(id: string): CaptureAction | undefined {
+  return CAPTURE_ACTIONS.find((action) => action.id === id);
+}
+
+export interface ByteChange {
+  offset: number;
+  before: number;
+  after: number;
+  /** Which profile field owns the byte, when the layout knows. */
+  field: string | null;
+}
+
+export interface SectorDiff {
+  sector: number;
+  changes: ByteChange[];
+  /**
+   * Offsets our own encoder failed to reproduce. Empty means OpenMouse can
+   * write this change byte-for-byte as the vendor app did; undefined means no
+   * verification was run.
+   */
+  unreproduced?: number[];
+}
+
+/** Byte-level diff of a profile sector before and after a change. */
+export function diffSectors(
+  before: Uint8Array,
+  after: Uint8Array,
+  describe: (offset: number) => string | null,
+): ByteChange[] {
+  const changes: ByteChange[] = [];
+  const length = Math.min(before.length, after.length);
+  for (let offset = 0; offset < length; offset += 1) {
+    if (before[offset] !== after[offset]) {
+      changes.push({ offset, before: before[offset], after: after[offset], field: describe(offset) });
+    }
+  }
+  return changes;
+}
+
+export interface SectorBytes {
+  sector: number;
+  before: Uint8Array;
+  after: Uint8Array;
+}
+
+export interface CaptureExport {
+  device: string | null;
+  profileFormat: string | null;
+  /** What the user changed in the vendor app; several may apply at once. */
+  actions: string[];
+  notes: string;
+  diffs: SectorDiff[];
+  /** Raw sectors, so a maintainer can paste them straight into a test fixture. */
+  sectors?: SectorBytes[];
+}
+
+export interface ProfileVerificationProfile {
+  sector: number;
+  enabled: boolean;
+  isCurrent: boolean;
+  crcValid: boolean;
+  decoded: Record<string, unknown>;
+  bytes: Uint8Array;
+}
+
+/** Everything needed to independently validate one profile-format dump. */
+export interface ProfileVerificationExport {
+  device: string | null;
+  profileFormat: string | null;
+  info: {
+    memoryModelId: number;
+    profileFormatId: number;
+    profileCount: number;
+    sectorCount: number;
+    sectorSize: number;
+  };
+  infoReply: Uint8Array;
+  mode: string;
+  modeValue: number;
+  modeReply: Uint8Array;
+  currentSector: number;
+  currentProfileReply: Uint8Array;
+  directory: Uint8Array;
+  directoryCrcValid: boolean;
+  profiles: ProfileVerificationProfile[];
+}
+
+function hexBlock(bytes: Uint8Array): string {
+  const rows: string[] = [];
+  for (let offset = 0; offset < bytes.length; offset += 16) {
+    rows.push([...bytes.slice(offset, offset + 16)]
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join(" "));
+  }
+  return rows.join("\n");
+}
+
+const hexByte = (value: number): string => `0x${value.toString(16).padStart(2, "0")}`;
+
+const hexWord = (value: number): string => `0x${value.toString(16).padStart(4, "0")}`;
+
+/** Markdown verification bundle suitable for an issue or a test fixture. */
+export function formatProfileVerificationMarkdown(capture: ProfileVerificationExport): string {
+  const { info } = capture;
+  const sections = [
+    "## OpenMouse profile-format verification",
+    "",
+    `- Device: ${capture.device ?? "unknown"}`,
+    `- Profile format: ${capture.profileFormat ?? info.profileFormatId}`,
+    `- Memory model: ${info.memoryModelId}`,
+    `- Reported profiles: ${info.profileCount}`,
+    `- Sector geometry: ${info.sectorCount} × ${info.sectorSize} bytes`,
+    `- Device mode: ${capture.mode} (${hexByte(capture.modeValue)})`,
+    `- Current profile sector: ${hexWord(capture.currentSector)}`,
+    `- Directory CRC: ${capture.directoryCrcValid ? "valid" : "INVALID"}`,
+    `- Profile CRCs: ${capture.profiles.every((profile) => profile.crcValid) ? "all valid" : "ONE OR MORE INVALID"}`,
+    "",
+    "### Raw protocol replies",
+    "",
+    `- getInfo: \`${[...capture.infoReply].map((byte) => byte.toString(16).padStart(2, "0")).join(" ")}\``,
+    `- getMode: \`${[...capture.modeReply].map((byte) => byte.toString(16).padStart(2, "0")).join(" ")}\``,
+    `- getCurrentProfile: \`${[...capture.currentProfileReply].map((byte) => byte.toString(16).padStart(2, "0")).join(" ")}\``,
+    "",
+    "### Directory sector 0",
+    "",
+    "```",
+    hexBlock(capture.directory),
+    "```",
+  ];
+
+  for (const profile of capture.profiles) {
+    sections.push(
+      "",
+      `### Profile sector ${hexWord(profile.sector)}`,
+      "",
+      `- Enabled: ${profile.enabled}`,
+      `- Current: ${profile.isCurrent}`,
+      `- CRC: ${profile.crcValid ? "valid" : "INVALID"}`,
+      "- Decoded by current OpenMouse layout:",
+      "",
+      "```json",
+      JSON.stringify(profile.decoded, null, 2),
+      "```",
+      "",
+      "```",
+      hexBlock(profile.bytes),
+      "```",
+    );
+  }
+
+  sections.push(
+    "",
+    "This bundle was collected read-only. It includes the device-reported memory geometry, full directory, every listed profile sector, and checksums; no profile flash was written.",
+  );
+  return sections.join("\n");
+}
+
+/** Markdown, so a capture can be pasted straight into an issue. */
+export function formatCaptureMarkdown(capture: CaptureExport): string {
+  const changed = capture.diffs.filter((diff) => diff.changes.length > 0);
+  const labels = capture.actions
+    .map((id) => actionById(id)?.label ?? id)
+    .sort();
+
+  const sections = [
+    "## OpenMouse profile capture",
+    "",
+    `- Device: ${capture.device ?? "unknown"}`,
+    `- Profile format: ${capture.profileFormat ?? "not reported"}`,
+    `- Changed: ${labels.length > 0 ? labels.join(", ") : "not stated"}`,
+  ];
+
+  if (capture.notes.trim().length > 0) {
+    sections.push("", "### Notes", "", capture.notes.trim());
+  }
+
+  if (changed.length === 0) {
+    sections.push(
+      "",
+      "### Result",
+      "",
+      capture.diffs.length === 0
+        ? "No comparison was run."
+        : "No profile bytes changed, so this setting is not stored in a profile.",
+    );
+    return sections.join("\n");
+  }
+
+  for (const diff of changed) {
+    sections.push(
+      "",
+      `### Sector ${diff.sector} — ${diff.changes.length} byte(s) changed`,
+      "",
+      "| Offset | Before | After | Field |",
+      "| --- | --- | --- | --- |",
+      ...diff.changes.map((change) =>
+        `| ${hexByte(change.offset)} | ${hexByte(change.before)} | ${hexByte(change.after)} | ${change.field ?? "unknown"} |`),
+    );
+
+    if (diff.unreproduced !== undefined) {
+      sections.push(
+        "",
+        diff.unreproduced.length === 0
+          ? "**Write path verified** — OpenMouse reproduces this change byte for byte."
+          : `**Write path incomplete** — cannot reproduce ${diff.unreproduced.length} byte(s): `
+            + diff.unreproduced.map(hexByte).join(", "),
+      );
+    }
+  }
+
+  // Raw bytes last: verbose, but they are what turns a report into a
+  // regression test, and they let a maintainer re-derive the diff independently.
+  const rawSectors = (capture.sectors ?? []).filter((entry) =>
+    changed.some((diff) => diff.sector === entry.sector));
+  if (rawSectors.length > 0) {
+    sections.push("", "### Raw sectors");
+    for (const entry of rawSectors) {
+      sections.push(
+        "",
+        `<details><summary>Sector ${entry.sector}</summary>`,
+        "",
+        "Before:",
+        "",
+        "```",
+        hexBlock(entry.before),
+        "```",
+        "",
+        "After:",
+        "",
+        "```",
+        hexBlock(entry.after),
+        "```",
+        "",
+        "</details>",
+      );
+    }
+  }
+
+  return sections.join("\n");
+}

--- a/src/capture-panel.ts
+++ b/src/capture-panel.ts
@@ -1,0 +1,237 @@
+import {
+  CAPTURE_ACTIONS,
+  diffSectors,
+  formatCaptureMarkdown,
+  formatProfileVerificationMarkdown,
+  type ProfileVerificationExport,
+  type SectorBytes,
+  type SectorDiff,
+} from "./capture-format";
+import { escapeHtml } from "./ui/dom";
+
+/**
+ * Profile capture panel.
+ *
+ * Snapshot the profiles, change one setting in the vendor app, compare. The
+ * bytes that moved are what that setting maps to, which is what confirms a
+ * layout — and what makes a write safe to implement.
+ *
+ * Raw HID traffic is deliberately not shown: it is dominated by routine polling,
+ * and a vendor app's writes are invisible to us in any case.
+ */
+
+export interface CaptureProfileSource {
+  read(): Promise<Array<{ sector: number; bytes: Uint8Array }>>;
+  readVerification(): Promise<Omit<ProfileVerificationExport, "device" | "profileFormat">>;
+  describeOffset(offset: number): string | null;
+  /** Applies the change with OpenMouse's own encoders, for verification. */
+  reproduce(before: Uint8Array, after: Uint8Array): Uint8Array;
+}
+
+interface CaptureContext {
+  device: string | null;
+  profileFormat: string | null;
+  profiles: CaptureProfileSource | null;
+}
+
+let context: CaptureContext = { device: null, profileFormat: null, profiles: null };
+/** Sector -> bytes, taken before the vendor-app change. */
+let snapshot: Map<number, Uint8Array> | null = null;
+let diffs: SectorDiff[] = [];
+let sectors: SectorBytes[] = [];
+const selectedActions = new Set<string>();
+
+export function setCaptureContext(next: CaptureContext): void {
+  context = next;
+}
+
+function renderActions(): void {
+  const container = document.querySelector<HTMLElement>("#capture-action-list");
+  if (!container) return;
+  container.innerHTML = CAPTURE_ACTIONS.map((action) => {
+    const active = selectedActions.has(action.id);
+    return `<button type="button" data-capture-action="${action.id}" aria-pressed="${active}" style="padding:.22rem .5rem;border:1px solid ${active ? action.color : "#3a3a3f"};border-radius:999px;background:${active ? `${action.color}22` : "#19191c"};color:${active ? action.color : "#8b8b90"};font-size:.6rem;font-weight:600;cursor:pointer">${escapeHtml(action.label)}</button>`;
+  }).join("");
+}
+
+function renderDiffs(): void {
+  const container = document.querySelector<HTMLElement>("#capture-diff");
+  if (!container) return;
+
+  const changed = diffs.filter((diff) => diff.changes.length > 0);
+  if (changed.length === 0) {
+    const message = diffs.length > 0
+      ? "No profile bytes changed — this setting is not stored in a profile."
+      : snapshot
+        ? "Snapshot ready. Change one setting in the vendor app, then Compare."
+        : "Snapshot the profiles, change one setting in the vendor app, then Compare.";
+    container.innerHTML = `<p style="color:#77777c;font-size:.62rem;margin:0">${message}</p>`;
+    return;
+  }
+
+  container.innerHTML = changed.map((diff) => {
+    const verdict = diff.unreproduced === undefined
+      ? ""
+      : diff.unreproduced.length === 0
+        ? `<span style="color:#6fd3a0;font-size:.6rem;font-weight:600">✓ write path verified</span>`
+        : `<span style="color:#e8798f;font-size:.6rem;font-weight:600">✗ ${diff.unreproduced.length} byte(s) not reproducible</span>`;
+    return `
+    <div style="margin-bottom:.5rem">
+      <div style="display:flex;gap:.5rem;align-items:baseline;flex-wrap:wrap"><strong style="font-size:.66rem;color:#e6e6ea">Sector ${diff.sector} — ${diff.changes.length} byte(s)</strong>${verdict}</div>
+      <div style="display:grid;gap:.1rem;margin-top:.2rem">
+        ${diff.changes.map((change) => `<div style="display:flex;gap:.6rem;font-size:.62rem;color:#d8d8dc;align-items:baseline">
+          <code style="color:#8b8b90;min-width:3.2rem">0x${change.offset.toString(16).padStart(2, "0")}</code>
+          <code style="min-width:5rem">${change.before.toString(16).padStart(2, "0")} → ${change.after.toString(16).padStart(2, "0")}</code>
+          <span style="color:${change.field === "checksum" ? "#77777c" : "#6fd3a0"}">${escapeHtml(change.field ?? "unknown")}</span>
+        </div>`).join("")}
+      </div>
+    </div>`;
+  }).join("");
+}
+
+function setCaptureMessage(message: string): void {
+  const status = document.querySelector<HTMLElement>("#capture-status");
+  if (status) status.textContent = message;
+}
+
+export function refreshCapturePanel(): void {
+  renderActions();
+  renderDiffs();
+}
+
+async function takeSnapshot(): Promise<void> {
+  if (!context.profiles) {
+    setCaptureMessage("Connect a Logitech mouse with onboard profiles first.");
+    return;
+  }
+  setCaptureMessage("Reading profiles…");
+  try {
+    const sectors = await context.profiles.read();
+    snapshot = new Map(sectors.map((entry) => [entry.sector, entry.bytes]));
+    diffs = [];
+    renderDiffs();
+    setCaptureMessage(`Snapshot taken (${snapshot.size} profiles). Change one setting in G HUB or Onboard Memory Manager, then press Compare.`);
+  } catch (error) {
+    setCaptureMessage(error instanceof Error ? error.message : "Could not read profiles.");
+  }
+}
+
+async function compareSnapshot(): Promise<void> {
+  if (!context.profiles || !snapshot) {
+    setCaptureMessage("Take a snapshot first.");
+    return;
+  }
+  setCaptureMessage("Re-reading profiles…");
+  try {
+    const sectorsNow = await context.profiles.read();
+    sectors = sectorsNow.map((entry) => ({
+      sector: entry.sector,
+      before: snapshot!.get(entry.sector) ?? entry.bytes,
+      after: entry.bytes,
+    }));
+    diffs = sectorsNow.map((entry) => {
+      const before = snapshot!.get(entry.sector) ?? entry.bytes;
+      const changes = diffSectors(before, entry.bytes, (offset) => context.profiles!.describeOffset(offset));
+      if (changes.length === 0) return { sector: entry.sector, changes };
+
+      // Replay the same change through our own encoders. Anything we cannot
+      // reproduce is a field we would write incorrectly.
+      const reproduced = context.profiles!.reproduce(before, entry.bytes);
+      const unreproduced = [...entry.bytes].flatMap((byte, offset) =>
+        (reproduced[offset] === byte ? [] : [offset]));
+      return { sector: entry.sector, changes, unreproduced };
+    });
+    renderDiffs();
+
+    const total = diffs.reduce((sum, diff) => sum + diff.changes.length, 0);
+    const failed = diffs.reduce((sum, diff) => sum + (diff.unreproduced?.length ?? 0), 0);
+    setCaptureMessage(total === 0
+      ? "No profile bytes changed."
+      : failed === 0
+        ? `${total} byte(s) changed — write path verified, OpenMouse reproduces this exactly.`
+        : `${total} byte(s) changed, ${failed} not reproducible by OpenMouse yet.`);
+  } catch (error) {
+    setCaptureMessage(error instanceof Error ? error.message : "Could not read profiles.");
+  }
+}
+
+export function bindCapturePanel(): void {
+  const dialog = document.querySelector<HTMLDialogElement>("#capture-dialog");
+  const openDialog = (): void => {
+    if (!dialog) return;
+    if (typeof dialog.showModal === "function") dialog.showModal();
+    else dialog.setAttribute("open", "");
+  };
+  const closeDialog = (): void => {
+    if (!dialog) return;
+    if (typeof dialog.close === "function") dialog.close();
+    else dialog.removeAttribute("open");
+  };
+  document.querySelector<HTMLButtonElement>("#capture-open")?.addEventListener("click", () => {
+    refreshCapturePanel();
+    openDialog();
+  });
+  document.querySelector<HTMLButtonElement>("#capture-close")?.addEventListener("click", closeDialog);
+  // Clicking the backdrop closes; clicks inside the panel must not.
+  dialog?.addEventListener("click", (event) => {
+    if (event.target === dialog) closeDialog();
+  });
+
+  document.querySelector<HTMLElement>("#capture-action-list")?.addEventListener("click", (event) => {
+    const button = (event.target as HTMLElement).closest<HTMLButtonElement>("[data-capture-action]");
+    if (!button) return;
+    const id = button.dataset.captureAction!;
+    if (selectedActions.has(id)) selectedActions.delete(id);
+    else selectedActions.add(id);
+    renderActions();
+  });
+
+  document.querySelector<HTMLButtonElement>("#capture-snapshot")?.addEventListener("click", () => void takeSnapshot());
+  document.querySelector<HTMLButtonElement>("#capture-compare")?.addEventListener("click", () => void compareSnapshot());
+  document.querySelector<HTMLButtonElement>("#capture-verification")?.addEventListener("click", (event) => {
+    const button = event.currentTarget as HTMLButtonElement;
+    if (!context.profiles) {
+      setCaptureMessage("Connect a Logitech mouse with onboard profiles first.");
+      return;
+    }
+    button.disabled = true;
+    setCaptureMessage("Reading the directory and every profile sector…");
+    void context.profiles.readVerification().then(async (verification) => {
+      const markdown = formatProfileVerificationMarkdown({
+        ...verification,
+        device: context.device,
+        profileFormat: context.profileFormat,
+      });
+      await navigator.clipboard.writeText(markdown);
+      setCaptureMessage(`Verification data copied (${verification.profiles.length} profiles, format ${verification.info.profileFormatId}).`);
+    }).catch((error) => {
+      setCaptureMessage(error instanceof Error ? error.message : "Could not collect profile verification data.");
+    }).finally(() => {
+      button.disabled = false;
+    });
+  });
+
+  document.querySelector<HTMLButtonElement>("#capture-reset")?.addEventListener("click", () => {
+    snapshot = null;
+    diffs = [];
+    sectors = [];
+    selectedActions.clear();
+    refreshCapturePanel();
+    setCaptureMessage("Cleared.");
+  });
+
+  document.querySelector<HTMLButtonElement>("#capture-copy")?.addEventListener("click", () => {
+    const markdown = formatCaptureMarkdown({
+      device: context.device,
+      profileFormat: context.profileFormat,
+      actions: [...selectedActions],
+      notes: document.querySelector<HTMLTextAreaElement>("#capture-notes")?.value ?? "",
+      diffs,
+      sectors,
+    });
+    void navigator.clipboard.writeText(markdown).then(
+      () => setCaptureMessage("Capture copied — paste it into a GitHub issue."),
+      () => setCaptureMessage("Could not copy to the clipboard."),
+    );
+  });
+}

--- a/src/control-events.ts
+++ b/src/control-events.ts
@@ -27,6 +27,7 @@ export interface ControlEventHandlers {
   toggleSidebar(): void;
   resetInterfacePreferences(): void;
   downloadDiagnostics(): void;
+  resetLogitechProfiles(): Promise<void>;
   chooseCustomDpi(): void;
   sanitizeCustomDpi(): void;
   finishCustomDpiEditing(): void;
@@ -114,6 +115,7 @@ export function bindControlEvents(handlers: ControlEventHandlers): void {
   onClick("#sidebar-menu-toggle", handlers.toggleSidebar);
   onClick("#reset-interface-settings", handlers.resetInterfacePreferences);
   onClick("#download-diagnostics", handlers.downloadDiagnostics);
+  onClick("#reset-logitech-profiles", () => void handlers.resetLogitechProfiles());
   onClick("#custom-dpi", () => void handlers.chooseCustomDpi());
   onClick("#apply-logitech-axes", () => void handlers.applyLogitechAxisDpi());
   onClick("#apply-logitech-left-button", () => void handlers.applyLogitechAnalogButton(0));

--- a/src/control-events.ts
+++ b/src/control-events.ts
@@ -1,6 +1,16 @@
 import type { EggSpdtMode } from "./devices/endgame/egg-op1-hid";
 import type { MouseStatus } from "./devices/mouse-types";
+import { clampBunnyHopMs } from "./devices/logitech/onboard-profiles";
 
+type EggLiftOffLevel = NonNullable<MouseStatus["liftOffDistance"]>;
+
+/** Closes every open lift-off menu; only one may be open at a time. */
+function closeLodMenus(): void {
+  document.querySelectorAll<HTMLElement>(".lod-select.is-open").forEach((select) => {
+    select.classList.remove("is-open");
+    select.querySelector("[data-lod-toggle]")?.setAttribute("aria-expanded", "false");
+  });
+}
 type PulsarToggleSetting = "motionSync" | "angleSnapping" | "rippleControl" | "performanceMode";
 type EggFilterSetting = "slamclick" | "motionJitter";
 
@@ -39,6 +49,29 @@ export interface ControlEventHandlers {
   applyLiftOffDistance(lod: NonNullable<MouseStatus["liftOffDistance"]>): void;
   applyGamingSurfaceMode(mode: NonNullable<MouseStatus["gamingSurfaceMode"]>): void;
   applyLightforceSwitchMode(mode: NonNullable<MouseStatus["lightforceSwitchMode"]>): void;
+  // Mode and profile selection apply immediately: both are volatile navigation
+  // actions, and the profiles cannot be re-read until they have taken effect.
+  applyOnboardMode(mode: "Onboard" | "Host"): Promise<void>;
+  applyBunnyHopMs(milliseconds: number): void;
+  setDpiSlotCount(count: number): void;
+  setDpiSlotAxis(index: number, axis: "x" | "y", value: number): void;
+  setDpiSlotLod(index: number, level: EggLiftOffLevel): void;
+  setDpiSlotDefault(index: number): void;
+  setDpiAxisLock(index: number, locked: boolean): void;
+  /** Switches the mouse to a profile. */
+  selectOnboardProfile(sector: number): Promise<void>;
+  /** Opens a profile, or the host layer, without switching the mouse to it. */
+  openOnboardProfile(sector: number | "host"): void;
+  renameOnboardProfile(sector: number): void;
+  /** Expands or collapses the profile list; selecting one does not close it. */
+  toggleProfilesExpanded(): void;
+  setProfileReportRate(link: "wireless" | "wired", hz: number): void;
+  /** Slider positions are indices; this maps one back to hertz. */
+  rateFromSlider(selector: string, index: number): number | null;
+  /** Repaints a slider's readout and dots mid-drag, without staging anything. */
+  previewRateSlider(selector: string, index: number): void;
+  toggleOnboardProfileEnabled(sector: number, enabled: boolean): Promise<void>;
+  reloadOnboardProfiles(): Promise<void>;
   flashPendingChanges(): Promise<void>;
   revertPendingChanges(): void;
 }
@@ -162,6 +195,16 @@ export function bindControlEvents(handlers: ControlEventHandlers): void {
   document.querySelector<HTMLSelectElement>("#profile-select")?.addEventListener("change", (event) => {
     void handlers.applyProSetting("profile", Number((event.target as HTMLSelectElement).value));
   });
+  // "change" rather than "input": dragging across stops must not stage every
+  // rate it passes over, only the one the thumb is released on.
+  document.querySelector<HTMLElement>("#host-rate-slider")?.addEventListener("change", (event) => {
+    const hz = handlers.rateFromSlider("#host-rate-slider", Number((event.target as HTMLInputElement).value));
+    if (hz !== null) void handlers.applyPollingRate(hz);
+  });
+  // Redraw while dragging so the readout and the lit dots follow the thumb.
+  document.querySelector<HTMLElement>("#host-rate-slider")?.addEventListener("input", (event) => {
+    handlers.previewRateSlider("#host-rate-slider", Number((event.target as HTMLInputElement).value));
+  });
   for (const [selector, setting] of [
     ["#finalmouse-dongle-led", "dongleLed"],
     ["#finalmouse-tournament-scroll", "tournamentScroll"],
@@ -171,9 +214,6 @@ export function bindControlEvents(handlers: ControlEventHandlers): void {
       handlers.applyFinalmouseSetting(setting, Number((event.target as HTMLSelectElement).value));
     });
   }
-  document.querySelectorAll<HTMLButtonElement>("[data-rate]").forEach((button) => {
-    button.addEventListener("click", () => void handlers.applyPollingRate(Number(button.dataset.rate)));
-  });
   document.querySelectorAll<HTMLButtonElement>("[data-lod]").forEach((button) => {
     button.addEventListener("click", () => {
       const lod = button.dataset.lod as MouseStatus["liftOffDistance"];
@@ -185,6 +225,123 @@ export function bindControlEvents(handlers: ControlEventHandlers): void {
       const mode = button.dataset.gamingSurface as MouseStatus["gamingSurfaceMode"];
       if (mode) void handlers.applyGamingSurfaceMode(mode);
     });
+  });
+  // The profile list is re-rendered wholesale, so its buttons are delegated.
+  document.querySelector<HTMLElement>("#onboard-profile-list")?.addEventListener("click", (event) => {
+    const target = (event.target as HTMLElement).closest<HTMLButtonElement>("button");
+    if (!target || target.disabled) return;
+
+    if (target.dataset.onboardMode === "Host") {
+      void handlers.applyOnboardMode("Host");
+      return;
+    }
+    if (target.dataset.profileEnabled !== undefined) {
+      void handlers.toggleOnboardProfileEnabled(
+        Number(target.dataset.profileEnabled),
+        target.dataset.enabled !== "true",
+      );
+      return;
+    }
+    if (target.dataset.profileRename !== undefined) {
+      handlers.renameOnboardProfile(Number(target.dataset.profileRename));
+      return;
+    }
+    if (target.dataset.profileActivate !== undefined) {
+      void handlers.selectOnboardProfile(Number(target.dataset.profileActivate));
+      return;
+    }
+    // Opening a profile only changes what the settings panels edit; switching
+    // the mouse to it is the separate button above.
+    const opened = target.dataset.onboardProfile;
+    if (opened !== undefined) {
+      handlers.openOnboardProfile(opened === "host" ? "host" : Number(opened));
+    }
+  });
+  // "change" rather than "input": a number field fires it on blur or Enter, so
+  // a value is not staged on every keystroke.
+  document.querySelector<HTMLInputElement>("#bunny-hop-input")?.addEventListener("change", (event) => {
+    const input = event.target as HTMLInputElement;
+    // min/max/step only gate the spinner, not typing, so snap the typed value
+    // into range here rather than rejecting it with an error.
+    const milliseconds = clampBunnyHopMs(Number(input.value));
+    input.value = String(milliseconds);
+    handlers.applyBunnyHopMs(milliseconds);
+  });
+  document.querySelector<HTMLButtonElement>("#bunny-hop-enabled")?.addEventListener("click", (event) => {
+    const toggle = event.currentTarget as HTMLButtonElement;
+    const enabled = toggle.getAttribute("aria-checked") !== "true";
+    const input = document.querySelector<HTMLInputElement>("#bunny-hop-input");
+    // Turning it back on restores whatever is in the field, defaulting to the
+    // lowest value G HUB allows.
+    handlers.applyBunnyHopMs(enabled ? clampBunnyHopMs(Number(input?.value)) : 0);
+  });
+  for (const link of ["wireless", "wired"] as const) {
+    const slider = document.querySelector<HTMLElement>(`#profile-rate-${link}`);
+    slider?.addEventListener("change", (event) => {
+      const hz = handlers.rateFromSlider(`#profile-rate-${link}`, Number((event.target as HTMLInputElement).value));
+      if (hz !== null) handlers.setProfileReportRate(link, hz);
+    });
+    slider?.addEventListener("input", (event) => {
+      handlers.previewRateSlider(`#profile-rate-${link}`, Number((event.target as HTMLInputElement).value));
+    });
+  }
+  // Both the count stops and the slot rows are rebuilt on every render, so
+  // their clicks are delegated to the containers.
+  onClick("#profile-disclosure-toggle", handlers.toggleProfilesExpanded);
+  document.querySelector<HTMLElement>("#dpi-slot-count")?.addEventListener("click", (event) => {
+    const target = (event.target as HTMLElement).closest<HTMLButtonElement>("[data-dpi-slot-count]");
+    if (target && !target.disabled) handlers.setDpiSlotCount(Number(target.dataset.dpiSlotCount));
+  });
+  // The slot rows are rebuilt on every render, so their events are delegated.
+  const slotList = document.querySelector<HTMLElement>("#dpi-slot-list");
+  slotList?.addEventListener("change", (event) => {
+    const target = event.target as HTMLElement;
+    const slot = target.dataset.dpiSlot;
+    if (slot !== undefined && target.dataset.dpiAxis !== undefined) {
+      const axis = target.dataset.dpiAxis === "y" ? "y" : "x";
+      handlers.setDpiSlotAxis(Number(slot), axis, Number((target as HTMLInputElement).value));
+    }
+  });
+  slotList?.addEventListener("click", (event) => {
+    // The lift-off menu is a listbox rather than a select, so opening,
+    // choosing and closing are all clicks handled here.
+    const toggle = (event.target as HTMLElement).closest<HTMLButtonElement>("[data-lod-toggle]");
+    if (toggle && !toggle.disabled) {
+      const select = toggle.closest<HTMLElement>(".lod-select");
+      const opening = !select?.classList.contains("is-open");
+      closeLodMenus();
+      if (opening && select) {
+        select.classList.add("is-open");
+        toggle.setAttribute("aria-expanded", "true");
+      }
+      return;
+    }
+    const option = (event.target as HTMLElement).closest<HTMLElement>("[data-lod-value]");
+    if (option) {
+      const menu = option.closest<HTMLElement>("[data-dpi-slot-lod]");
+      closeLodMenus();
+      if (menu) {
+        handlers.setDpiSlotLod(Number(menu.dataset.dpiSlotLod), option.dataset.lodValue as EggLiftOffLevel);
+      }
+      return;
+    }
+    const lock = (event.target as HTMLElement).closest<HTMLButtonElement>("[data-dpi-axis-lock]");
+    if (lock && !lock.disabled) {
+      handlers.setDpiAxisLock(Number(lock.dataset.dpiAxisLock), lock.getAttribute("aria-pressed") !== "true");
+      return;
+    }
+    const target = (event.target as HTMLElement).closest<HTMLButtonElement>("[data-dpi-slot-default]");
+    if (target && !target.disabled) handlers.setDpiSlotDefault(Number(target.dataset.dpiSlotDefault));
+  });
+  // A click anywhere else, or Escape, dismisses an open lift-off menu.
+  document.addEventListener("click", (event) => {
+    if (!(event.target as HTMLElement).closest(".lod-select")) closeLodMenus();
+  });
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") closeLodMenus();
+  });
+  document.querySelector<HTMLButtonElement>("#onboard-refresh")?.addEventListener("click", () => {
+    void handlers.reloadOnboardProfiles();
   });
   document.querySelectorAll<HTMLButtonElement>("[data-lightforce]").forEach((button) => {
     button.addEventListener("click", () => {

--- a/src/control-profiles.css
+++ b/src/control-profiles.css
@@ -1,0 +1,235 @@
+/*
+ * Logitech onboard-profile UI: the profile rail, the DPI slot editor, the
+ * report-rate sliders and the lift-off menu.
+ *
+ * Kept apart from control.css because it is all specific to one driver's
+ * profile model, and because upstream restructured the shared stylesheets
+ * while this was being written.
+ */
+/* HID++ capture dialog. Native dialog buttons default to the light UA style,
+   which is unreadable against the dark panel, so they are themed explicitly. */
+#capture-dialog { color-scheme:dark }
+#capture-dialog::backdrop { background:rgb(0 0 0 / 62%) }
+#capture-dialog button { padding:.4rem .62rem;border:1px solid #3a3a3f;border-radius:6px;background:#1c1c20;color:#d8d8dc;font-size:.62rem;font-weight:600;cursor:pointer }
+#capture-dialog button:hover { border-color:#4a4a52;background:#232328 }
+#capture-dialog button:focus-visible { outline:2px solid var(--ui-accent);outline-offset:1px }
+#capture-dialog button.is-primary { border-color:var(--ui-accent);background:var(--ui-accent);color:var(--ui-accent-ink) }
+#capture-dialog textarea:focus-visible { outline:2px solid var(--ui-accent);outline-offset:1px }
+
+/* Marks settings stored in the selected onboard profile rather than globally,
+   so it is clear which values follow the profile and which apply to the mouse
+   as a whole. Global settings carry no badge. */
+.setting-scope { display:inline-block;margin-left:.5rem;padding:.12rem .38rem;border:1px solid #34343a;border-radius:999px;background:#18181b;color:#8b8b90;font-family:'JetBrains Mono',monospace;font-size:.53rem;font-weight:600;letter-spacing:.05em;text-transform:uppercase;vertical-align:middle;white-space:nowrap }
+.setting-heading h2 .setting-scope { position:relative;top:-.1em }
+
+/* Per-profile DPI slots. Each row is one slot: its number, X and Y DPI, and
+   the lift-off level stored alongside them in the same stage record. */
+/* The slot count and its title sit together on the left, so the eye reads the
+   label and the control it belongs to in one movement. The title uses the same
+   overline treatment as the card headings above it. */
+.dpi-slot-header { display:flex;flex-direction:column;align-items:flex-start;gap:.35rem;margin-bottom:.6rem;/*padding-left:.6rem;border-left:2px solid #2f2f34*/ }
+.dpi-slot-header > span { color:#8b8b90;font-family:'JetBrains Mono',monospace;font-size:.58rem;font-weight:600;letter-spacing:.08em;text-transform:uppercase;white-space:nowrap }
+/* Divides the slot picker from the table it sizes. */
+.dpi-slot-rule { height:1px;margin:0 0 .55rem;background:#26262a }
+.dpi-slot-count { display:flex;gap:.22rem }
+.dpi-slot-count button { min-width:1.55rem;padding:.26rem 0;border:1px solid #303034;border-radius:6px;background:#18181b;color:#85858a;font-family:'JetBrains Mono',monospace;font-size:.62rem;cursor:pointer }
+.dpi-slot-count button:hover:not(:disabled) { border-color:#66666b;color:#fff }
+.dpi-slot-count button.selected { border-color:var(--ui-accent);background:var(--ui-accent);color:var(--ui-accent-ink) }
+.dpi-slot-count button:disabled { opacity:.5;cursor:not-allowed }
+
+.dpi-slot-list { display:grid;gap:.3rem;overflow:visible }
+/* One shared column template so the headings line up with the fields under
+   them: slot number, X, axis link, Y, lift-off. */
+.dpi-slot-row { display:grid;grid-template-columns:1.7rem minmax(0,1fr) 1.5rem minmax(0,1fr) 4.6rem;gap:.3rem;align-items:center }
+.dpi-slot-head { padding:0 0 .1rem;color:#5c5c62;font-size:.53rem;letter-spacing:.06em;text-transform:uppercase }
+.dpi-slot-head span { padding-left:.15rem }
+.dpi-slot-row > button.dpi-slot-index { padding:.34rem 0;border:1px solid #343438;border-radius:6px;background:#18181b;color:#8b8b90;font-family:'JetBrains Mono',monospace;font-size:.62rem;font-weight:600;cursor:pointer }
+.dpi-slot-row.is-default > button.dpi-slot-index { border-color:var(--ui-accent);background:color-mix(in srgb, var(--ui-accent) 16%, #18181b);color:var(--ui-accent) }
+/* The link control sits between the two fields it joins, so the pairing is
+   read from the layout rather than from a label. */
+.dpi-axis-lock { display:flex;align-items:center;justify-content:center;padding:.3rem 0;border:0;background:none;color:#5c5c62;cursor:pointer }
+.dpi-axis-lock:hover:not(:disabled) { color:#b3b3b7 }
+.dpi-axis-lock.is-locked { color:var(--ui-accent) }
+.dpi-axis-lock:disabled { opacity:.45;cursor:not-allowed }
+.dpi-slot-row input[type="number"] { width:100%;min-width:0;box-sizing:border-box;padding:.34rem .3rem;border:1px solid #303034;border-radius:7px;background:#18181b;color:#e6e6ea;font-size:.66rem }
+.dpi-slot-row input[type="number"]:hover:not(:disabled) { border-color:#66666b }
+.dpi-slot-row input[type="number"]:focus-visible { outline:2px solid var(--ui-accent);outline-offset:1px }
+
+/* Lift-off picker. A native select cannot be themed or animated, so it is a
+   button plus a listbox that shares the inputs' shape and colours. */
+.lod-select { position:relative;min-width:0 }
+.lod-select-value { display:flex;width:100%;box-sizing:border-box;align-items:center;justify-content:space-between;gap:.25rem;padding:.34rem .4rem;border:1px solid #303034;border-radius:7px;background:#18181b;color:#e6e6ea;font-size:.66rem;cursor:pointer;transition:border-color .16s ease,background .16s ease }
+.lod-select-value:hover:not(:disabled) { border-color:#66666b }
+.lod-select-value:disabled { opacity:.55;cursor:not-allowed }
+.lod-select-value span { overflow:hidden;text-overflow:ellipsis;white-space:nowrap }
+.lod-select-value i { width:.32rem;height:.32rem;flex:0 0 auto;border-right:1.2px solid #85858a;border-bottom:1.2px solid #85858a;transform:translateY(-1px) rotate(45deg);transition:transform .18s ease }
+.lod-select.is-open .lod-select-value { border-color:var(--ui-accent) }
+.lod-select.is-open .lod-select-value i { transform:translateY(1px) rotate(-135deg) }
+.lod-select-menu { position:absolute;z-index:30;top:calc(100% + .25rem);right:0;left:0;margin:0;padding:.2rem;border:1px solid #3a3a3f;border-radius:8px;background:#141416;box-shadow:0 10px 22px rgb(0 0 0 / 45%);list-style:none;opacity:0;transform:translateY(-.25rem) scale(.97);transform-origin:top center;pointer-events:none;transition:opacity .16s ease,transform .16s ease }
+.lod-select.is-open .lod-select-menu { opacity:1;transform:none;pointer-events:auto }
+.lod-select-menu li { padding:.32rem .42rem;border-radius:5px;color:#b3b3b7;font-size:.64rem;cursor:pointer;transition:background .12s ease,color .12s ease }
+.lod-select-menu li:hover { background:#1f1f23;color:#fff }
+.lod-select-menu li[aria-selected="true"] { color:var(--ui-accent) }
+@media (prefers-reduced-motion:reduce) {
+  .lod-select-value, .lod-select-value i, .lod-select-menu, .lod-select-menu li { transition:none }
+}
+.dpi-slot-row input:disabled, .dpi-slot-row select:disabled { opacity:.55;cursor:not-allowed }
+
+/* Report rate as a slider with one stop per supported rate. */
+.rate-slider { display:grid;gap:.1rem }
+.rate-slider + .rate-slider { margin-top:.65rem }
+.rate-slider-head { display:flex;align-items:baseline;justify-content:space-between;gap:.5rem;color:#77777c;font-size:.6rem }
+.rate-slider-head output { color:#e6e6ea;font-family:'JetBrains Mono',monospace;font-size:.68rem }
+.rate-slider-input { width:100%;margin:0;accent-color:var(--ui-accent);cursor:pointer }
+.rate-slider-input:disabled { opacity:.5;cursor:not-allowed }
+.rate-slider-scale { position:relative;height:1.15rem;margin-top:.1rem }
+.rate-slider-scale i { position:absolute;top:0;width:5px;height:5px;border-radius:50%;background:#3a3a3f;transform:translateX(-50%) }
+.rate-slider-scale i.is-on { background:var(--ui-accent) }
+.rate-slider-scale span { position:absolute;top:.45rem;transform:translateX(-50%);color:#66666b;font-family:'JetBrains Mono',monospace;font-size:.53rem;white-space:nowrap }
+.rate-slider-scale span.is-on { color:#e6e6ea }
+@media (max-width:640px) { .dpi-slot-row { grid-template-columns:auto minmax(0,1fr);row-gap:.4rem } }
+
+/* The compact layout pins the settings grid to a 176px row. Five slot rows are
+   far taller than that, so the grid falls back to sizing by content while the
+   slot editor is showing, the same way it does for the X/Y axis controls. */
+.control-shell .settings-grid.has-dpi-slots { grid-template-rows:minmax(176px,auto) }
+.control-shell .settings-grid.has-dpi-slots .dpi-card { grid-row:auto }
+
+/* `.segmented` and friends set display, which outranks the user-agent
+   `[hidden] { display: none }` rule — so hiding those rows by setting the
+   hidden property silently did nothing. Make the attribute win everywhere. */
+[hidden] { display: none !important; }
+
+/* Profiles as a disclosure directly under the device overview: collapsed it
+   names the profile being edited, expanded it lists them all. Height is
+   animated with a 0fr/1fr grid row, which unlike max-height needs no guessed
+   pixel value and so cannot cut long lists off. */
+/* The panel is a flex column, so without a fixed basis this section shrinks to
+   its min-height — which `overflow:hidden` makes zero — and collapses to just
+   its borders. Every other section in the panel sets the same. */
+.profile-disclosure { flex:0 0 auto;margin-top:.65rem;overflow:hidden;border:1px solid #2b2b2f;border-radius:12px;background:#111113 }
+.profile-summary { display:flex;align-items:stretch;gap:.35rem;padding:.15rem .55rem .15rem .15rem }
+.profile-summary-main { display:flex;flex:1 1 auto;align-items:center;justify-content:space-between;gap:.75rem;min-width:0;padding:.6rem .55rem;border:0;border-radius:10px;background:none;color:inherit;text-align:left;cursor:pointer;transition:background .16s ease }
+.profile-summary-main:hover { background:#17171a }
+.profile-summary-text { display:grid;min-width:0;gap:.1rem }
+.profile-summary-label { color:#5c5c62;font-family:'JetBrains Mono',monospace;font-size:.53rem;font-weight:600;letter-spacing:.09em }
+.profile-summary-text strong { overflow:hidden;color:#e6e6ea;font-size:.78rem;font-weight:600;text-overflow:ellipsis;white-space:nowrap }
+.profile-summary-text small { overflow:hidden;color:#77777c;font-size:.62rem;text-overflow:ellipsis;white-space:nowrap }
+.profile-summary-chevron { width:.4rem;height:.4rem;flex:0 0 auto;border-right:1.4px solid #85858a;border-bottom:1.4px solid #85858a;transform:translateY(-2px) rotate(45deg);transition:transform .2s ease }
+.profile-disclosure.is-open .profile-summary-chevron { transform:translateY(1px) rotate(-135deg) }
+/* Height is animated as a measured max-height rather than a 0fr/1fr grid row:
+   an fr track resolves against free space, and with an overflow-hidden child
+   contributing zero min-content there is none, so the row stayed collapsed.
+   The pixel value is measured from the content, so a long list cannot clip. */
+.profile-disclosure-body { max-height:0;overflow:hidden;transition:max-height .22s ease }
+.profile-disclosure-inner > div, .profile-disclosure-inner > small { margin:0 .7rem }
+.profile-disclosure-inner > small { display:block;padding-bottom:.7rem }
+
+/* An auto column sizes to the widest row, which let rows run past the panel
+   instead of shrinking into it. A capped 1fr track forces them to fit and lets
+   the text ellipsis do its job. */
+#onboard-profile-list { display:grid;grid-template-columns:minmax(0,1fr);gap:.3rem;padding-bottom:.5rem }
+#onboard-profile-list > * { min-width:0;box-sizing:border-box }
+#onboard-status { color:#66666b;font-size:.58rem;line-height:1.45 }
+.profile-row-text { overflow:hidden }
+.profile-row-text strong, .profile-row-text small { display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap }
+
+/* Square icon buttons, matching the segmented controls' border and hover. */
+.icon-button { display:inline-flex;align-items:center;justify-content:center;align-self:center;padding:.34rem;border:1px solid #303034;border-radius:7px;background:#18181b;color:#8b8b90;cursor:pointer;transition:border-color .16s ease,color .16s ease,background .16s ease }
+.icon-button:hover:not(:disabled) { border-color:#66666b;background:#1f1f23;color:#e6e6ea }
+.icon-button:disabled { opacity:.45;cursor:not-allowed }
+
+/* Bunny hop: a switch, a number and its unit on one line, sharing the shape of
+   the DPI slot fields above them. */
+.bunny-hop-controls { display:flex;align-items:center;gap:.45rem;margin-top:.1rem }
+.bunny-hop-controls input[type="number"] { width:5rem;box-sizing:border-box;padding:.36rem .4rem;border:1px solid #303034;border-radius:7px;background:#18181b;color:#e6e6ea;font-size:.66rem }
+.bunny-hop-controls input[type="number"]:hover:not(:disabled) { border-color:#66666b }
+.bunny-hop-controls input[type="number"]:disabled { opacity:.5;cursor:not-allowed }
+.bunny-hop-controls > span { color:#77777c;font-size:.62rem }
+#bunny-hop-row { margin-top:.9rem;padding-top:.85rem;border-top:1px solid #26262a }
+#bunny-hop-row .setting-heading { margin-bottom:.45rem }
+
+@media (prefers-reduced-motion:reduce) {
+  .profile-disclosure-body, .profile-summary-chevron, .profile-summary-main, .icon-button { transition:none }
+}
+
+/* Divides the slot picker from the table it sizes. */
+.dpi-slot-rule { height:1px;margin:0 0 .55rem;background:#26262a }
+.dpi-slot-count { display:flex;gap:.22rem }
+.dpi-slot-count button { min-width:1.55rem;padding:.26rem 0;border:1px solid #303034;border-radius:6px;background:#18181b;color:#85858a;font-family:'JetBrains Mono',monospace;font-size:.62rem;cursor:pointer }
+.dpi-slot-count button:hover:not(:disabled) { border-color:#66666b;color:#fff }
+.dpi-slot-count button.selected { border-color:var(--ui-accent);background:var(--ui-accent);color:var(--ui-accent-ink) }
+.dpi-slot-count button:disabled { opacity:.5;cursor:not-allowed }
+
+.dpi-slot-list { display:grid;gap:.3rem;overflow:visible }
+/* One shared column template so the headings line up with the fields under
+   them: slot number, X, axis link, Y, lift-off. */
+.dpi-slot-row { display:grid;grid-template-columns:1.7rem minmax(0,1fr) 1.5rem minmax(0,1fr) 4.6rem;gap:.3rem;align-items:center }
+.dpi-slot-head { padding:0 0 .1rem;color:#5c5c62;font-size:.53rem;letter-spacing:.06em;text-transform:uppercase }
+.dpi-slot-head span { padding-left:.15rem }
+.dpi-slot-row > button.dpi-slot-index { padding:.34rem 0;border:1px solid #343438;border-radius:6px;background:#18181b;color:#8b8b90;font-family:'JetBrains Mono',monospace;font-size:.62rem;font-weight:600;cursor:pointer }
+.dpi-slot-row.is-default > button.dpi-slot-index { border-color:var(--ui-accent);background:color-mix(in srgb, var(--ui-accent) 16%, #18181b);color:var(--ui-accent) }
+/* The link control sits between the two fields it joins, so the pairing is
+   read from the layout rather than from a label. */
+.dpi-axis-lock { display:flex;align-items:center;justify-content:center;padding:.3rem 0;border:0;background:none;color:#5c5c62;cursor:pointer }
+.dpi-axis-lock:hover:not(:disabled) { color:#b3b3b7 }
+.dpi-axis-lock.is-locked { color:var(--ui-accent) }
+.dpi-axis-lock:disabled { opacity:.45;cursor:not-allowed }
+.dpi-slot-row input[type="number"] { width:100%;min-width:0;box-sizing:border-box;padding:.34rem .3rem;border:1px solid #303034;border-radius:7px;background:#18181b;color:#e6e6ea;font-size:.66rem }
+.dpi-slot-row input[type="number"]:hover:not(:disabled) { border-color:#66666b }
+.dpi-slot-row input[type="number"]:focus-visible { outline:2px solid var(--ui-accent);outline-offset:1px }
+
+/* Lift-off picker. A native select cannot be themed or animated, so it is a
+   button plus a listbox that shares the inputs' shape and colours. */
+.lod-select { position:relative;min-width:0 }
+.lod-select-value { display:flex;width:100%;box-sizing:border-box;align-items:center;justify-content:space-between;gap:.25rem;padding:.34rem .4rem;border:1px solid #303034;border-radius:7px;background:#18181b;color:#e6e6ea;font-size:.66rem;cursor:pointer;transition:border-color .16s ease,background .16s ease }
+.lod-select-value:hover:not(:disabled) { border-color:#66666b }
+.lod-select-value:disabled { opacity:.55;cursor:not-allowed }
+.lod-select-value span { overflow:hidden;text-overflow:ellipsis;white-space:nowrap }
+.lod-select-value i { width:.32rem;height:.32rem;flex:0 0 auto;border-right:1.2px solid #85858a;border-bottom:1.2px solid #85858a;transform:translateY(-1px) rotate(45deg);transition:transform .18s ease }
+.lod-select.is-open .lod-select-value { border-color:var(--ui-accent) }
+.lod-select.is-open .lod-select-value i { transform:translateY(1px) rotate(-135deg) }
+.lod-select-menu { position:absolute;z-index:30;top:calc(100% + .25rem);right:0;left:0;margin:0;padding:.2rem;border:1px solid #3a3a3f;border-radius:8px;background:#141416;box-shadow:0 10px 22px rgb(0 0 0 / 45%);list-style:none;opacity:0;transform:translateY(-.25rem) scale(.97);transform-origin:top center;pointer-events:none;transition:opacity .16s ease,transform .16s ease }
+.lod-select.is-open .lod-select-menu { opacity:1;transform:none;pointer-events:auto }
+.lod-select-menu li { padding:.32rem .42rem;border-radius:5px;color:#b3b3b7;font-size:.64rem;cursor:pointer;transition:background .12s ease,color .12s ease }
+.lod-select-menu li:hover { background:#1f1f23;color:#fff }
+.lod-select-menu li[aria-selected="true"] { color:var(--ui-accent) }
+@media (prefers-reduced-motion:reduce) {
+  .lod-select-value, .lod-select-value i, .lod-select-menu, .lod-select-menu li { transition:none }
+}
+.dpi-slot-row input:disabled, .dpi-slot-row select:disabled { opacity:.55;cursor:not-allowed }
+
+/* Report rate as a slider with one stop per supported rate. */
+.rate-slider { display:grid;gap:.1rem }
+.rate-slider + .rate-slider { margin-top:.65rem }
+.rate-slider-head { display:flex;align-items:baseline;justify-content:space-between;gap:.5rem;color:#77777c;font-size:.6rem }
+.rate-slider-head output { color:#e6e6ea;font-family:'JetBrains Mono',monospace;font-size:.68rem }
+.rate-slider-input { width:100%;margin:0;accent-color:var(--ui-accent);cursor:pointer }
+.rate-slider-input:disabled { opacity:.5;cursor:not-allowed }
+.rate-slider-scale { position:relative;height:1.15rem;margin-top:.1rem }
+.rate-slider-scale i { position:absolute;top:0;width:5px;height:5px;border-radius:50%;background:#3a3a3f;transform:translateX(-50%) }
+.rate-slider-scale i.is-on { background:var(--ui-accent) }
+.rate-slider-scale span { position:absolute;top:.45rem;transform:translateX(-50%);color:#66666b;font-family:'JetBrains Mono',monospace;font-size:.53rem;white-space:nowrap }
+.rate-slider-scale span.is-on { color:#e6e6ea }
+@media (max-width:640px) { .dpi-slot-row { grid-template-columns:auto minmax(0,1fr);row-gap:.4rem } }
+
+/* The compact layout pins the settings grid to a 176px row. Five slot rows are
+   far taller than that, so the grid falls back to sizing by content while the
+   slot editor is showing, the same way it does for the X/Y axis controls. */
+.control-shell .settings-grid.has-dpi-slots { grid-template-rows:minmax(176px,auto) }
+.control-shell .settings-grid.has-dpi-slots .dpi-card { grid-row:auto }
+
+/* `.segmented` and friends set display, which outranks the user-agent
+   `[hidden] { display: none }` rule — so hiding those rows by setting the
+   hidden property silently did nothing. Make the attribute win everywhere. */
+[hidden] { display: none !important; }
+
+/* Driver previews in interface settings. Development only — the section is
+   hidden and its fixtures are never fetched in a production build. */
+.preview-launcher { margin-top:.9rem }
+.preview-launcher-list { display:grid;grid-template-columns:repeat(auto-fill,minmax(190px,1fr));gap:.4rem;margin-top:.7rem }
+.preview-launcher-link { display:grid;gap:.1rem;padding:.5rem .6rem;border:1px solid #2b2b2f;border-radius:9px;background:#141416;color:#d8d8dc;font-size:.7rem;text-decoration:none;transition:border-color .16s ease,background .16s ease }
+.preview-launcher-link:hover { border-color:#4a4a52;background:#1b1b1f;color:#fff }
+.preview-launcher-link small { color:#66666b;font-family:'JetBrains Mono',monospace;font-size:.55rem }
+.preview-launcher-link.is-active { border-color:var(--ui-accent);color:var(--ui-accent) }
+.preview-launcher-link.is-active small { color:var(--ui-accent) }

--- a/src/control-profiles.css
+++ b/src/control-profiles.css
@@ -138,6 +138,8 @@
 .icon-button { display:inline-flex;align-items:center;justify-content:center;align-self:center;padding:.34rem;border:1px solid #303034;border-radius:7px;background:#18181b;color:#8b8b90;cursor:pointer;transition:border-color .16s ease,color .16s ease,background .16s ease }
 .icon-button:hover:not(:disabled) { border-color:#66666b;background:#1f1f23;color:#e6e6ea }
 .icon-button:disabled { opacity:.45;cursor:not-allowed }
+.icon-button.profile-delete-button { border-color:#713038;background:#35171b;color:#ef8e96 }
+.icon-button.profile-delete-button:hover:not(:disabled) { border-color:#bd4650;background:#611f26;color:#fff1f2 }
 
 /* Bunny hop: a switch, a number and its unit on one line, sharing the shape of
    the DPI slot fields above them. */

--- a/src/control-template.ts
+++ b/src/control-template.ts
@@ -63,6 +63,7 @@ export function controlTemplate(buildLabel: string): string {
               <i class="profile-summary-chevron" aria-hidden="true"></i>
             </button>
             <button id="onboard-refresh" class="icon-button" type="button" aria-label="Reload profiles" title="Reload profiles"><svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13.6 6.6A6 6 0 1 0 14 8"/><path d="M14 2.4V6.6H9.8"/></svg></button>
+            <button id="reset-logitech-profiles" class="icon-button profile-delete-button" type="button" aria-label="Delete and reset every onboard profile" title="Delete all profiles and restore defaults" hidden disabled><svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 4.5h10"/><path d="M6 2.5h4l.6 2H5.4l.6-2Z"/><path d="m4.2 4.5.6 9h6.4l.6-9"/><path d="M6.5 7v4M9.5 7v4"/></svg></button>
           </div>
           <div id="profile-disclosure-body" class="profile-disclosure-body">
             <div class="profile-disclosure-inner">

--- a/src/control-template.ts
+++ b/src/control-template.ts
@@ -1,4 +1,4 @@
-const TOGGLE = "switch-button";
+﻿const TOGGLE = "switch-button";
 const TOGGLE_ROW = "switch-row";
 const FIELD_LABEL = "field-label";
 const CARD_HEADING = "setting-heading compact";
@@ -52,11 +52,30 @@ export function controlTemplate(buildLabel: string): string {
           <article class="summary-stat"><span>FIRMWARE</span><strong id="firmware-value">—</strong><small id="firmware-detail">Read after connection</small></article>
           <article class="summary-stat" data-pending-key="dongle-led"><span>CONNECTION</span><strong id="connection-value">—</strong><small id="connection-detail">2.4 GHz receiver</small><button id="dongle-led-toggle" class="dongle-led-button" type="button" hidden disabled>Receiver LED</button></article>
         </section>
+        <section id="logitech-onboard" class="profile-disclosure device-data" hidden>
+          <div class="profile-summary">
+            <button id="profile-disclosure-toggle" class="profile-summary-main" type="button" aria-expanded="false" aria-controls="profile-disclosure-body">
+              <span class="profile-summary-text">
+                <span class="profile-summary-label">EDITING</span>
+                <strong id="profile-summary-name">—</strong>
+                <small id="profile-summary-detail"></small>
+              </span>
+              <i class="profile-summary-chevron" aria-hidden="true"></i>
+            </button>
+            <button id="onboard-refresh" class="icon-button" type="button" aria-label="Reload profiles" title="Reload profiles"><svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13.6 6.6A6 6 0 1 0 14 8"/><path d="M14 2.4V6.6H9.8"/></svg></button>
+          </div>
+          <div id="profile-disclosure-body" class="profile-disclosure-body">
+            <div class="profile-disclosure-inner">
+              <div id="onboard-profile-list"></div>
+              <small id="onboard-status">Profiles load when the mouse is in onboard mode.</small>
+            </div>
+          </div>
+        </section>
         <section class="settings-grid device-data" aria-label="Mouse status">
-          <article class="setting-card dpi-card" data-pending-key="dpi"><div class="setting-heading"><div><p>DPI</p><h2>Sensitivity</h2></div><div class="dpi-header-actions"><input id="dpi-output" type="text" inputmode="numeric" value="— DPI" aria-label="DPI value" readonly /><button id="custom-dpi" type="button" disabled>Custom</button></div></div><div id="dpi-presets" class="segmented dpi-presets" role="group" aria-label="Common DPI values"></div><div id="logitech-axis-controls" style="display:none"><div class="axis-grid"><label>X axis<input id="logitech-dpi-x" type="number" min="100" step="50" /></label><label>Y axis<input id="logitech-dpi-y" type="number" min="100" step="50" /></label><button id="apply-logitech-axes" class="axis-apply" type="button">Apply</button></div></div><div class="setting-action"><span id="dpi-pending">Choose a DPI value</span></div></article>
-          <article class="setting-card" data-pending-key="polling-rate"><div class="setting-heading"><div><p>POLLING RATE</p><h2>Report frequency</h2></div></div><div class="segmented rate-options" role="group" aria-label="Polling rate"><button data-rate="125" disabled>125</button><button data-rate="250" disabled>250</button><button data-rate="500" disabled>500</button><button data-rate="1000" disabled>1K</button><button data-rate="2000" disabled>2K</button><button data-rate="4000" disabled>4K</button><button data-rate="8000" disabled>8K</button></div><small id="polling-note" class="setting-note">Higher rates update cursor movement more often, but use more battery.</small></article>
-          <article class="setting-card" data-pending-key="lift-off-distance gaming-surface"><div class="setting-heading tight"><div><p>SENSOR</p></div></div><div id="gaming-surface-row" hidden><div class="setting-heading"><div><h2>Gaming surface</h2></div></div><div class="segmented three" role="group" aria-label="Gaming surface"><button data-gaming-surface="On" disabled>On</button><button data-gaming-surface="Off" disabled>Off</button><button data-gaming-surface="Auto" disabled>Auto</button></div><small class="setting-note">Tunes the sensor for gaming mouse pads. Auto lets the mouse decide; turn it off if tracking misbehaves on a non-gaming surface.</small></div><div class="setting-heading"><div><h2>Lift-off distance</h2></div></div><div class="segmented three" role="group" aria-label="Lift-off distance"><button data-lod="Low" disabled>0.7 mm</button><button data-lod="Medium" disabled>1 mm</button><button data-lod="High" disabled>2 mm</button></div><small id="lod-note" class="setting-note">Controls how far you can lift the mouse before tracking stops. Higher values keep tracking a little longer.</small></article>
-          <article id="lightforce-card" class="setting-card" data-pending-key="lightforce-switch-mode" hidden><div class="setting-heading"><div><p>SWITCHES</p><h2>LightForce</h2></div></div><div class="segmented" role="group" aria-label="LightForce switch mode"><button data-lightforce="Hybrid" disabled>Hybrid</button><button data-lightforce="Optical" disabled>Optical only</button></div><small class="setting-note">Hybrid saves power by using the mechanical contact and only waking the optical sensor when needed. Optical only is consistent but uses more battery.</small></article>
+          <article class="setting-card dpi-card" data-pending-key="dpi"><div class="setting-heading"><div><p>DPI</p><h2>Sensitivity<span class="setting-scope" id="dpi-scope-badge" hidden></span></h2></div><div class="dpi-header-actions"><input id="dpi-output" type="text" inputmode="numeric" value="— DPI" aria-label="DPI value" readonly /><button id="custom-dpi" type="button" disabled>Custom</button></div></div><div id="dpi-presets" class="segmented dpi-presets" role="group" aria-label="Common DPI values"></div><div id="logitech-axis-controls" style="display:none"><div class="axis-grid"><label>X axis<input id="logitech-dpi-x" type="number" min="100" step="50" /></label><label>Y axis<input id="logitech-dpi-y" type="number" min="100" step="50" /></label><button id="apply-logitech-axes" class="axis-apply" type="button">Apply</button></div></div><div id="logitech-dpi-slots" hidden><div class="dpi-slot-header"><span>Slots in use</span><div id="dpi-slot-count" class="dpi-slot-count" role="group" aria-label="Number of DPI slots"></div></div><div class="dpi-slot-rule"></div><div id="dpi-slot-list" class="dpi-slot-list"></div><small id="dpi-slot-note" class="setting-note"></small></div><div class="setting-action"><span id="dpi-pending">Choose a DPI value</span></div></article>
+          <article id="polling-card" class="setting-card" data-pending-key="polling-rate"><div class="setting-heading"><div><p>POLLING RATE</p><h2>Report frequency<span class="setting-scope" id="rate-scope-badge" hidden></span></h2></div></div><div id="profile-rate-rows" hidden><div id="profile-rate-wireless" class="rate-slider" data-rate-link="wireless"></div><div id="profile-rate-wired" class="rate-slider" data-rate-link="wired"></div></div><div id="host-rate-slider" class="rate-slider"></div><small id="polling-note" class="setting-note">Higher rates update cursor movement more often, but use more battery.</small></article>
+          <article class="setting-card" data-pending-key="lift-off-distance gaming-surface"><div class="setting-heading tight"><div><p>SENSOR</p></div></div><div id="gaming-surface-row" hidden><div class="setting-heading"><div><h2>Gaming surface</h2></div></div><div class="segmented three" role="group" aria-label="Gaming surface"><button data-gaming-surface="On" disabled>On</button><button data-gaming-surface="Off" disabled>Off</button><button data-gaming-surface="Auto" disabled>Auto</button></div><small class="setting-note">Tunes the sensor for gaming mouse pads. Auto lets the mouse decide; turn it off if tracking misbehaves on a non-gaming surface.</small></div><div id="host-lod-row"><div class="setting-heading"><div><h2>Lift-off distance</h2></div></div><div class="segmented three" role="group" aria-label="Lift-off distance"><button data-lod="Low" disabled>Low</button><button data-lod="Medium" disabled>Medium</button><button data-lod="High" disabled>High</button></div><small id="lod-note" class="setting-note">Controls how far you can lift the mouse before tracking stops. Higher values keep tracking a little longer.</small></div></article>
+          <article id="lightforce-card" class="setting-card" data-pending-key="lightforce-switch-mode" hidden><div class="setting-heading"><div><p>SWITCHES</p><h2>LightForce</h2></div></div><div class="segmented" role="group" aria-label="LightForce switch mode"><button data-lightforce="Hybrid" disabled>Hybrid</button><button data-lightforce="Optical" disabled>Optical only</button></div><small class="setting-note">Hybrid saves power by using the mechanical contact and only waking the optical sensor when needed. Optical only is consistent but uses more battery.</small><div id="bunny-hop-row" hidden><div class="setting-heading"><div><h2>Bunny hop<span class="setting-scope">Per-profile</span></h2></div></div><div class="bunny-hop-controls"><button id="bunny-hop-enabled" class="${TOGGLE}" type="button" role="switch" aria-checked="false">Off</button><input id="bunny-hop-input" type="number" min="100" max="1000" step="10" value="100" aria-label="Bunny hop time in milliseconds" /><span>ms</span></div><small class="setting-note" id="bunny-hop-note"></small></div></article>
         </section>
         <section id="logitech-device-details" class="device-data" style="display:none">
           <details class="egg-collapsible"><summary><span><small>LOGITECH HID++</small>Device details</span><i aria-hidden="true"></i></summary><div class="egg-collapsible-body"><article class="setting-card"><div id="logitech-detail-list"></div></article></div></details>
@@ -82,7 +101,7 @@ export function controlTemplate(buildLabel: string): string {
           <span>Record the device identifier, protocol version, and any failing setting in the issue or pull request. Do not use factory reset during initial testing.</span>
         </aside>
         <section id="device-debug-details" class="device-data" aria-label="Device diagnostics">
-          <details class="egg-collapsible"><summary><span><small>DEVELOPMENT</small>Diagnostics</span><i aria-hidden="true"></i></summary><div class="egg-collapsible-body"><article class="setting-card device-debug-card"><div id="device-debug-overview" class="device-debug-overview"></div><div class="device-debug-actions"><button id="download-diagnostics" type="button" disabled>Download diagnostics</button><span id="diagnostic-download-status" role="status" aria-live="polite"></span></div><details id="device-debug-readlog" class="device-debug-raw"><summary>Reads</summary><pre id="device-debug-reads" class="device-debug-snapshot"></pre></details><details id="device-debug-raw" class="device-debug-raw"><summary>Raw snapshot</summary><pre id="device-debug-snapshot" class="device-debug-snapshot">Connect a mouse to collect diagnostics.</pre></details></article></div></details>
+          <details class="egg-collapsible"><summary><span><small>DEVELOPMENT</small>Diagnostics</span><i aria-hidden="true"></i></summary><div class="egg-collapsible-body"><article class="setting-card device-debug-card"><div id="device-debug-overview" class="device-debug-overview"></div><div class="device-debug-actions"><button id="download-diagnostics" type="button" disabled>Download diagnostics</button><button id="capture-open" type="button" hidden>Verify profile format</button><span id="diagnostic-download-status" role="status" aria-live="polite"></span></div><details id="device-debug-readlog" class="device-debug-raw"><summary>Reads</summary><pre id="device-debug-reads" class="device-debug-snapshot"></pre></details><details id="device-debug-raw" class="device-debug-raw"><summary>Raw snapshot</summary><pre id="device-debug-snapshot" class="device-debug-snapshot">Connect a mouse to collect diagnostics.</pre></details></article></div></details>
         </section>
         <section id="interface-settings-page" class="interface-settings-page" aria-labelledby="interface-settings-title">
           <header class="interface-settings-header"><div><p class="overline">OPENMOUSE</p><h2 id="interface-settings-title">Interface settings</h2></div><button id="close-interface-settings" class="interface-settings-back" type="button">Back to device</button></header>
@@ -93,6 +112,14 @@ export function controlTemplate(buildLabel: string): string {
             <article class="interface-setting-card"><span>SECTIONS</span><h3>Advanced editors</h3><p>Choose whether CPI, button mapping, and experimental sections begin expanded.</p><label class="interface-switch-row"><span>Expand by default</span><input id="interface-expand-sections" type="checkbox" /></label></article>
             <article class="interface-setting-card"><span>EXPERIMENTAL</span><h3>Experimental controls</h3><p>Show or completely hide controls that may vary between firmware versions.</p><label class="interface-switch-row"><span>Show experimental settings</span><input id="interface-show-experimental" type="checkbox" /></label></article>
           </div>
+          <section id="preview-launcher" class="preview-launcher" hidden aria-labelledby="preview-launcher-title">
+            <div class="interface-setting-card">
+              <span>DEVELOPMENT</span>
+              <h3 id="preview-launcher-title">Driver previews</h3>
+              <p>Render any supported driver without its hardware, to check a change against every brand. Nothing is written to a device.</p>
+              <div id="preview-launcher-list" class="preview-launcher-list"></div>
+            </div>
+          </section>
           <button id="reset-interface-settings" class="interface-reset" type="button">Reset interface preferences</button>
         </section>
       </main>
@@ -112,6 +139,29 @@ export function controlTemplate(buildLabel: string): string {
           </div>
         </div>
       </div>
+      <dialog id="capture-dialog" style="width:min(1100px,94vw);max-width:none;height:min(88vh,900px);padding:0;border:1px solid #303036;border-radius:12px;background:#131316;color:#d8d8dc">
+        <div style="display:flex;flex-direction:column;height:100%;padding:1rem 1.1rem;box-sizing:border-box;gap:.6rem">
+          <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:1rem">
+            <div>
+              <p style="margin:0;color:#77777c;font-size:.6rem;letter-spacing:.05em">DEVELOPMENT</p>
+              <h2 style="margin:.1rem 0 0;font-size:1rem;color:#ececef">HID++ capture</h2>
+            </div>
+            <button id="capture-close" type="button" aria-label="Close capture">Close</button>
+          </div>
+          <small style="color:#77777c;font-size:.64rem"><strong style="color:#a8a8ae">Verify a format:</strong> copy a read-only bundle containing the memory geometry, full directory, every profile and all CRC results. To map an individual setting, snapshot the profiles, change only that setting in G HUB or Onboard Memory Manager, compare, mark the change and copy the comparison.</small>
+          <div style="display:flex;flex-wrap:wrap;gap:.4rem;align-items:center">
+            <button id="capture-verification" type="button" class="is-primary">Copy verification data</button>
+            <button id="capture-snapshot" type="button">Snapshot profiles</button>
+            <button id="capture-compare" type="button">Compare</button>
+            <button id="capture-reset" type="button">Clear</button>
+            <button id="capture-copy" type="button">Copy comparison</button>
+            <span id="capture-status" role="status" aria-live="polite" style="color:#77777c;font-size:.62rem"></span>
+          </div>
+          <div id="capture-diff" style="flex:1;min-height:0;overflow:auto;border:1px solid #26262a;border-radius:8px;padding:.5rem"></div>
+          <div><p style="margin:0 0 .25rem;color:#77777c;font-size:.62rem">What did you change?</p><div id="capture-action-list" style="display:flex;flex-wrap:wrap;gap:.3rem"></div></div>
+          <textarea id="capture-notes" rows="2" placeholder="Optional detail, e.g. wireless polling 8000 Hz to 1000 Hz" style="width:100%;box-sizing:border-box;padding:.45rem;border:1px solid #343438;border-radius:6px;background:#171719;color:#d8d8dc;font-size:.66rem"></textarea>
+        </div>
+      </dialog>
     </div>
     <section id="size-blocker" class="small-screen-blocker">
       <h1>Make the window wider.</h1>

--- a/src/control.css
+++ b/src/control.css
@@ -1,4 +1,5 @@
 @import "./control-devices.css";
+@import "./control-profiles.css";
 
 :root {
   --ink: #09090b;

--- a/src/control.ts
+++ b/src/control.ts
@@ -436,6 +436,10 @@ function renderControl(): void {
   renderStagedMarkers();
   populateInterfaceSettings();
   applyInterfacePreferences();
+  // Preview selection is intentionally URL-driven in development. This is not
+  // an authorization check: it only keeps fixture pages isolated from real
+  // hardware, while production builds force `previewMode` to null.
+  // codeql[js/user-controlled-bypass]
   if (!isAnyPreview) {
     navigator.hid?.addEventListener("connect", handleHidConnect);
     navigator.hid?.addEventListener("disconnect", handleHidDisconnect);

--- a/src/control.ts
+++ b/src/control.ts
@@ -21,6 +21,7 @@ import {
   hasPendingChanges,
   isPendingChange,
   onPendingChanges,
+  pendingChangeBatches,
   pendingChanges,
   stagePendingChange,
   withPendingChanges,
@@ -55,7 +56,29 @@ import {
 } from "./devices/endgame/egg-we-control";
 import { AtkHidClient } from "./devices/atk/hid";
 import { LamzuHidClient } from "./devices/lamzu/hid";
-import { LogitechHidppClient } from "./devices/logitech/hidpp";
+import {
+  LogitechHidppClient,
+  NotAMouseError,
+  PROFILE_DPI_WRITES_ENABLED,
+  type OnboardProfile,
+} from "./devices/logitech/hidpp";
+import {
+  BUNNY_HOP_LIMITS,
+  PROFILE_STAGE_LOD,
+  capabilitiesForFormat,
+  clampDpi,
+  describeOffset,
+  reportRatesFor,
+  validateProfileName,
+  validateReportRate,
+  reproduceProfile,
+  stageLodLevel,
+  validateBunnyHoppingMs,
+  type DpiStageCapabilities,
+  type DpiStagePlan,
+} from "./devices/logitech/onboard-profiles";
+import { escapeHtml } from "./ui/dom";
+import { bindCapturePanel, setCaptureContext } from "./capture-panel";
 import type { MouseStatus } from "./devices/mouse-types";
 import { PulsarProHidClient } from "./devices/pulsar/pulsar-pro-hid";
 import { OrbitalHidClient } from "./devices/orbital/hid";
@@ -76,8 +99,14 @@ if (!controlApp) {
 const appRoot = controlApp;
 
 const BUILD_LABEL = `${__BUILD_CHANNEL__.toUpperCase()} · v${__APP_VERSION__}`;
-const isSuperstrikePreview = import.meta.env.DEV
-  && new URLSearchParams(window.location.search).get("preview") === "superstrike";
+const previewMode = import.meta.env.DEV
+  ? new URLSearchParams(window.location.search).get("preview")
+  : null;
+const isSuperstrikePreview = previewMode === "superstrike";
+/** Any `?preview=` value, so the HID listeners stay off in every preview. */
+const isAnyPreview = previewMode !== null;
+/** Dev-only: renders the profile list and slot editor without hardware. */
+const isSlotsPreview = previewMode === "slots";
 let activeClient: LogitechHidppClient | null = null;
 let activePulsarClient: PulsarClient | null = null;
 let activeEggClient: EggOp1HidClient | null = null;
@@ -88,11 +117,42 @@ let activeRazerClient: RazerHidClient | null = null;
 let activeTeevolutionClient: TeevolutionHidClient | null = null;
 let activeVgnClient: VgnF2HidClient | null = null;
 let activeViperClient: RazerViperV4ProHidClient | null = null;
+/** Cached onboard profiles; a full read is far too slow for the refresh loop. */
+let onboardProfiles: OnboardProfile[] | null = null;
+let onboardProfilesLoading = false;
+let lastDeviceMode: MouseStatus["deviceMode"] = "Unknown";
+let lastProfileFormat: MouseStatus["onboardProfileFormat"] = null;
+
+const ICON_ENABLED = `<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="#9fe0b6" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 8s2.2-4 6-4 6 4 6 4-2.2 4-6 4-6-4-6-4Z"/><circle cx="8" cy="8" r="1.8"/></svg>`;
+/** Closed link: this slot's X and Y move together. */
+const ICON_LINKED = `<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" aria-hidden="true"><path d="M6.5 9.5a2.6 2.6 0 0 0 3.7 0l2.3-2.3a2.6 2.6 0 0 0-3.7-3.7l-.7.7"/><path d="M9.5 6.5a2.6 2.6 0 0 0-3.7 0L3.5 8.8a2.6 2.6 0 0 0 3.7 3.7l.7-.7"/></svg>`;
+/** Broken link: this slot's X and Y are set separately. */
+const ICON_UNLINKED = `<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" aria-hidden="true"><path d="M7 4.4l1.1-1.1a2.6 2.6 0 0 1 3.7 3.7L10.7 8.1"/><path d="M9 11.6l-1.1 1.1a2.6 2.6 0 0 1-3.7-3.7L5.3 7.9"/><path d="M2.6 2.6l10.8 10.8"/></svg>`;
+/** Pencil: rename this profile. */
+const ICON_RENAME = `<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="#8b8b90" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11.2 2.6a1.7 1.7 0 0 1 2.4 2.4L5.4 13.2 2 14l.8-3.4Z"/></svg>`;
+/** Filled dot: the mouse is running this profile. */
+const ICON_RUNNING = `<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="#9fe0b6" stroke-width="1.6" aria-hidden="true"><circle cx="8" cy="8" r="5.5"/><circle cx="8" cy="8" r="2.4" fill="#9fe0b6" stroke="none"/></svg>`;
+/** Hollow dot: switching the mouse to this profile. */
+const ICON_ACTIVATE = `<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="#77777c" stroke-width="1.6" aria-hidden="true"><circle cx="8" cy="8" r="5.5"/></svg>`;
+const ICON_DISABLED = `<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="#77777c" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 8s2.2-4 6-4 6 4 6 4a10 10 0 0 1-1.7 1.9"/><path d="M6.3 11.7A7.6 7.6 0 0 0 8 12"/><path d="m2 2 12 12"/></svg>`;
 let activeFinalmouseClient: FinalmouseHidClient | null = null;
 let refreshTimer: number | null = null;
 let refreshInProgress = false;
 let dpiOptions: number[] = [];
 let settingInProgress = false;
+
+/**
+ * Clears the in-progress flag and repaints the controls that read it.
+ *
+ * Every control rendered during a write comes out disabled, so simply clearing
+ * the flag in a `finally` leaves them that way until something else happens to
+ * re-render. Anything that sets the flag must end through here.
+ */
+function endDeviceWrite(): void {
+  settingInProgress = false;
+  if (latestDeviceStatus) showStatus(latestDeviceStatus);
+  renderOnboardProfiles();
+}
 let lastRenderedStatusKey: string | null = null;
 let activeDevice: HIDDevice | null = null;
 const deviceStatuses = new Map<HIDDevice, MouseStatus>();
@@ -167,6 +227,9 @@ function stageChange(change: PendingChange): void {
 // True when previewing the change over the device status would leave it unchanged
 function matchesDeviceStatus(change: PendingChange): boolean {
   if (!latestDeviceStatus) return false;
+  // Without a preview the setting is not in MouseStatus, so there is nothing to
+  // compare and the caller has to decide for itself whether the value changed.
+  if (!change.preview) return false;
   const preview = structuredClone(latestDeviceStatus);
   change.preview(preview);
   return JSON.stringify(preview) === JSON.stringify(latestDeviceStatus);
@@ -191,24 +254,28 @@ async function flashPause(milliseconds = FLASH_STEP_DELAY_MS): Promise<void> {
 }
 
 async function flashPendingChanges(): Promise<void> {
-  const queued = pendingChanges();
-  if (queued.length === 0 || settingInProgress || refreshInProgress) return;
+  const batches = pendingChangeBatches();
+  if (batches.length === 0 || settingInProgress || refreshInProgress) return;
   settingInProgress = true;
   setPendingBarBusy(true);
   let written = 0;
   let failure: string | null = null;
   try {
-    for (const change of queued) {
-      setPendingBarStatus(`${change.progress} (${written + 1} of ${queued.length})`);
-      setText("#read-status", change.progress);
+    for (const batch of batches) {
+      // Grouped settings share a byte or sector, so the last change staged into
+      // the group carries the combined write and the rest ride along with it.
+      const writer = batch[batch.length - 1];
+      if (!writer) continue;
+      setPendingBarStatus(`${writer.progress} (${written + 1} of ${batches.length})`);
+      setText("#read-status", writer.progress);
       // Let the step render before the write blocks on HID traffic.
       await flashPause();
-      recordDiagnosticCommand(change.command);
-      await change.apply();
+      for (const change of batch) recordDiagnosticCommand(change.command);
+      await writer.apply();
       // Drop each change as it lands, so a later failure leaves only the
       // unwritten ones staged and the user can retry just those.
-      dropPendingChange(change.key);
-      written += 1;
+      for (const change of batch) dropPendingChange(change.key);
+      written += batch.length;
     }
   } catch (error) {
     recordDiagnosticError(error, "Unable to flash the staged changes.");
@@ -217,8 +284,10 @@ async function flashPendingChanges(): Promise<void> {
   await flashPause(FLASH_SETTLE_MS);
   const client = activeSettingsClient();
   const status = client ? await statusAfterWrite(client).catch(() => null) : null;
-  settingInProgress = false;
-  if (status) showStatus(status);
+  // statusAfterWrite may have failed, so re-render either way rather than
+  // leaving the controls disabled from the write.
+  if (status) latestDeviceStatus = status;
+  endDeviceWrite();
   setPendingBarBusy(false);
   if (failure) {
     setText("#read-status", failure);
@@ -269,6 +338,7 @@ function renderControl(): void {
     renderDeviceDiagnostics(latestDiagnosticStatus);
   });
 
+  bindCapturePanel();
   bindControlEvents({
     connect,
     selectAuthorizedDevice,
@@ -328,18 +398,147 @@ function renderControl(): void {
     applyLightforceSwitchMode,
     flashPendingChanges,
     revertPendingChanges,
+    applyOnboardMode,
+    applyBunnyHopMs,
+    setDpiSlotCount,
+    setDpiSlotAxis,
+    setDpiSlotLod,
+    setDpiSlotDefault,
+    setDpiAxisLock,
+    selectOnboardProfile,
+    openOnboardProfile: selectEditedProfile,
+    renameOnboardProfile,
+    toggleProfilesExpanded,
+    setProfileReportRate,
+    rateFromSlider,
+    previewRateSlider,
+    toggleOnboardProfileEnabled,
+    reloadOnboardProfiles,
   });
   onPendingChanges(renderPendingBar);
+  onPendingChanges(() => {
+    // Flashed or reverted: stop previewing and fall back to the device value.
+    if (!isPendingChange(BUNNY_HOP_KEY)) stagedBunnyHopMs = null;
+    if (!isPendingChange(PROFILE_RATE_KEY)) stagedProfileRates = { wireless: null, wired: null };
+    if (!isPendingChange(PROFILE_NAME_KEY)) stagedProfileName = null;
+    if (!isPendingChange(DPI_SLOTS_KEY)) {
+      // Flashed or reverted: reseed the editor from whatever the mouse holds.
+      syncDpiSlotPlan();
+      renderDpiSlots();
+    }
+    if (!isPendingChange("gaming-surface")) stagedGamingSurface = null;
+    if (!isPendingChange("lightforce-switch-mode")) stagedLightforce = null;
+    renderBunnyHop();
+  });
   onPendingChanges(renderStagedMarkers);
   renderPendingBar();
   renderStagedMarkers();
   populateInterfaceSettings();
   applyInterfacePreferences();
-  if (!isSuperstrikePreview) {
+  if (!isAnyPreview) {
     navigator.hid?.addEventListener("connect", handleHidConnect);
     navigator.hid?.addEventListener("disconnect", handleHidDisconnect);
     void reconnectAuthorizedDevice();
   }
+}
+
+/**
+ * Dev-only preview of a Pro X Superlight 2 with its onboard profiles loaded,
+ * so the profile list and the slot editor can be looked at without hardware.
+ */
+function showSlotsPreview(): void {
+  dpiOptions = [100, 200, 400, 800, 1600, 3200, 6400, 8000, 16000, 32000];
+  const stages = [
+    { x: 800, y: 800, lod: 1 },
+    { x: 1200, y: 1200, lod: 2 },
+    { x: 1600, y: 1600, lod: 2 },
+    { x: 2400, y: 2400, lod: 2 },
+    { x: 3200, y: 3200, lod: 3 },
+  ];
+  onboardProfiles = [1, 2, 3].map((index) => ({
+    sector: index,
+    enabled: index !== 3,
+    isCurrent: index === 1,
+    name: `Profile ${index}`,
+    dpiStages: stages.slice(0, index === 1 ? 5 : 2),
+    defaultDpiIndex: 0,
+    reportRateWireless: 8000,
+    reportRateWired: 1000,
+    angleSnapping: false,
+    powerSaveTimeoutSeconds: 60,
+    powerOffTimeoutSeconds: 300,
+    bunnyHoppingMs: 100,
+    crcValid: true,
+  } as OnboardProfile));
+  const status: MouseStatus = {
+    brand: "Logitech",
+    name: "PRO X SUPERLIGHT 2",
+    ui: { family: "logitech-hidpp", lodRequiresSurface: true },
+    batteryPercent: 72,
+    batteryState: "Discharging",
+    dpi: 800,
+    dpiY: 800,
+    supportsSeparateDpiAxes: true,
+    pollingRateHz: 8000,
+    supportedPollingRates: [125, 250, 500, 1000, 2000, 4000, 8000],
+    liftOffDistance: "Low",
+    supportedLiftOffDistances: ["Low", "Medium", "High"],
+    onboardProfileFormat: { id: 7, name: "unnamed (v6 + bunny hopping)", base: "v6", supported: true, verified: true },
+    gamingSurfaceMode: "Auto",
+    lightforceSwitchMode: "Hybrid",
+    activeProfile: 1,
+    deviceMode: "Onboard",
+    connectionType: "Wireless",
+    firmware: ["MPM 39.00.B0004"],
+  };
+  // Stand-in client so the staging paths run without hardware. Every write
+  // refuses: the preview is for looking at the UI, not pretending to flash.
+  const refuse = async (): Promise<never> => {
+    throw new Error("Preview mode: no mouse is connected, so nothing was written.");
+  };
+  activeClient = {
+    writeActiveProfile: refuse,
+    setBunnyHoppingMs: refuse,
+    setProfileDpiStages: refuse,
+    setModeStatus: refuse,
+    readOnboardProfiles: async () => onboardProfiles ?? [],
+  } as unknown as LogitechHidppClient;
+
+  configureDpiControl(status.dpi);
+  showStatus(status);
+  renderOnboardProfiles();
+  setConnectionButtons(true, "Preview mode");
+  setText("#read-status", "Preview: profile format 7 with five DPI slots.");
+}
+
+/**
+ * Renders one driver's fixture, or lists the available ones when the name is
+ * unknown. The shell decides what to show from MouseStatus alone, so this walks
+ * the same rendering path the real driver would.
+ */
+async function showFixturePreview(name: string): Promise<void> {
+  // Loaded on demand so the fixtures never reach a production bundle, where
+  // `previewMode` is always null and none of this is reachable.
+  const { PREVIEW_FIXTURES, PREVIEW_KEYS } = await import("./preview-fixtures");
+  const fixture = PREVIEW_FIXTURES[name];
+  if (!fixture) {
+    // `?preview=list` lands here on purpose: an index is more useful than an
+    // error when you cannot remember the driver's key.
+    const heading = document.querySelector<HTMLElement>("#empty-state-title");
+    if (heading) heading.textContent = "Driver previews";
+    const links = PREVIEW_KEYS
+      .map((key) => `<a href="?preview=${key}" style="color:var(--ui-accent)">${key}</a>`)
+      .join(" · ");
+    const blurb = heading?.nextElementSibling;
+    if (blurb) blurb.innerHTML = `Render any supported driver without its hardware: ${links}`;
+    setText("#read-status", name === "list" ? "Pick a driver preview." : `Unknown preview "${name}".`);
+    return;
+  }
+  dpiOptions = [100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 32000];
+  configureDpiControl(fixture.status.dpi);
+  showStatus(fixture.status);
+  setConnectionButtons(true, "Preview mode");
+  setText("#read-status", `Preview: ${fixture.label}. Nothing is written.`);
 }
 
 function showSuperstrikePreview(): void {
@@ -399,7 +598,30 @@ function closeInterfaceSettings(): void {
   showInterfaceSettings(false);
 }
 
+/**
+ * Fills the driver-preview list in interface settings. Development only: the
+ * fixtures are a dynamic import so they never reach a production bundle, and
+ * the section stays hidden there.
+ */
+async function populatePreviewLauncher(): Promise<void> {
+  const section = document.querySelector<HTMLElement>("#preview-launcher");
+  const list = document.querySelector<HTMLElement>("#preview-launcher-list");
+  if (!section || !list || !import.meta.env.DEV || list.childElementCount > 0) return;
+
+  const { PREVIEW_FIXTURES } = await import("./preview-fixtures");
+  const entries: Array<[string, string]> = [
+    ["slots", "Logitech PRO X Superlight 2"],
+    ["superstrike", "Logitech PRO X 2 Superstrike"],
+    ...Object.entries(PREVIEW_FIXTURES).map(([key, fixture]) => [key, fixture.label] as [string, string]),
+  ];
+  list.innerHTML = entries
+    .map(([key, label]) => `<a class="preview-launcher-link${previewMode === key ? " is-active" : ""}" href="?preview=${key}">${escapeHtml(label)}<small>${key}</small></a>`)
+    .join("");
+  section.hidden = false;
+}
+
 function populateInterfaceSettings(): void {
+  void populatePreviewLauncher();
   setControlValue("#interface-density", interfacePreferences.density);
   setControlValue("#interface-theme", interfacePreferences.theme);
   const reducedMotion = document.querySelector<HTMLInputElement>("#interface-reduced-motion");
@@ -500,7 +722,53 @@ function recordDiagnosticError(error: unknown, fallback: string): void {
   renderDeviceDiagnostics(latestDiagnosticStatus);
 }
 
+function configureProfileCapture(status: MouseStatus | null): void {
+  // Capture must be reachable from the profile section even when the separate
+  // Diagnostics disclosure is closed.
+  const logitechClient = status?.brand === "Logitech" ? activeClient as LogitechHidppClient | null : null;
+  const formatId = status?.onboardProfileFormat?.id ?? null;
+  const captureOpen = document.querySelector<HTMLButtonElement>("#capture-open");
+  if (captureOpen) captureOpen.hidden = logitechClient === null || formatId === null;
+  setCaptureContext({
+    device: activeDevice ? describeHidDevice(activeDevice) : status?.name ?? null,
+    profileFormat: status?.onboardProfileFormat ? `${status.onboardProfileFormat.id} · ${status.onboardProfileFormat.name}` : null,
+    profiles: logitechClient && formatId !== null
+      ? {
+        read: async () => (await logitechClient.readOnboardProfiles())
+          .map((profile) => ({ sector: profile.sector, bytes: profile.raw })),
+        readVerification: async () => {
+          const verification = await logitechClient.readOnboardProfileVerification();
+          return {
+            ...verification,
+            profiles: verification.profiles.map((profile) => ({
+              sector: profile.sector,
+              enabled: profile.enabled,
+              isCurrent: profile.isCurrent,
+              crcValid: profile.crcValid,
+              decoded: {
+                name: profile.name,
+                dpiStages: profile.dpiStages,
+                defaultDpiIndex: profile.defaultDpiIndex,
+                reportRateWireless: profile.reportRateWireless,
+                reportRateWired: profile.reportRateWired,
+                angleSnapping: profile.angleSnapping,
+                powerSaveTimeoutSeconds: profile.powerSaveTimeoutSeconds,
+                powerOffTimeoutSeconds: profile.powerOffTimeoutSeconds,
+                bunnyHoppingMs: profile.bunnyHoppingMs,
+              },
+              bytes: profile.raw,
+            })),
+          };
+        },
+        describeOffset: (offset) => describeOffset(formatId, offset),
+        reproduce: (before, after) => reproduceProfile(before, after, formatId),
+      }
+      : null,
+  });
+}
+
 function renderDeviceDiagnostics(status: MouseStatus | null): void {
+  configureProfileCapture(status);
   const output = document.querySelector<HTMLPreElement>("#device-debug-snapshot");
   if (!output || !diagnosticsOpen()) return;
 
@@ -715,7 +983,7 @@ function showStatus(deviceStatus: MouseStatus): void {
     ?? (isEgg8k
       ? "Higher rates update cursor movement more often and increase CPU/USB processing load."
       : "Higher rates update cursor movement more often, but use more battery."));
-  const pollingCard = document.querySelector<HTMLElement>("[data-rate]")?.closest<HTMLElement>(".setting-card");
+  const pollingCard = document.querySelector<HTMLElement>("#polling-card");
   if (pollingCard) {
     pollingCard.hidden = false;
     pollingCard.style.display = "";
@@ -871,29 +1139,25 @@ function showStatus(deviceStatus: MouseStatus): void {
   if (meter) meter.style.width = status.batteryPercent === null ? "0%" : `${status.batteryPercent}%`;
   document.querySelectorAll<HTMLElement>(".device-dot, .status-dot").forEach((dot) => dot.classList.remove("is-idle"));
   document.querySelector<HTMLElement>(".control-shell")?.classList.remove("is-empty");
-  document.querySelectorAll<HTMLButtonElement>("[data-rate]").forEach((button) => setSelected(button, Number(button.dataset.rate) === status.pollingRateHz));
   document.querySelectorAll<HTMLButtonElement>("[data-lod]").forEach((button) => setSelected(button, button.dataset.lod === status.liftOffDistance));
-  document.querySelectorAll<HTMLButtonElement>("[data-rate]").forEach((button) => {
-    const rate = Number(button.dataset.rate);
-    const supportedRates = status.supportedPollingRates;
-    const unsupportedForEgg8k = isEgg8k && rate < 1000;
-    const unsupportedForListed = Array.isArray(supportedRates) && !supportedRates.includes(rate);
-    const hideListed = (status.brand === "Logitech" || ui?.hideUnsupportedPollingRates) && unsupportedForListed;
-    const hide = unsupportedForEgg8k || hideListed || settingsPending;
-    button.hidden = hide;
+  // The host rate is one stop per rate the mouse actually advertises, so an
+  // unsupported rate is simply not a stop rather than a hidden button.
+  const advertisedRates = (status.supportedPollingRates ?? RATE_STEPS_HZ)
+    .filter((rate) => !(isEgg8k && rate < 1000))
+    .slice()
+    .sort((a, b) => a - b);
+  renderRateSlider(
+    document.querySelector<HTMLElement>("#host-rate-slider"),
+    advertisedRates,
+    status.pollingRateHz,
     // A read-only rate still shows which one is active, it just cannot be staged.
-    button.disabled = hide || settingsPending || ui?.pollingReadOnly === true;
-  });
+    { disabled: settingsPending || ui?.pollingReadOnly === true },
+  );
   document.querySelectorAll<HTMLButtonElement>("[data-lod]").forEach((button) => {
     const supportedLods = status.supportedLiftOffDistances;
-    const usesNamedLods = Array.isArray(supportedLods)
-      && supportedLods.includes("Low")
-      && supportedLods.includes("High")
-      && !supportedLods.includes("Medium");
-    const lod = button.dataset.lod as NonNullable<MouseStatus["liftOffDistance"]>;
-    button.textContent = usesNamedLods
-      ? lod
-      : ({ Low: "0.7 mm", Medium: "1 mm", High: "2 mm" } as const)[lod];
+    // Named levels rather than millimetres: the mouse reports a level, not a
+    // height, and the millimetre figures differed per brand anyway.
+    button.textContent = button.dataset.lod ?? "";
     const hideLow = button.dataset.lod === "Low"
       && (isEgg || ui?.hideLodLow === true);
     const unsupported = Array.isArray(supportedLods)
@@ -905,6 +1169,10 @@ function showStatus(deviceStatus: MouseStatus): void {
     const lodNeedsSurface = ui?.lodRequiresSurface === true && status.gamingSurfaceMode === "Off";
     button.disabled = hideLow || unsupported || settingsPending || legacyLogitechLow || lodNeedsSurface;
   });
+  // Runs after the DPI controls above so the slot editor, when it is in charge,
+  // has the last word on which of them are visible.
+  renderDpiSlots();
+  renderProfileRates();
   const lodNote = document.querySelector<HTMLElement>("#lod-note");
   if (lodNote) {
     lodNote.textContent = ui?.lodRequiresSurface === true && status.gamingSurfaceMode === "Off"
@@ -926,6 +1194,20 @@ function showStatus(deviceStatus: MouseStatus): void {
       && Array.isArray(status.supportedLiftOffDistances)
       && status.supportedLiftOffDistances.length === 0;
   }
+  const onboardSection = document.querySelector<HTMLElement>("#logitech-onboard");
+  if (onboardSection) {
+    const supportsOnboard = status.brand === "Logitech" && status.deviceMode !== undefined && status.deviceMode !== "Unknown";
+    onboardSection.hidden = !supportsOnboard;
+    if (supportsOnboard) {
+      lastDeviceMode = status.deviceMode;
+      lastProfileFormat = status.onboardProfileFormat ?? null;
+      // Profiles stay in flash regardless of mode, so they are listed either
+      // way; only which entry is highlighted changes. Read once per device —
+      // the refresh loop must never trigger a full profile pass.
+      if (onboardProfiles === null && !onboardProfilesLoading) void reloadOnboardProfiles();
+      else renderOnboardProfiles();
+    }
+  }
   const lightforceCard = document.querySelector<HTMLElement>("#lightforce-card");
   if (lightforceCard) lightforceCard.hidden = !status.lightforceSwitchMode;
   document.querySelectorAll<HTMLButtonElement>("[data-lightforce]").forEach((button) => {
@@ -943,7 +1225,9 @@ function showStatus(deviceStatus: MouseStatus): void {
     dpiOutputField.readOnly = true;
   }
   const axisControls = document.querySelector<HTMLElement>("#logitech-axis-controls");
-  const showSeparateDpiAxes = status.brand === "Logitech" && status.supportsSeparateDpiAxes === true;
+  const showSeparateDpiAxes = status.brand === "Logitech"
+    && status.supportsSeparateDpiAxes === true
+    && !dpiSlotsAvailable();
   if (axisControls) axisControls.style.display = showSeparateDpiAxes ? "block" : "none";
   const dpiLabel = (source: MouseStatus): string => showSeparateDpiAxes
     ? `X ${source.dpi.toLocaleString()} · Y ${(source.dpiY ?? source.dpi).toLocaleString()} DPI`
@@ -1022,6 +1306,9 @@ function renderLogitechDetails(status: MouseStatus): void {
   const items = [
     ["Mode", status.deviceMode ?? "Unknown"],
     ["Active profile", status.activeProfile === null ? "None in host mode" : `Profile ${status.activeProfile}`],
+    ["Profile format", status.onboardProfileFormat
+      ? `${status.onboardProfileFormat.id} · ${status.onboardProfileFormat.name} (base ${status.onboardProfileFormat.base})`
+      : "Not reported"],
     ["Model ID", status.modelId ?? "Not reported"],
     ["Unit ID", status.unitId ?? "Not reported"],
     ["Transport IDs", transports],
@@ -1096,6 +1383,7 @@ async function activateClient(client: SupportedClient): Promise<void> {
   activeTeevolutionClient = null;
   activeVgnClient = null;
   activeViperClient = null;
+  if (activeDevice !== client.device) onboardProfiles = null;
   activeFinalmouseClient = null;
   activeDevice = client.device;
   recordDiagnosticCommand("Read device status");
@@ -1203,6 +1491,7 @@ function showDisconnectedState(): void {
   activeViperClient = null;
   activeFinalmouseClient = null;
   activeDevice = null;
+  onboardProfiles = null;
   lastRenderedStatusKey = null;
   clearPendingChanges();
   latestDeviceStatus = null;
@@ -1341,12 +1630,15 @@ async function connect(): Promise<void> {
     await activateClient(client);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unable to read the mouse.";
-    recordDiagnosticError(error, message);
+    // Picking a keyboard or headset is a wrong choice, not a failure: say so,
+    // and do not file it as a device error in diagnostics.
+    const wrongDevice = error instanceof NotAMouseError;
+    if (!wrongDevice) recordDiagnosticError(error, message);
     await activeEggClient?.close().catch(() => undefined);
     activeEggClient = null;
     await activeEggWeClient?.close().catch(() => undefined);
     activeEggWeClient = null;
-    setText("#device-status", "Connection failed");
+    setText("#device-status", wrongDevice ? "Not a mouse" : "Connection failed");
     setText("#read-status", message);
   } finally {
     // Always clear the busy label — success used to leave "Connecting…" stuck.
@@ -1572,6 +1864,899 @@ function applyLogitechAnalogButton(button: 0 | 1): void {
   stageAnalogButton(button, readAnalogTuning(button === 0 ? "left" : "right"));
 }
 
+async function applyOnboardMode(mode: "Onboard" | "Host"): Promise<void> {
+  const client = activeClient;
+  if (!client || refreshInProgress || settingInProgress) return;
+  // Host mode opens the host layer, which discards profile edits the same way.
+  if (mode === "Host" && !confirmDiscardingProfileEdits("host")) return;
+  settingInProgress = true;
+  const buttons = document.querySelectorAll<HTMLButtonElement>("[data-onboard-mode]");
+  buttons.forEach((button) => { button.disabled = true; });
+  setText("#read-status", `Switching to ${mode.toLowerCase()} mode…`);
+  recordDiagnosticCommand(`Set onboard mode to ${mode}`);
+  try {
+    await client.setOnboardMode(mode);
+    // Host has no stored profile to edit, so switching to it also opens it.
+    if (mode === "Host") selectEditedProfile("host");
+    showStatus(await statusAfterWrite(client));
+  } catch (error) {
+    recordDiagnosticError(error, "Unable to change the onboard mode.");
+    setText("#read-status", error instanceof Error ? error.message : "Unable to change the onboard mode.");
+  } finally {
+    endDeviceWrite();
+    buttons.forEach((button) => { button.disabled = false; });
+  }
+}
+
+async function selectOnboardProfile(sector: number): Promise<void> {
+  const client = activeClient;
+  if (!client || refreshInProgress || settingInProgress) return;
+  // Asked before the mouse is touched: switching profiles also opens the new
+  // one, so the edits would be gone by the time the prompt appeared.
+  if (!confirmDiscardingProfileEdits(sector)) return;
+  settingInProgress = true;
+  setText("#read-status", `Switching to profile ${sector}…`);
+  recordDiagnosticCommand(`Select onboard profile ${sector}`);
+  try {
+    if (lastDeviceMode !== "Onboard") await client.setOnboardMode("Onboard");
+    await client.setCurrentProfile(sector);
+    // Switching to a profile also opens it, which is what you would expect
+    // after asking the mouse to run it.
+    selectEditedProfile(sector);
+    showStatus(await statusAfterWrite(client));
+    await reloadOnboardProfiles();
+  } catch (error) {
+    recordDiagnosticError(error, "Unable to select that profile.");
+    setText("#read-status", error instanceof Error ? error.message : "Unable to select that profile.");
+  } finally {
+    endDeviceWrite();
+  }
+}
+
+/**
+ * Enabling or disabling a slot rewrites the directory sector, so it costs a
+ * flash erase/write cycle and uses a write sequence not yet proven on hardware.
+ * Confirm explicitly rather than treating the icon as a cheap toggle.
+ */
+async function toggleOnboardProfileEnabled(sector: number, enabled: boolean): Promise<void> {
+  const client = activeClient;
+  if (!client || refreshInProgress || settingInProgress) return;
+
+  const confirmed = window.confirm(
+    `${enabled ? "Enable" : "Disable"} profile ${sector}?\n\n`
+    + "This writes to the mouse's flash memory — one write cycle per change. "
+    + "OpenMouse has not yet verified this write sequence on hardware; G HUB can restore the profiles if anything goes wrong.",
+  );
+  if (!confirmed) return;
+
+  settingInProgress = true;
+  setText("#onboard-status", `${enabled ? "Enabling" : "Disabling"} profile ${sector}…`);
+  recordDiagnosticCommand(`${enabled ? "Enable" : "Disable"} onboard profile ${sector}`);
+  try {
+    await client.setProfileEnabled(sector, enabled);
+    await reloadOnboardProfiles();
+  } catch (error) {
+    recordDiagnosticError(error, "Unable to change the profile state.");
+    setText("#onboard-status", error instanceof Error ? error.message : "Unable to change the profile state.");
+  } finally {
+    endDeviceWrite();
+  }
+}
+
+/**
+ * Bunny hop lives in the active onboard profile, so applying it writes flash.
+ * The encoding is confirmed on hardware but the write sequence is not, hence
+ * the confirmation.
+ */
+const BUNNY_HOP_KEY = "logitech-bunny-hop";
+/**
+ * Settings written into the active profile's sector. Flash is erased and
+ * rewritten a whole sector at a time, so two of these staged together must
+ * cost one erase cycle, not two.
+ */
+const PROFILE_SECTOR_GROUP = "logitech-profile-sector";
+const DPI_SLOTS_KEY = "logitech-dpi-slots";
+
+/**
+ * Writes every staged profile setting in one sector write. This is the apply
+ * for the whole profile-sector group, so it must send everything staged in it:
+ * the group runs once, and whichever change happened to be staged last is the
+ * one that carries it.
+ */
+async function writeStagedProfileSector(): Promise<void> {
+  if (!activeClient) throw new Error("The mouse is no longer connected.");
+  const entry = editedProfileEntry();
+  if (!entry) throw new Error("No profile is open for editing.");
+  const ratesStaged = isPendingChange(PROFILE_RATE_KEY);
+  await activeClient.writeActiveProfile({
+    // The open profile, which is not necessarily the one the mouse is running.
+    sector: entry.sector,
+    bunnyHoppingMs: isPendingChange(BUNNY_HOP_KEY) ? stagedBunnyHopMs : null,
+    dpiStages: isPendingChange(DPI_SLOTS_KEY) ? dpiSlotPlan : null,
+    reportRateWirelessHz: ratesStaged ? stagedProfileRates.wireless : null,
+    reportRateWiredHz: ratesStaged ? stagedProfileRates.wired : null,
+    name: isPendingChange(PROFILE_NAME_KEY) ? stagedProfileName : null,
+  });
+  // The write changed profile flash, so every cached read is stale.
+  onboardProfiles = null;
+  await reloadOnboardProfiles();
+}
+/**
+ * Staged bunny-hop value. It cannot ride on MouseStatus like the other staged
+ * settings because it lives in the onboard profile, not the status snapshot,
+ * so the pending value is mirrored here for rendering instead.
+ */
+let stagedBunnyHopMs: number | null = null;
+
+function applyBunnyHopMs(milliseconds: number): void {
+  if (!activeClient) return;
+
+  const invalid = validateBunnyHoppingMs(milliseconds);
+  if (invalid) {
+    setText("#bunny-hop-note", invalid);
+    return;
+  }
+
+  const stored = editedProfileEntry()?.bunnyHoppingMs ?? null;
+  if (stored === milliseconds) {
+    stagedBunnyHopMs = null;
+    dropPendingChange(BUNNY_HOP_KEY);
+    renderBunnyHop();
+    return;
+  }
+
+  stagedBunnyHopMs = milliseconds;
+  stageChange({
+    key: BUNNY_HOP_KEY,
+    // Everything stored in the active profile shares one sector, so a second
+    // profile setting must join this group rather than cost its own erase.
+    group: PROFILE_SECTOR_GROUP,
+    label: milliseconds === 0 ? "Bunny hop off" : `Bunny hop ${milliseconds} ms`,
+    command: `Set bunny hop to ${milliseconds} ms`,
+    progress: milliseconds === 0 ? "Turning bunny hop off…" : `Setting bunny hop to ${milliseconds} ms…`,
+    // No preview: the value lives in the onboard profile, not MouseStatus, so
+    // renderBunnyHop mirrors the staged value from stagedBunnyHopMs instead.
+    apply: writeStagedProfileSector,
+  });
+  renderBunnyHop();
+}
+
+
+function renderBunnyHop(): void {
+  const row = document.querySelector<HTMLElement>("#bunny-hop-row");
+  if (!row) return;
+  const active = editedProfileEntry();
+  // Support is a property of the format, not of the stored value: a profile
+  // that never had bunny hop written reads 0xff and decodes to null, which
+  // means off, not unsupported. Keying on the value hid the control entirely
+  // on any profile the setting had not been used on yet.
+  const supported = active !== null
+    && capabilitiesForFormat(lastProfileFormat?.id).bunnyHop;
+  row.hidden = !supported;
+  if (!supported || !active) return;
+
+  const locked = lastProfileFormat?.verified !== true;
+  // Show the staged value, so a background refresh cannot snap the control back
+  // to what is still on the device.
+  // A never-written byte counts as off, so the toggle starts in the off state
+  // rather than the control vanishing.
+  const value = stagedBunnyHopMs ?? active.bunnyHoppingMs ?? 0;
+  const enabled = value !== 0;
+
+  setToggleValue("#bunny-hop-enabled", enabled);
+  const toggle = document.querySelector<HTMLButtonElement>("#bunny-hop-enabled");
+  if (toggle) toggle.disabled = locked || settingInProgress;
+
+  const input = document.querySelector<HTMLInputElement>("#bunny-hop-input");
+  if (input) {
+    // Leave the field alone while it has focus, or typing gets overwritten.
+    // While off there is no stored time, so the field keeps the lowest value
+    // G HUB allows and turning it on applies that.
+    if (document.activeElement !== input) input.value = String(enabled ? value : BUNNY_HOP_LIMITS.minMs);
+    input.disabled = locked || settingInProgress || !enabled;
+  }
+
+  setText("#bunny-hop-note", locked
+    ? "This profile format has not been verified on hardware, so it is read-only."
+    : `Ignores repeat clicks that land within this window, so a switch that bounces during fast click spam only registers once. Longer times filter harder; shorter times let genuine fast clicks through. ${BUNNY_HOP_LIMITS.minMs}–${BUNNY_HOP_LIMITS.maxMs} ms in steps of ${BUNNY_HOP_LIMITS.stepMs}.`);
+}
+
+/**
+ * DPI slots live in the active profile's stage table. The plan is edited as a
+ * whole because the slot count is expressed by zeroing the stages that fall out
+ * of use, so a single slot cannot be written on its own.
+ */
+let dpiSlotPlan: DpiStagePlan | null = null;
+/**
+ * Per-slot axis lock: while a slot is locked, typing X mirrors into Y. Slots
+ * are independent because the choice is per slot — a sniper slot may want
+ * separate axes while the rest stay square.
+ */
+let dpiAxisLocks: boolean[] = [];
+
+function dpiAxisLockedAt(index: number): boolean {
+  return dpiAxisLocks[index] ?? true;
+}
+
+function dpiSlotLimits(): DpiStageCapabilities | null {
+  const format = lastProfileFormat;
+  return format ? capabilitiesForFormat(format.id).dpiStages : null;
+}
+
+/**
+ * True when the slot editor is driving DPI, which means the preset row and the
+ * single X/Y pair must give way: they write the host layer, the slots write the
+ * profile, and showing both would offer two DPI values that can disagree.
+ * Mice with no slot support keep the preset UI unchanged.
+ */
+function dpiSlotsAvailable(): boolean {
+  return editingStoredProfile() && dpiSlotLimits() !== null && dpiSlotPlan !== null;
+}
+
+/** True while the flash write sequence for stage tables is still unproven. */
+function dpiSlotsLocked(): boolean {
+  return !PROFILE_DPI_WRITES_ENABLED || lastProfileFormat?.verified !== true;
+}
+
+/**
+ * Which profile the settings panels are editing. This is deliberately not the
+ * same as which profile the mouse is running: you can open any stored profile,
+ * change it and flash it without switching to it. "host" means the live layer
+ * rather than a stored profile.
+ */
+let editedProfile: number | "host" | null = null;
+
+function editedProfileEntry(): OnboardProfile | null {
+  if (editedProfile === "host" || editedProfile === null) return null;
+  return onboardProfiles?.find((profile) => profile.sector === editedProfile) ?? null;
+}
+
+/** True while a stored profile is open, so profile settings are in charge. */
+function editingStoredProfile(): boolean {
+  return editedProfileEntry() !== null;
+}
+
+function syncEditedProfile(): void {
+  if (!onboardProfiles) return;
+  // Follow the device on first load, and whenever the chosen profile is gone.
+  const stillThere = editedProfile !== "host"
+    && onboardProfiles.some((profile) => profile.sector === editedProfile);
+  if (stillThere) return;
+  if (editedProfile === "host") return;
+  editedProfile = lastDeviceMode === "Host"
+    ? "host"
+    : onboardProfiles.find((profile) => profile.isCurrent)?.sector ?? "host";
+}
+
+/**
+ * Changes staged against the profile currently open. They are built from that
+ * sector's bytes, so they cannot follow you to another profile.
+ */
+function stagedProfileEdits(): PendingChange[] {
+  return pendingChanges().filter((change) => change.group === PROFILE_SECTOR_GROUP);
+}
+
+/**
+ * Asks before throwing away unflashed edits. Switching profiles discards them,
+ * and losing a set of DPI slots to a stray click is not something to do
+ * silently. Returns false when the user chooses to stay.
+ */
+function confirmDiscardingProfileEdits(target: number | "host"): boolean {
+  const staged = stagedProfileEdits();
+  if (staged.length === 0 || target === editedProfile) return true;
+
+  const from = describeProfileEntry(editedProfileEntry()).name.replace(/ · .*$/, "");
+  const to = target === "host"
+    ? "Host"
+    : onboardProfiles?.find((profile) => profile.sector === target)?.name ?? `Profile ${target}`;
+  return window.confirm(
+    `${from} has ${staged.length} change${staged.length === 1 ? "" : "s"} you have not flashed:\n\n`
+    + `${staged.map((change) => `  • ${change.label}`).join("\n")}\n\n`
+    + `Opening ${to} discards ${staged.length === 1 ? "it" : "them"}. Continue?`,
+  );
+}
+
+function selectEditedProfile(sector: number | "host"): void {
+  if (!confirmDiscardingProfileEdits(sector)) return;
+  editedProfile = sector;
+  // Opening a different profile abandons edits staged against the old one:
+  // they were built from that sector's bytes and cannot carry over.
+  dropPendingChange(DPI_SLOTS_KEY);
+  dropPendingChange(BUNNY_HOP_KEY);
+  dropPendingChange(PROFILE_RATE_KEY);
+  dropPendingChange(PROFILE_NAME_KEY);
+  stagedBunnyHopMs = null;
+  stagedProfileRates = { wireless: null, wired: null };
+  stagedProfileName = null;
+  // The locks describe the slots of the profile that was open, not this one.
+  dpiAxisLocks = [];
+  syncDpiSlotPlan();
+  renderOnboardProfiles();
+  if (latestDeviceStatus) showStatus(latestDeviceStatus);
+}
+
+function syncDpiSlotPlan(): void {
+  const limits = dpiSlotLimits();
+  const entry = editedProfileEntry();
+  // A reload in flight leaves onboardProfiles null for a moment. Clearing the
+  // plan there made the editor blink out and back, so the last one is kept
+  // until there is something to replace it with.
+  if (!onboardProfiles) return;
+  if (!entry || !limits || entry.dpiStages.length === 0) {
+    dpiSlotPlan = null;
+    return;
+  }
+  // A background refresh must not discard edits the user has staged but not
+  // flashed yet, so the device value only reseeds the plan when none is staged.
+  if (isPendingChange(DPI_SLOTS_KEY)) return;
+  dpiSlotPlan = {
+    stages: entry.dpiStages.slice(0, limits.maxStages).map((stage) => ({ ...stage })),
+    defaultIndex: Math.min(entry.defaultDpiIndex ?? 0, entry.dpiStages.length - 1),
+  };
+}
+
+function deviceDpiSlotPlan(): DpiStagePlan | null {
+  const entry = editedProfileEntry();
+  if (!entry || entry.dpiStages.length === 0) return null;
+  return {
+    stages: entry.dpiStages.map((stage) => ({ ...stage })),
+    defaultIndex: Math.min(entry.defaultDpiIndex ?? 0, entry.dpiStages.length - 1),
+  };
+}
+
+/**
+ * Stages the edited slot table, or drops the change once it matches the mouse
+ * again. The whole table is one change: the slot count is expressed by zeroing
+ * the stages that fall out of use, so slots cannot be written individually.
+ */
+function stageDpiSlots(): void {
+  // Render first: the edit already changed the plan, so bailing out below must
+  // not leave the controls showing the values from before it.
+  renderDpiSlots();
+  if (!activeClient || !dpiSlotPlan) return;
+  const stored = deviceDpiSlotPlan();
+  if (stored && JSON.stringify(stored) === JSON.stringify(dpiSlotPlan)) {
+    dropPendingChange(DPI_SLOTS_KEY);
+    renderDpiSlots();
+    return;
+  }
+
+  const count = dpiSlotPlan.stages.length;
+  stageChange({
+    key: DPI_SLOTS_KEY,
+    group: PROFILE_SECTOR_GROUP,
+    label: count === 1 ? "1 DPI slot" : `${count} DPI slots`,
+    command: `Write ${count} DPI slot(s) to the active profile`,
+    progress: "Writing DPI slots to the profile…",
+    // No preview: the slot table is not part of MouseStatus, so renderDpiSlots
+    // shows the edited plan directly.
+    apply: writeStagedProfileSector,
+  });
+  renderDpiSlots();
+}
+
+function setDpiSlotCount(count: number): void {
+  const limits = dpiSlotLimits();
+  if (!dpiSlotPlan || !limits || dpiSlotsLocked()) return;
+  const wanted = Math.min(limits.maxStages, Math.max(1, Math.round(count)));
+  const stages = dpiSlotPlan.stages.slice(0, wanted);
+  // Growing reuses the last slot's values, so a new slot starts somewhere sane
+  // rather than at zero, which would read back as unused.
+  while (stages.length < wanted) {
+    const previous = stages[stages.length - 1] ?? { x: limits.minDpi, y: limits.minDpi, lod: 2 };
+    stages.push({ ...previous });
+  }
+  dpiSlotPlan = { stages, defaultIndex: Math.min(dpiSlotPlan.defaultIndex, stages.length - 1) };
+  stageDpiSlots();
+}
+
+function setDpiSlotAxis(index: number, axis: "x" | "y", value: number): void {
+  const limits = dpiSlotLimits();
+  const stage = dpiSlotPlan?.stages[index];
+  if (!stage || !limits || dpiSlotsLocked()) return;
+  const dpi = clampDpi(value, limits);
+  stage[axis] = dpi;
+  // With this slot's axes locked the pair moves together, whichever was typed.
+  if (dpiAxisLockedAt(index)) stage[axis === "x" ? "y" : "x"] = dpi;
+  stageDpiSlots();
+}
+
+function setDpiSlotLod(index: number, level: NonNullable<MouseStatus["liftOffDistance"]>): void {
+  const stage = dpiSlotPlan?.stages[index];
+  if (!stage || dpiSlotsLocked()) return;
+  stage.lod = PROFILE_STAGE_LOD[level];
+  stageDpiSlots();
+}
+
+function setDpiSlotDefault(index: number): void {
+  if (!dpiSlotPlan || dpiSlotsLocked()) return;
+  if (index < 0 || index >= dpiSlotPlan.stages.length) return;
+  dpiSlotPlan.defaultIndex = index;
+  stageDpiSlots();
+}
+
+function setDpiAxisLock(index: number, locked: boolean): void {
+  if (dpiSlotsLocked()) return;
+  dpiAxisLocks[index] = locked;
+  const stage = dpiSlotPlan?.stages[index];
+  // Locking pulls Y onto X straight away, so the state matches what is shown.
+  if (locked && stage && stage.y !== stage.x) {
+    stage.y = stage.x;
+    // Mirroring changes the table, so it is staged like any other edit.
+    stageDpiSlots();
+    return;
+  }
+  renderDpiSlots();
+}
+
+/** Fallback stops for a driver that does not advertise a rate list. */
+const RATE_STEPS_HZ = [125, 250, 500, 1000, 2000, 4000, 8000];
+
+/** 125 → "125", 8000 → "8K": the scale has to fit under a narrow card. */
+function shortRate(hz: number): string {
+  return hz >= 1000 ? `${hz / 1000}K` : String(hz);
+}
+
+/**
+ * Renders a rate picker as a slider with one stop per supported rate.
+ *
+ * The slider runs over indices rather than hertz because the steps are not
+ * evenly spaced — 125 to 8000 doubles each time — so an index scale puts the
+ * stops at equal distances, which is what makes the dots line up.
+ */
+function renderRateSlider(
+  root: HTMLElement | null,
+  options: number[],
+  valueHz: number | null,
+  state: { label?: string; disabled: boolean },
+): void {
+  if (!root) return;
+  if (options.length === 0) {
+    root.innerHTML = "";
+    return;
+  }
+  // A stored rate can sit off the scale — another tool may have written one
+  // above this link's ceiling. Land on the nearest stop rather than falling
+  // back to index 0, which would read as the slowest rate rather than the
+  // fastest one available.
+  const exact = options.indexOf(valueHz ?? -1);
+  const index = exact >= 0
+    ? exact
+    : options.reduce(
+      (best, rate, step) =>
+        Math.abs(rate - (valueHz ?? options[0] ?? 0)) < Math.abs((options[best] ?? 0) - (valueHz ?? options[0] ?? 0))
+          ? step
+          : best,
+      0,
+    );
+  const last = Math.max(1, options.length - 1);
+  // The thumb centre travels between half a thumb in from each end, so the
+  // dots are inset by the same amount to sit under it.
+  const position = (step: number): string => `calc(7px + (100% - 14px) * ${step} / ${last})`;
+
+  const scale = options.map((rate, step) => {
+    const on = step <= index;
+    return `<i class="${on ? "is-on" : ""}" style="left:${position(step)}"></i>`
+      + `<span class="${step === index ? "is-on" : ""}" style="left:${position(step)}">${shortRate(rate)}</span>`;
+  }).join("");
+
+  root.innerHTML = `${state.label ? `<div class="rate-slider-head"><span>${escapeHtml(state.label)}</span><output>${options[index]?.toLocaleString() ?? "—"} Hz</output></div>` : ""}
+    <input type="range" class="rate-slider-input" min="0" max="${last}" step="1" value="${index}"${state.disabled ? " disabled" : ""} aria-label="${escapeHtml(state.label ?? "Report rate")}" aria-valuetext="${options[index] ?? 0} Hz" />
+    <div class="rate-slider-scale">${scale}</div>`;
+  // The index is only meaningful next to the list it came from.
+  root.dataset.rates = options.join(",");
+}
+
+/** Maps a slider index back to hertz using the list that produced it. */
+function rateFromSlider(selector: string, index: number): number | null {
+  const root = document.querySelector<HTMLElement>(selector);
+  if (!root) return null;
+  const rates = (root.dataset.rates ?? "").split(",").map(Number).filter((rate) => rate > 0);
+  return rates[index] ?? null;
+}
+
+/**
+ * Updates a slider's readout and lit dots as the thumb moves. Nothing is
+ * staged: the value only counts once the drag ends.
+ */
+function previewRateSlider(selector: string, index: number): void {
+  const root = document.querySelector<HTMLElement>(selector);
+  if (!root) return;
+  const hz = rateFromSlider(selector, index);
+  const output = root.querySelector("output");
+  if (output && hz !== null) output.textContent = `${hz.toLocaleString()} Hz`;
+  root.querySelectorAll<HTMLElement>(".rate-slider-scale i").forEach((dot, step) => {
+    dot.classList.toggle("is-on", step <= index);
+  });
+  root.querySelectorAll<HTMLElement>(".rate-slider-scale span").forEach((label, step) => {
+    label.classList.toggle("is-on", step === index);
+  });
+}
+
+const PROFILE_NAME_KEY = "logitech-profile-name";
+let stagedProfileName: string | null = null;
+
+function renameOnboardProfile(sector: number): void {
+  const entry = onboardProfiles?.find((profile) => profile.sector === sector);
+  if (!entry || !activeClient) return;
+  const maxLength = lastProfileFormat ? capabilitiesForFormat(lastProfileFormat.id).maxNameLength : null;
+  if (maxLength === null) {
+    setText("#onboard-status", "This profile format has no name field.");
+    return;
+  }
+  // Renaming a profile that is not open would stage against the wrong sector,
+  // so opening it first keeps the pending write pointed at what is on screen.
+  if (editedProfile !== sector) selectEditedProfile(sector);
+
+  const current = stagedProfileName ?? entry.name ?? "";
+  const input = window.prompt(`Profile name (up to ${maxLength} characters)`, current);
+  if (input === null) return;
+
+  const invalid = validateProfileName(input, maxLength);
+  if (invalid) {
+    setText("#onboard-status", invalid);
+    return;
+  }
+  const name = input.trim();
+  if (name === entry.name) {
+    stagedProfileName = null;
+    dropPendingChange(PROFILE_NAME_KEY);
+    renderOnboardProfiles();
+    return;
+  }
+
+  stagedProfileName = name;
+  stageChange({
+    key: PROFILE_NAME_KEY,
+    group: PROFILE_SECTOR_GROUP,
+    label: `Rename to "${name}"`,
+    command: `Rename profile ${sector} to "${name}"`,
+    progress: "Writing the profile name…",
+    apply: writeStagedProfileSector,
+  });
+  renderOnboardProfiles();
+}
+
+/** Staged per-profile report rates, keyed by link. */
+let stagedProfileRates: { wireless: number | null; wired: number | null } = { wireless: null, wired: null };
+const PROFILE_RATE_KEY = "logitech-profile-rate";
+
+function setProfileReportRate(link: "wireless" | "wired", hz: number): void {
+  const entry = editedProfileEntry();
+  if (!entry || !activeClient) return;
+  const rates = lastProfileFormat ? capabilitiesForFormat(lastProfileFormat.id).reportRates : null;
+  const invalid = validateReportRate(hz, rates, link);
+  if (invalid) {
+    setText("#polling-note", invalid);
+    return;
+  }
+  stagedProfileRates = { ...stagedProfileRates, [link]: hz };
+
+  const stored = { wireless: entry.reportRateWireless, wired: entry.reportRateWired };
+  const wanted = {
+    wireless: stagedProfileRates.wireless ?? stored.wireless,
+    wired: stagedProfileRates.wired ?? stored.wired,
+  };
+  if (wanted.wireless === stored.wireless && wanted.wired === stored.wired) {
+    stagedProfileRates = { wireless: null, wired: null };
+    dropPendingChange(PROFILE_RATE_KEY);
+    renderProfileRates();
+    return;
+  }
+
+  stageChange({
+    key: PROFILE_RATE_KEY,
+    group: PROFILE_SECTOR_GROUP,
+    label: `${link === "wired" ? "Wired" : "Wireless"} ${hz.toLocaleString()} Hz`,
+    command: `Set profile ${link} report rate to ${hz} Hz`,
+    progress: "Writing the report rate to the profile…",
+    // No preview: profile rates are not part of MouseStatus.
+    apply: writeStagedProfileSector,
+  });
+  renderProfileRates();
+}
+
+function renderProfileRates(): void {
+  const rows = document.querySelector<HTMLElement>("#profile-rate-rows");
+  const rateButtons = document.querySelector<HTMLElement>("#host-rate-slider");
+  if (!rows) return;
+  const entry = editedProfileEntry();
+  const rates = lastProfileFormat ? capabilitiesForFormat(lastProfileFormat.id).reportRates : null;
+  const available = entry !== null && rates !== null;
+
+  rows.hidden = !available;
+  // The host slider writes the host layer, so only one of the two is shown.
+  if (rateButtons) rateButtons.hidden = available;
+  const badge = document.querySelector<HTMLElement>("#rate-scope-badge");
+  if (badge) {
+    badge.hidden = editedProfile === null;
+    badge.textContent = available ? "Per-profile" : "Host";
+  }
+  if (!available || !entry || !rates) return;
+
+  const locked = lastProfileFormat?.verified !== true;
+  for (const link of ["wireless", "wired"] as const) {
+    const value = stagedProfileRates[link]
+      ?? (link === "wired" ? entry.reportRateWired : entry.reportRateWireless);
+    renderRateSlider(
+      document.querySelector<HTMLElement>(`#profile-rate-${link}`),
+      reportRatesFor(rates, link),
+      value,
+      { label: link === "wired" ? "Wired" : "Wireless", disabled: locked || settingInProgress },
+    );
+  }
+
+  setText("#polling-note", `Stored in this profile, one rate per link. Up to ${
+    reportRatesFor(rates, "wireless").at(-1)?.toLocaleString()} Hz wireless, ${
+    reportRatesFor(rates, "wired").at(-1)?.toLocaleString()} Hz over the cable.`);
+}
+
+function renderDpiSlots(): void {
+  const section = document.querySelector<HTMLElement>("#logitech-dpi-slots");
+  if (!section) return;
+  const limits = dpiSlotLimits();
+  // No limits means the format's slot table was never established, so nothing
+  // is shown rather than guessing another format's numbers.
+  const available = dpiSlotsAvailable();
+  section.hidden = !available;
+  // One card, two sources: the badge says which one is on screen. Mice with no
+  // profile list have only one source, so it carries no badge at all.
+  const scopeBadge = document.querySelector<HTMLElement>("#dpi-scope-badge");
+  if (scopeBadge) {
+    scopeBadge.hidden = editedProfile === null;
+    scopeBadge.textContent = available ? "Per-profile" : "Host";
+  }
+  // The compact layout pins the settings grid to a fixed row height, which the
+  // slot editor overflows. Set here rather than in showStatus so the class
+  // tracks the editor however the render was reached.
+  document.querySelector<HTMLElement>(".settings-grid")?.classList.toggle("has-dpi-slots", available);
+  // The standalone lift-off control writes the host layer and forces the mouse
+  // into host mode, so it stands down while a stored profile is open — there
+  // lift-off belongs to each DPI slot instead. Toggled here rather than in
+  // showStatus, which runs before the open profile is known.
+  const hostLodRow = document.querySelector<HTMLElement>("#host-lod-row");
+  if (hostLodRow) hostLodRow.hidden = available;
+  // The host layer has no stored slots, so it keeps the preset row instead.
+  if (!available || limits === null || dpiSlotPlan === null) {
+    // No slots on this mouse or profile format, so the preset row stays in
+    // charge exactly as it did before slots existed.
+    const presetRow = document.querySelector<HTMLElement>("#dpi-presets");
+    if (presetRow) presetRow.hidden = false;
+    const customButton = document.querySelector<HTMLButtonElement>("#custom-dpi");
+    if (customButton) customButton.hidden = false;
+    return;
+  }
+
+  const locked = dpiSlotsLocked();
+  const levels = lastProfileFormat ? capabilitiesForFormat(lastProfileFormat.id).supportedLods : [];
+
+  // The preset row writes host DPI, so it stands down while slots are shown.
+  const presets = document.querySelector<HTMLElement>("#dpi-presets");
+  if (presets) presets.hidden = true;
+  const custom = document.querySelector<HTMLButtonElement>("#custom-dpi");
+  if (custom) custom.hidden = true;
+  const axisControls = document.querySelector<HTMLElement>("#logitech-axis-controls");
+  if (axisControls) axisControls.style.display = "none";
+
+  // A short row of stops reads faster than a dropdown and matches the other
+  // pickers on the page.
+  const count = document.querySelector<HTMLElement>("#dpi-slot-count");
+  if (count) {
+    count.innerHTML = Array.from({ length: limits.maxStages }, (_, step) => {
+      const value = step + 1;
+      const on = value === dpiSlotPlan?.stages.length;
+      return `<button type="button" data-dpi-slot-count="${value}"${locked ? " disabled" : ""} class="${on ? "selected" : ""}" aria-pressed="${on}">${value}</button>`;
+    }).join("");
+  }
+
+  const list = document.querySelector<HTMLElement>("#dpi-slot-list");
+  if (list) {
+    list.innerHTML = dpiSlotPlan.stages.map((stage, index) => {
+      const level = stageLodLevel(stage.lod);
+      // A native select cannot be styled or animated, so the menu is built by
+      // hand. It keeps listbox semantics so it still reads as a select.
+      const lodOptions = levels
+        .map((name) => `<li role="option" data-lod-value="${name}" aria-selected="${name === level}">${name}</li>`)
+        .join("");
+      const isDefault = index === dpiSlotPlan?.defaultIndex;
+      const axisLocked = dpiAxisLockedAt(index);
+      return `<div class="dpi-slot-row${isDefault ? " is-default" : ""}">
+        <button type="button" class="dpi-slot-index" data-dpi-slot-default="${index}"${locked ? " disabled" : ""} title="${isDefault ? "Starting slot" : "Make this the starting slot"}" aria-pressed="${isDefault}">${index + 1}</button>
+        <input type="number" data-dpi-slot="${index}" data-dpi-axis="x" aria-label="Slot ${index + 1} X DPI" min="${limits.minDpi}" max="${limits.maxDpi}" step="${limits.stepDpi}" value="${stage.x}"${locked ? " disabled" : ""} />
+        <button type="button" class="dpi-axis-lock${axisLocked ? " is-locked" : ""}" data-dpi-axis-lock="${index}"${locked ? " disabled" : ""} title="${axisLocked ? "X and Y are linked — click to set them separately" : "X and Y are separate — click to link them"}" aria-label="Link X and Y for slot ${index + 1}" aria-pressed="${axisLocked}">${axisLocked ? ICON_LINKED : ICON_UNLINKED}</button>
+        <input type="number" data-dpi-slot="${index}" data-dpi-axis="y" aria-label="Slot ${index + 1} Y DPI" min="${limits.minDpi}" max="${limits.maxDpi}" step="${limits.stepDpi}" value="${stage.y}"${locked || axisLocked ? " disabled" : ""} />
+        <div class="lod-select" data-lod-select="${index}">
+          <button type="button" class="lod-select-value" data-lod-toggle="${index}"${locked ? " disabled" : ""} aria-haspopup="listbox" aria-expanded="false" aria-label="Slot ${index + 1} lift-off"><span>${level ?? "—"}</span><i aria-hidden="true"></i></button>
+          <ul class="lod-select-menu" role="listbox" data-dpi-slot-lod="${index}" aria-label="Slot ${index + 1} lift-off">${lodOptions}</ul>
+        </div>
+      </div>`;
+    }).join("");
+    // Column headings once, rather than a label on every field: at this card
+    // width the repeated labels were squeezing the inputs they described.
+    list.insertAdjacentHTML("afterbegin",
+      `<div class="dpi-slot-row dpi-slot-head"><span></span><span>X</span><span></span><span>Y</span><span>Lift-off</span></div>`);
+  }
+
+  setText("#dpi-slot-note", locked
+    ? "Read-only: writing DPI slots to a profile is not enabled yet, because the flash write sequence has not been verified on hardware."
+    : `Each slot stores its own X/Y sensitivity and lift-off level. ${limits.minDpi}–${limits.maxDpi} DPI in steps of ${limits.stepDpi}. The highlighted slot is the one the mouse starts on.`);
+}
+
+async function reloadOnboardProfiles(): Promise<void> {
+  const client = activeClient;
+  if (!client || onboardProfilesLoading) return;
+  onboardProfilesLoading = true;
+  setText("#onboard-status", "Reading onboard profiles…");
+  try {
+    onboardProfiles = await client.readOnboardProfiles();
+    renderOnboardProfiles();
+  } catch (error) {
+    recordDiagnosticError(error, "Unable to read onboard profiles.");
+    setText("#onboard-status", error instanceof Error ? error.message : "Unable to read onboard profiles.");
+  } finally {
+    onboardProfilesLoading = false;
+  }
+}
+
+/**
+ * Whether the profile list is expanded. Deliberately sticky: opening a profile
+ * to edit it does not collapse the list, so several can be compared or switched
+ * between without reopening it each time.
+ */
+let profilesExpanded = false;
+
+function toggleProfilesExpanded(): void {
+  profilesExpanded = !profilesExpanded;
+  renderProfileSummary();
+  syncDisclosureHeight();
+}
+
+/**
+ * Drives the open/close animation from the content's measured height.
+ *
+ * Called after the list is rendered, not before, so growing or shrinking the
+ * list while it is open animates to the new size instead of keeping a stale one.
+ */
+function syncDisclosureHeight(): void {
+  const body = document.querySelector<HTMLElement>("#profile-disclosure-body");
+  const inner = document.querySelector<HTMLElement>(".profile-disclosure-inner");
+  if (!body || !inner) return;
+  body.style.maxHeight = profilesExpanded ? `${inner.scrollHeight}px` : "0px";
+}
+
+/** Describes one entry the way the collapsed summary shows it. */
+function describeProfileEntry(entry: OnboardProfile | null): { name: string; detail: string } {
+  if (!entry) {
+    return {
+      name: `Host${lastDeviceMode === "Host" ? " · active" : ""}`,
+      detail: "Live settings, not stored on the mouse",
+    };
+  }
+  const dpi = entry.dpiStages.length > 0
+    ? `${entry.dpiStages.length} DPI slot${entry.dpiStages.length === 1 ? "" : "s"}`
+    : "no DPI slots";
+  const rate = entry.reportRateWireless ? `${entry.reportRateWireless.toLocaleString()} Hz` : "—";
+  return {
+    name: `${entry.name ?? `Profile ${entry.sector}`}${entry.isCurrent && lastDeviceMode !== "Host" ? " · active" : ""}`,
+    detail: [dpi, rate, entry.enabled ? null : "disabled"].filter(Boolean).join(" · "),
+  };
+}
+
+function renderProfileSummary(): void {
+  const section = document.querySelector<HTMLElement>("#logitech-onboard");
+  const toggle = document.querySelector<HTMLButtonElement>("#profile-disclosure-toggle");
+  if (!section || !toggle) return;
+  section.classList.toggle("is-open", profilesExpanded);
+  toggle.setAttribute("aria-expanded", String(profilesExpanded));
+
+  const { name, detail } = describeProfileEntry(editedProfileEntry());
+  setText("#profile-summary-name", name);
+  setText("#profile-summary-detail", detail);
+}
+
+function renderOnboardProfiles(): void {
+  // Runs first so the row hides itself when no profile is loaded.
+  syncEditedProfile();
+  renderBunnyHop();
+  syncDpiSlotPlan();
+  renderDpiSlots();
+  renderProfileRates();
+  renderProfileSummary();
+  const list = document.querySelector<HTMLElement>("#onboard-profile-list");
+  if (!list) return;
+  if (!onboardProfiles) {
+    list.innerHTML = "";
+    return;
+  }
+  if (onboardProfiles.length === 0) {
+    list.innerHTML = "";
+    setText("#onboard-status", "This mouse reported no onboard profiles.");
+    return;
+  }
+
+  // Two independent states: which entry is open for editing, and what the mouse
+  // is actually running. Opening host must not change what is marked active.
+  const hostOpened = editedProfile === "host";
+  const hostRunning = lastDeviceMode === "Host";
+  const profileLayoutVerified = lastProfileFormat?.verified === true;
+  const profileNameLimit = lastProfileFormat ? capabilitiesForFormat(lastProfileFormat.id).maxNameLength : null;
+  // Host is a live, volatile source rather than a stored profile, so it is
+  // listed apart from them rather than mixed in.
+  // Host gets the same split as a profile row: open it to see its settings,
+  // use the circle to actually put the mouse into host mode.
+  const hostTags = [hostRunning ? "active" : null, hostOpened ? "editing" : null].filter(Boolean).join(" · ");
+  const hostRow = `<div style="display:flex;gap:.55rem;align-items:center;padding:.45rem .6rem;border:1px solid ${hostOpened ? "#4a4a52" : "#26262a"};border-radius:7px;background:${hostOpened ? "#1b1b1f" : "#141416"}">
+      <button type="button" data-onboard-profile="host" title="Open host settings" style="display:flex;gap:.55rem;align-items:center;flex:1;min-width:0;text-align:left;background:none;border:0;padding:0;cursor:pointer">
+        <span class="device-dot${hostRunning ? "" : " is-idle"}"></span>
+        <span class="profile-row-text" style="display:flex;flex-direction:column;min-width:0">
+          <strong style="font-size:.72rem;color:#e6e6ea">Host — live${hostTags ? ` · ${hostTags}` : ""}</strong>
+          <small style="color:#77777c;font-size:.62rem">Settings applied by software, not stored on the mouse. Lost on power-cycle.</small>
+        </span>
+      </button>
+      <button type="button" data-onboard-mode="Host" ${hostRunning ? "disabled" : ""} title="${hostRunning ? "The mouse is already in host mode" : "Switch the mouse to host mode"}" aria-label="Switch to host mode" aria-pressed="${hostRunning}" style="display:flex;padding:.3rem;border:1px solid ${hostRunning ? "#4a4a52" : "#3a3a3f"};border-radius:5px;background:#19191c;cursor:${hostRunning ? "not-allowed" : "pointer"}">
+        ${hostRunning ? ICON_RUNNING : ICON_ACTIVATE}
+      </button>
+    </div>
+    <div style="display:flex;align-items:center;gap:.5rem;margin:.15rem 0 .05rem"><span style="height:1px;flex:1;background:#26262a"></span><small style="color:#5c5c62;font-size:.58rem;letter-spacing:.04em">STORED ON THE MOUSE</small><span style="height:1px;flex:1;background:#26262a"></span></div>
+    <small style="display:block;margin:0 0 .2rem;color:#5c5c62;font-size:.58rem">Click a profile to edit it. Use the circle to switch the mouse to it.</small>`;
+
+  list.innerHTML = hostRow + onboardProfiles.map((profile) => {
+    const dpi = profile.dpiStages.length > 0
+      ? profile.dpiStages.map((stage) => (stage.x === stage.y ? `${stage.x}` : `${stage.x}/${stage.y}`)).join(" · ")
+      : "no DPI stages";
+    const rate = profile.reportRateWireless ? `${profile.reportRateWireless.toLocaleString()} Hz` : "—";
+    const detail = [
+      `${dpi} DPI`,
+      rate,
+      profile.enabled ? "enabled" : "disabled",
+      profile.crcValid ? null : "checksum mismatch",
+    ].filter(Boolean).join(" · ");
+    // An unverified layout may be decoding the wrong bytes entirely, so the
+    // values are shown but nothing may act on them.
+    const locked = !profileLayoutVerified;
+    // Being open for editing and being the profile the mouse runs are separate
+    // states: you can change any stored profile without switching to it.
+    const opened = editedProfile === profile.sector;
+    const nameable = profileNameLimit !== null;
+    const running = profile.isCurrent && !hostRunning;
+    const border = opened ? "#4a4a52" : "#26262a";
+    const tags = [running ? "active" : null, opened ? "editing" : null].filter(Boolean).join(" · ");
+    return `<div style="display:flex;gap:.55rem;align-items:center;padding:.45rem .6rem;border:1px solid ${border};border-radius:7px;background:${opened ? "#1b1b1f" : "#141416"};opacity:${profile.enabled ? "1" : ".55"}">
+      <button type="button" data-onboard-profile="${profile.sector}" ${locked ? "disabled" : ""} title="${locked ? "This profile layout has not been verified on hardware" : "Open this profile to edit it"}" style="display:flex;gap:.55rem;align-items:center;flex:1;min-width:0;text-align:left;background:none;border:0;padding:0;cursor:${locked ? "not-allowed" : "pointer"}">
+        <span class="device-dot${running ? "" : " is-idle"}"></span>
+        <span class="profile-row-text" style="display:flex;flex-direction:column;min-width:0">
+          <strong style="font-size:.72rem;color:#e6e6ea">${escapeHtml((opened && stagedProfileName) || profile.name || `Profile ${profile.sector}`)}${tags ? ` · ${tags}` : ""}</strong>
+          <small style="color:#77777c;font-size:.62rem">${escapeHtml(detail)}</small>
+        </span>
+      </button>
+      <button type="button" data-profile-rename="${profile.sector}" ${locked || !nameable ? "disabled" : ""} title="${!nameable ? "This profile format has no name field" : "Rename this profile"}" aria-label="Rename profile ${profile.sector}" style="display:flex;padding:.3rem;border:1px solid #3a3a3f;border-radius:5px;background:#19191c;cursor:${locked || !nameable ? "not-allowed" : "pointer"};opacity:${locked || !nameable ? ".4" : "1"}">
+        ${ICON_RENAME}
+      </button>
+      <button type="button" data-profile-activate="${profile.sector}" ${locked || running || !profile.enabled ? "disabled" : ""} title="${running ? "The mouse is running this profile" : !profile.enabled ? "Enable this profile before switching to it" : "Switch the mouse to this profile"}" aria-label="Switch to profile ${profile.sector}" aria-pressed="${running}" style="display:flex;padding:.3rem;border:1px solid ${running ? "#4a4a52" : "#3a3a3f"};border-radius:5px;background:#19191c;cursor:${locked || running || !profile.enabled ? "not-allowed" : "pointer"};opacity:${locked || !profile.enabled ? ".4" : "1"}">
+        ${running ? ICON_RUNNING : ICON_ACTIVATE}
+      </button>
+      <button type="button" data-profile-enabled="${profile.sector}" data-enabled="${profile.enabled}" ${locked ? "disabled" : ""} title="${locked ? "This profile layout has not been verified on hardware" : profile.enabled ? "Disable this profile" : "Enable this profile"}" aria-label="${profile.enabled ? "Disable" : "Enable"} profile ${profile.sector}" style="display:flex;padding:.3rem;border:1px solid #3a3a3f;border-radius:5px;background:#19191c;cursor:${locked ? "not-allowed" : "pointer"};opacity:${locked ? ".4" : "1"}">
+        ${profile.enabled ? ICON_ENABLED : ICON_DISABLED}
+      </button>
+    </div>`;
+  }).join("");
+
+  if (!profileLayoutVerified) {
+    setText("#onboard-status", `Profile format ${lastProfileFormat?.id ?? "?"} has not been verified on hardware — shown for reference only, and locked. Send a capture so it can be confirmed.`);
+    syncDisclosureHeight();
+    return;
+  }
+  const active = onboardProfiles.find((profile) => profile.isCurrent);
+  setText("#onboard-status", hostOpened
+    ? "Running live from software. Stored profiles are unchanged."
+    : active
+      ? `Running from ${active.name ?? `slot ${active.sector}`}. Profile contents are read-only for now.`
+      : "Profile contents are read-only for now.");
+  // Last, so the animation measures the list that was just rendered.
+  syncDisclosureHeight();
+}
+
+
 function applyLogitechAnalogButtons(): void {
   if (!activeClient) return;
   const tuning = readAnalogTuning("both");
@@ -1611,33 +2796,48 @@ function applyLiftOffDistance(lod: NonNullable<MouseStatus["liftOffDistance"]>):
   });
 }
 
+/**
+ * Gaming surface and LightForce are two fields of one 0x8090 byte, so they are
+ * staged as a group and written together. Each apply sends the whole group's
+ * staged state; whichever runs is the last one staged.
+ */
+const MODE_STATUS_GROUP = "logitech-mode-status";
+let stagedGamingSurface: MouseStatus["gamingSurfaceMode"] = null;
+let stagedLightforce: MouseStatus["lightforceSwitchMode"] = null;
+
+async function writeStagedModeStatus(): Promise<void> {
+  if (!activeClient) throw new Error("The mouse is no longer connected.");
+  await activeClient.setModeStatus({
+    gamingSurface: stagedGamingSurface,
+    lightforce: stagedLightforce,
+  });
+}
+
 function applyGamingSurfaceMode(mode: NonNullable<MouseStatus["gamingSurfaceMode"]>): void {
   if (!activeClient) return;
+  stagedGamingSurface = mode;
   stageChange({
     key: "gaming-surface",
+    group: MODE_STATUS_GROUP,
     label: `Gaming surface ${mode.toLowerCase()}`,
     command: `Set gaming surface to ${mode}`,
     progress: `Setting gaming surface to ${mode.toLowerCase()}…`,
     preview: (status) => { status.gamingSurfaceMode = mode; },
-    apply: async () => {
-      if (!activeClient) throw new Error("The mouse is no longer connected.");
-      await activeClient.setGamingSurfaceMode(mode);
-    },
+    apply: writeStagedModeStatus,
   });
 }
 
 function applyLightforceSwitchMode(mode: NonNullable<MouseStatus["lightforceSwitchMode"]>): void {
   if (!activeClient) return;
+  stagedLightforce = mode;
   stageChange({
     key: "lightforce-switch-mode",
+    group: MODE_STATUS_GROUP,
     label: `LightForce ${mode.toLowerCase()}`,
     command: `Set LightForce switches to ${mode}`,
     progress: `Setting LightForce switches to ${mode.toLowerCase()}…`,
     preview: (status) => { status.lightforceSwitchMode = mode; },
-    apply: async () => {
-      if (!activeClient) throw new Error("The mouse is no longer connected.");
-      await activeClient.setLightforceSwitchMode(mode);
-    },
+    apply: writeStagedModeStatus,
   });
 }
 
@@ -1977,4 +3177,6 @@ if (notice) {
 } else {
   renderControl();
   if (isSuperstrikePreview) showSuperstrikePreview();
+  else if (isSlotsPreview) showSlotsPreview();
+  else if (previewMode !== null) void showFixturePreview(previewMode);
 }

--- a/src/control.ts
+++ b/src/control.ts
@@ -89,6 +89,7 @@ import { TeevolutionHidClient } from "./devices/teevolution/hid";
 import { VgnF2HidClient } from "./devices/vgn/hid";
 import { SUPPORTED_HID_FILTERS } from "./devices/vendors";
 import { WLMouseHidClient } from "./devices/wlmouse/hid";
+import { parsePreviewMode, type PreviewMode } from "./preview-modes";
 
 const controlApp = document.querySelector<HTMLDivElement>("#control-app");
 
@@ -100,7 +101,7 @@ const appRoot = controlApp;
 
 const BUILD_LABEL = `${__BUILD_CHANNEL__.toUpperCase()} · v${__APP_VERSION__}`;
 const previewMode = import.meta.env.DEV
-  ? new URLSearchParams(window.location.search).get("preview")
+  ? parsePreviewMode(new URLSearchParams(window.location.search).get("preview"))
   : null;
 const isSuperstrikePreview = previewMode === "superstrike";
 /** Any `?preview=` value, so the HID listeners stay off in every preview. */
@@ -436,10 +437,6 @@ function renderControl(): void {
   renderStagedMarkers();
   populateInterfaceSettings();
   applyInterfacePreferences();
-  // Preview selection is intentionally URL-driven in development. This is not
-  // an authorization check: it only keeps fixture pages isolated from real
-  // hardware, while production builds force `previewMode` to null.
-  // codeql[js/user-controlled-bypass]
   if (!isAnyPreview) {
     navigator.hid?.addEventListener("connect", handleHidConnect);
     navigator.hid?.addEventListener("disconnect", handleHidDisconnect);
@@ -521,17 +518,20 @@ function showSlotsPreview(): void {
  * unknown. The shell decides what to show from MouseStatus alone, so this walks
  * the same rendering path the real driver would.
  */
-async function showFixturePreview(name: string): Promise<void> {
+async function showFixturePreview(name: PreviewMode): Promise<void> {
   // Loaded on demand so the fixtures never reach a production bundle, where
   // `previewMode` is always null and none of this is reachable.
   const { PREVIEW_FIXTURES, PREVIEW_KEYS } = await import("./preview-fixtures");
-  const fixture = PREVIEW_FIXTURES[name];
+  const fixture = name === "list" || name === "slots" || name === "superstrike"
+    ? undefined
+    : PREVIEW_FIXTURES[name];
   if (!fixture) {
     // `?preview=list` lands here on purpose: an index is more useful than an
     // error when you cannot remember the driver's key.
     const heading = document.querySelector<HTMLElement>("#empty-state-title");
     if (heading) heading.textContent = "Driver previews";
     const links = PREVIEW_KEYS
+      .filter((key) => key !== "list")
       .map((key) => `<a href="?preview=${key}" style="color:var(--ui-accent)">${key}</a>`)
       .join(" · ");
     const blurb = heading?.nextElementSibling;

--- a/src/control.ts
+++ b/src/control.ts
@@ -374,6 +374,7 @@ function renderControl(): void {
       populateInterfaceSettings();
     },
     downloadDiagnostics,
+    resetLogitechProfiles,
     chooseCustomDpi,
     sanitizeCustomDpi,
     finishCustomDpiEditing,
@@ -729,6 +730,15 @@ function configureProfileCapture(status: MouseStatus | null): void {
   const formatId = status?.onboardProfileFormat?.id ?? null;
   const captureOpen = document.querySelector<HTMLButtonElement>("#capture-open");
   if (captureOpen) captureOpen.hidden = logitechClient === null || formatId === null;
+  const resetButton = document.querySelector<HTMLButtonElement>("#reset-logitech-profiles");
+  if (resetButton) {
+    resetButton.hidden = logitechClient === null || formatId === null;
+    const supported = formatId === 7;
+    resetButton.disabled = settingInProgress || !supported;
+    resetButton.title = supported
+      ? "Permanently restore every onboard profile to Logitech defaults"
+      : `Factory defaults have not been captured for profile format ${formatId ?? "unknown"}`;
+  }
   setCaptureContext({
     device: activeDevice ? describeHidDevice(activeDevice) : status?.name ?? null,
     profileFormat: status?.onboardProfileFormat ? `${status.onboardProfileFormat.id} · ${status.onboardProfileFormat.name}` : null,
@@ -2595,6 +2605,52 @@ async function reloadOnboardProfiles(): Promise<void> {
     setText("#onboard-status", error instanceof Error ? error.message : "Unable to read onboard profiles.");
   } finally {
     onboardProfilesLoading = false;
+  }
+}
+
+async function resetLogitechProfiles(): Promise<void> {
+  const client = activeClient;
+  if (!client || settingInProgress || lastProfileFormat?.id !== 7) return;
+
+  const stagedWarning = hasPendingChanges()
+    ? "\n\nYour staged, unflashed changes will also be discarded."
+    : "";
+  const confirmed = window.confirm(
+    "Delete every onboard profile and restore Logitech defaults?\n\n"
+    + "This permanently erases all stored DPI stages, polling rates, lift-off distances, button assignments, G-Shift mappings, lighting, names, timeouts and every other byte in onboard profile memory. Fresh default profiles will be written back, with profile 1 as the only enabled profile. This cannot be undone in OpenMouse."
+    + stagedWarning,
+  );
+  if (!confirmed) return;
+
+  settingInProgress = true;
+  clearPendingChanges();
+  setText("#read-status", "Resetting every onboard profile…");
+  setText("#onboard-status", "Writing Logitech factory defaults…");
+  recordDiagnosticCommand("Reset every Logitech onboard profile to factory defaults");
+  configureProfileCapture(latestDeviceStatus);
+  try {
+    await client.resetAllOnboardProfiles();
+    onboardProfiles = await client.readOnboardProfiles();
+    editedProfile = onboardProfiles[0]?.sector ?? "host";
+    lastDeviceMode = "Onboard";
+    const status = await client.readStatus();
+    latestDeviceStatus = status;
+    deviceStatuses.set(client.device, status);
+    showStatus(status);
+    setText("#read-status", "All onboard profiles were reset to Logitech defaults.");
+    setText("#onboard-status", "Reset complete. Profile 1 is active; the other profiles are disabled.");
+  } catch (error) {
+    recordDiagnosticError(error, "Unable to reset every onboard profile.");
+    const message = error instanceof Error ? error.message : "Unable to reset every onboard profile.";
+    setText("#read-status", message);
+    setText("#onboard-status", message);
+    // Some earlier sectors may already have been written. Re-read the device so
+    // the UI never pretends an interrupted destructive operation was atomic.
+    onboardProfiles = null;
+    await reloadOnboardProfiles();
+  } finally {
+    endDeviceWrite();
+    configureProfileCapture(latestDeviceStatus);
   }
 }
 

--- a/src/devices/logitech/hidpp.test.ts
+++ b/src/devices/logitech/hidpp.test.ts
@@ -4,7 +4,9 @@ import test from "node:test";
 import {
   DEVICE_INDEX_DIRECT,
   DEVICE_INDEX_RECEIVER,
+  decodeBatteryLevelState,
   decodeReportRateBitmap,
+  decodeUnifiedBatteryState,
   hidppDeviceIndex,
   hidppErrorMessage,
   isDirectConnectProduct,
@@ -71,4 +73,29 @@ test("the legacy DPI fallback matches the grid G402 hardware advertises", () => 
   assert.equal(options.every((dpi, index) => index === 0 || dpi - options[index - 1] === 84), true);
   // The value the mouse reports while vendor software displays "2400".
   assert.equal(options.includes(2436), true);
+});
+
+test("the two battery features use different charging enums", () => {
+  // 0x1004 UNIFIED_BATTERY.
+  assert.equal(decodeUnifiedBatteryState(0x00), "Discharging");
+  assert.equal(decodeUnifiedBatteryState(0x01), "Charging");
+  assert.equal(decodeUnifiedBatteryState(0x02), "Charging slowly");
+  assert.equal(decodeUnifiedBatteryState(0x03), "Full");
+  // A charging fault is not any kind of charging.
+  assert.equal(decodeUnifiedBatteryState(0x04), "Unknown");
+
+  // 0x1000 BATTERY_LEVEL_STATUS numbers the same states differently.
+  assert.equal(decodeBatteryLevelState(0x00), "Discharging");
+  assert.equal(decodeBatteryLevelState(0x01), "Charging");
+  assert.equal(decodeBatteryLevelState(0x02), "Almost full");
+  assert.equal(decodeBatteryLevelState(0x03), "Full");
+  assert.equal(decodeBatteryLevelState(0x04), "Charging slowly");
+  // 5 invalid battery, 6 thermal error, 7 other charging error.
+  for (const code of [0x05, 0x06, 0x07]) {
+    assert.equal(decodeBatteryLevelState(code), "Unknown", `status ${code}`);
+  }
+
+  // The point of keeping them apart: 2 and 4 mean opposite things.
+  assert.notEqual(decodeUnifiedBatteryState(0x02), decodeBatteryLevelState(0x02));
+  assert.notEqual(decodeUnifiedBatteryState(0x04), decodeBatteryLevelState(0x04));
 });

--- a/src/devices/logitech/hidpp.test.ts
+++ b/src/devices/logitech/hidpp.test.ts
@@ -8,6 +8,8 @@ import {
   decodeReportRateBitmap,
   decodeUnifiedBatteryState,
   hidppDeviceIndex,
+  hidpp10ErrorMessage,
+  hidppErrorForRequest,
   hidppErrorMessage,
   isDirectConnection,
   isDirectConnectProduct,
@@ -70,6 +72,19 @@ test("HID++ error responses are reported with their documented reason", () => {
   assert.match(hidppErrorMessage(0x09), /unsupported/);
 });
 
+test("HID++ 1.0 error 0x0a is request unavailable", () => {
+  assert.match(hidpp10ErrorMessage(0x0a), /HID\+\+ 1\.0: request unavailable/);
+  assert.match(hidppErrorMessage(0x0a), /HID\+\+ 2\.0 error 0x0a/);
+});
+
+test("error frames are decoded by protocol and matched to their request", () => {
+  const hidpp10 = new Uint8Array([0xff, 0x8f, 0x0d, withSoftwareId(0x10), 0x0a]);
+  const hidpp20 = new Uint8Array([0x01, 0xff, 0x0d, withSoftwareId(0x10), 0x09]);
+  assert.match(hidppErrorForRequest(hidpp10, 0x0d, 0x10) ?? "", /HID\+\+ 1\.0: request unavailable/);
+  assert.match(hidppErrorForRequest(hidpp20, 0x0d, 0x10) ?? "", /unsupported/);
+  assert.equal(hidppErrorForRequest(hidpp10, 0x0e, 0x10), null, "another request's error must be ignored");
+});
+
 test("an unrecognised HID++ error still reports its raw code", () => {
   assert.match(hidppErrorMessage(0x7f), /0x7f/);
 });
@@ -108,20 +123,6 @@ test("the two battery features use different charging enums", () => {
   // The point of keeping them apart: 2 and 4 mean opposite things.
   assert.notEqual(decodeUnifiedBatteryState(0x02), decodeBatteryLevelState(0x02));
   assert.notEqual(decodeUnifiedBatteryState(0x04), decodeBatteryLevelState(0x04));
-});
-
-test("error 0x0a is explained rather than shown as a raw code", () => {
-  // Not in the HID++ 2.0 enum, which stops at 0x09 — it is the 1.0 code
-  // REQUEST_UNAVAILABLE, which a G102 returns when its mode forbids the write.
-  const message = hidppErrorMessage(0x0a);
-  assert.doesNotMatch(message, /0x0a/, "should not fall back to the raw code");
-  assert.match(message, /current mode/);
-
-  // The documented 2.0 codes keep their own wording.
-  assert.match(hidppErrorMessage(0x09), /unsupported/);
-  assert.match(hidppErrorMessage(0x02), /invalid argument/);
-  // Anything genuinely unknown still reports its code rather than inventing one.
-  assert.match(hidppErrorMessage(0x7f), /0x7f/);
 });
 
 test("an onboard-only mouse is told how to get itself supported", () => {

--- a/src/devices/logitech/hidpp.test.ts
+++ b/src/devices/logitech/hidpp.test.ts
@@ -9,7 +9,9 @@ import {
   decodeUnifiedBatteryState,
   hidppDeviceIndex,
   hidppErrorMessage,
+  isDirectConnection,
   isDirectConnectProduct,
+  OnboardOnlyError,
   legacyDpiFallback,
   withSoftwareId,
 } from "./protocol.ts";
@@ -39,6 +41,14 @@ test("receiver-attached and USB Superstrike devices keep index 0x01", () => {
     assert.equal(isDirectConnectProduct(productId), false);
     assert.equal(hidppDeviceIndex(productId), DEVICE_INDEX_RECEIVER);
   }
+});
+
+test("runtime probing classifies unknown wired mice as direct connections", () => {
+  const unknownG102ProductId = 0xc084;
+  assert.equal(isDirectConnectProduct(unknownG102ProductId), false);
+  assert.equal(isDirectConnection(unknownG102ProductId, DEVICE_INDEX_DIRECT), true);
+  assert.equal(isDirectConnection(unknownG102ProductId, DEVICE_INDEX_RECEIVER), false);
+  assert.equal(isDirectConnection(G402, null), true, "known PIDs still use the pre-probe fast path");
 });
 
 test("the legacy report-rate bitmap decodes the G402's advertised rates", () => {
@@ -98,4 +108,28 @@ test("the two battery features use different charging enums", () => {
   // The point of keeping them apart: 2 and 4 mean opposite things.
   assert.notEqual(decodeUnifiedBatteryState(0x02), decodeBatteryLevelState(0x02));
   assert.notEqual(decodeUnifiedBatteryState(0x04), decodeBatteryLevelState(0x04));
+});
+
+test("error 0x0a is explained rather than shown as a raw code", () => {
+  // Not in the HID++ 2.0 enum, which stops at 0x09 — it is the 1.0 code
+  // REQUEST_UNAVAILABLE, which a G102 returns when its mode forbids the write.
+  const message = hidppErrorMessage(0x0a);
+  assert.doesNotMatch(message, /0x0a/, "should not fall back to the raw code");
+  assert.match(message, /current mode/);
+
+  // The documented 2.0 codes keep their own wording.
+  assert.match(hidppErrorMessage(0x09), /unsupported/);
+  assert.match(hidppErrorMessage(0x02), /invalid argument/);
+  // Anything genuinely unknown still reports its code rather than inventing one.
+  assert.match(hidppErrorMessage(0x7f), /0x7f/);
+});
+
+test("an onboard-only mouse is told how to get itself supported", () => {
+  const known = new OnboardOnlyError(6);
+  assert.match(known.message, /profile format 6/);
+  assert.match(known.message, /Copy verification data/);
+  // Never claim a format number we did not read.
+  const unknown = new OnboardOnlyError(null);
+  assert.doesNotMatch(unknown.message, /format (\d|null)/);
+  assert.match(unknown.message, /Copy verification data/);
 });

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -6,7 +6,7 @@ import {
   decodeReportRateBitmap,
   decodeUnifiedBatteryState,
   hidppDeviceIndex,
-  hidppErrorMessage,
+  hidppErrorForRequest,
   isDirectConnection,
   isDirectConnectProduct,
   OnboardOnlyError,
@@ -228,13 +228,16 @@ export class LogitechHidppClient {
 
     // HID++ can emit a status notification between a write acknowledgement and
     // the matching read response. Leave the pending request in place and wait.
-    if (report[0] === this.deviceIndex && report[1] === 0xff) {
-      const failedIndex = this.waiters.findIndex(
-        (waiter) => report[2] === waiter.featureIndex && report[3] === withSoftwareId(waiter.functionId),
-      );
+    if (report[0] === this.deviceIndex && (report[1] === 0x8f || report[1] === 0xff)) {
+      let failure: string | null = null;
+      const failedIndex = this.waiters.findIndex((waiter) => {
+        failure = hidppErrorForRequest(report, waiter.featureIndex, waiter.functionId);
+        return failure !== null;
+      });
       if (failedIndex >= 0) {
-        this.waiters.splice(failedIndex, 1)[0].reject(new Error(hidppErrorMessage(report[4] ?? 0)));
+        this.waiters.splice(failedIndex, 1)[0].reject(new Error(failure ?? "The mouse rejected that request."));
       }
+      return;
     }
   };
 

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -1,6 +1,10 @@
 import type { MouseStatus } from "../mouse-types.ts";
 import {
+  DEVICE_INDEX_DIRECT,
+  DEVICE_INDEX_RECEIVER,
+  decodeBatteryLevelState,
   decodeReportRateBitmap,
+  decodeUnifiedBatteryState,
   hidppDeviceIndex,
   hidppErrorMessage,
   isDirectConnectProduct,
@@ -9,12 +13,106 @@ import {
 } from "./protocol.ts";
 import {
   MODE_STATUS,
-  buildModeStatusWrite,
+  buildModeStatusWriteMany,
   decodeModeStatus,
   type GamingSurfaceMode,
   type LightforceSwitchMode,
   type ModeStatusField,
 } from "./mode-status.ts";
+import {
+  ONBOARD_MODE,
+  PROFILE_FN,
+  applyCrc,
+  capabilitiesForFormat,
+  decodeLiftOffLevel,
+  decodeOnboardProfile,
+  describeProfileFormat,
+  encodeDpiStages,
+  encodeProfileName,
+  encodeReportRate,
+  validateDpiStagePlan,
+  type DpiStagePlan,
+  layoutForFormat,
+  parseDirectory,
+  parseProfilesInfo,
+  profileCrc,
+  setDirectoryEnabled,
+  storedCrc,
+  validateBunnyHoppingMs,
+  type OnboardProfile,
+  type ProfileFormatCapabilities,
+} from "./onboard-profiles.ts";
+
+export type { OnboardProfile };
+
+/** Raw, read-only evidence used to confirm an onboard-profile format. */
+export interface OnboardProfileVerification {
+  info: ReturnType<typeof parseProfilesInfo>;
+  infoReply: Uint8Array;
+  mode: "Onboard" | "Host" | "Unknown";
+  modeValue: number;
+  modeReply: Uint8Array;
+  currentSector: number;
+  currentProfileReply: Uint8Array;
+  directory: Uint8Array;
+  directoryCrcValid: boolean;
+  profiles: OnboardProfile[];
+}
+
+/**
+ * Master switch for writing DPI slots into profile flash.
+ *
+ * Enabled after probeProfileWriteSequence passed on a Pro X Superlight 2
+ * (format 7): writing a changed byte to sector 0x0002 appeared on read-back,
+ * and restoring it appeared too, both with valid checksums. That proves the
+ * memoryAddrWrite/memoryWrite/memoryWriteEnd sequence lands rather than being
+ * silently dropped. Run the probe again before trusting a new format.
+ */
+export const PROFILE_DPI_WRITES_ENABLED = true;
+
+export interface ProfileWriteProbeMismatch {
+  offset: number;
+  expected: number;
+  actual: number;
+}
+
+export interface ProfileWriteProbeStep {
+  name: string;
+  ok: boolean;
+  checksumValid: boolean;
+  mismatches: ProfileWriteProbeMismatch[];
+}
+
+export interface ProfileWriteProbe {
+  sector: number;
+  sectorSize: number;
+  offset: number;
+  originalByte: number;
+  probeByte: number;
+  steps: ProfileWriteProbeStep[];
+  ok: boolean;
+  restored: boolean;
+}
+
+/**
+ * A Logitech device that speaks HID++ but exposes no sensor, so it is not a
+ * mouse. Its own type so the shell can report it as a wrong choice rather than
+ * as a device that failed to read.
+ */
+/** No reply within the request window — nothing is listening on this index. */
+class HidppTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HidppTimeoutError";
+  }
+}
+
+export class NotAMouseError extends Error {
+  constructor(name: string) {
+    super(`${name} is not a mouse — it speaks Logitech's protocol but has no sensor to configure. Pick your mouse, or its receiver, instead.`);
+    this.name = "NotAMouseError";
+  }
+}
 
 const LOGITECH_VENDOR_ID = 0x046d;
 // HID++ control interfaces, including the PRO X 2 Superstrike USB interface.
@@ -25,6 +123,8 @@ const FEATURE = {
   deviceName: 0x0005,
   firmware: 0x0003,
   unifiedBattery: 0x1004,
+  // Pre-unified battery reporting, still the only one on HERO-era mice.
+  batteryStatus: 0x1000,
   batteryVoltage: 0x1001,
   adcMeasurement: 0x1f20,
   extendedDpi: 0x2202,
@@ -89,7 +189,12 @@ export class LogitechHidppClient {
   private rateFeatureResolved: ResolvedFeature | null = null;
   private reportRateFeatureIndex: number | null = null;
   private livePollingRateHz: number | null = null;
+  /** Discovered by resolveDeviceIndex; null until the mouse has answered. */
+  private resolvedDeviceIndex: number | null = null;
   private isSuperstrikeDevice = false;
+  /** Lift-off levels this device advertised; the single source of truth for both UI and validation. */
+  private lodCapabilities: ProfileFormatCapabilities = capabilitiesForFormat(null);
+  private supportedLods: Array<NonNullable<LogitechMouseStatus["liftOffDistance"]>> = ["Medium", "High"];
   private readonly rateChangeWaiters: Array<{ rate: number; resolve: () => void; reject: (reason: Error) => void }> = [];
   private readonly onInputReport = (event: HIDInputReportEvent): void => {
     if (event.reportId !== SHORT_REPORT_ID && event.reportId !== LONG_REPORT_ID) {
@@ -152,19 +257,62 @@ export class LogitechHidppClient {
 
   /** HID++ device index: the receiver's first slot, or the mouse itself. */
   private get deviceIndex(): number {
-    return hidppDeviceIndex(this.device.productId);
+    return this.resolvedDeviceIndex ?? hidppDeviceIndex(this.device.productId);
   }
 
-  static isSupported(device: HIDDevice): boolean {
-    if (device.vendorId !== LOGITECH_VENDOR_ID
-      || !(LOGITECH_RECEIVER_PRODUCT_IDS.has(device.productId) || isDirectConnectProduct(device.productId))) {
-      return false;
+  /**
+   * Finds which HID++ device index this connection answers on.
+   *
+   * A mouse reached through its receiver answers on the receiver's pairing slot
+   * (0x01); the same mouse plugged in by cable answers as itself (0xFF). That
+   * cannot be read from the descriptors, and deriving it from a list of product
+   * ids only works for the handful of ids on the list — every other mouse
+   * plugged in directly was addressed as a receiver and never replied.
+   *
+   * So ask. The root feature query is the cheapest request there is, and the
+   * wrong index simply times out.
+   */
+  private async resolveDeviceIndex(): Promise<void> {
+    if (this.resolvedDeviceIndex !== null) return;
+    // Start with whichever the product id suggests, so the common paths answer
+    // on the first try and only an unknown device pays for the second.
+    const first = hidppDeviceIndex(this.device.productId);
+    const candidates = first === DEVICE_INDEX_DIRECT
+      ? [DEVICE_INDEX_DIRECT, DEVICE_INDEX_RECEIVER]
+      : [DEVICE_INDEX_RECEIVER, DEVICE_INDEX_DIRECT];
+
+    for (const candidate of candidates) {
+      this.resolvedDeviceIndex = candidate;
+      // Any reply at all proves something is listening, including a HID++
+      // error reply. Only silence rules the index out.
+      const answered = await this.request(0x00, 0x00, FEATURE.firmware >> 8, FEATURE.firmware & 0xff)
+        .then(() => true)
+        .catch((error: unknown) => !(error instanceof HidppTimeoutError));
+      if (answered) return;
     }
+    this.resolvedDeviceIndex = null;
+    throw new Error("The mouse did not answer on any HID++ device index.");
+  }
+
+  /**
+   * Any Logitech device speaking HID++, not just the receivers we happen to
+   * have listed. Whether it is a *mouse* cannot be told from descriptors —
+   * keyboards and headsets use the same transport — so that is decided after
+   * connecting, by asking for a DPI feature. See readStatus.
+   */
+  static isSupported(device: HIDDevice): boolean {
+    if (device.vendorId !== LOGITECH_VENDOR_ID) return false;
     const hasHidppCollection = (collections: readonly HIDCollectionInfo[]): boolean =>
       collections.some((collection) =>
         (collection.usagePage === 0xff00 && collection.usage === 0x0001)
         || hasHidppCollection(collection.children));
     return hasHidppCollection(device.collections);
+  }
+
+  /** Known receivers, kept as the fast path for the WebHID picker's filters. */
+  static isKnownReceiver(device: HIDDevice): boolean {
+    return device.vendorId === LOGITECH_VENDOR_ID
+      && (LOGITECH_RECEIVER_PRODUCT_IDS.has(device.productId) || isDirectConnectProduct(device.productId));
   }
 
   static async requestReceiver(): Promise<LogitechHidppClient | null> {
@@ -196,13 +344,23 @@ export class LogitechHidppClient {
 
   async readStatus(): Promise<LogitechMouseStatus> {
     await this.open();
+    // Which index answers depends on how the mouse is attached, not on which
+    // mouse it is, so it is discovered once per connection before anything else.
+    await this.resolveDeviceIndex();
 
     const nameFeature = await this.getFeature(FEATURE.deviceName);
     const firmwareFeature = await this.getFeature(FEATURE.firmware);
     const batteryFeature = await this.getFeature(FEATURE.unifiedBattery);
+    const batteryStatusFeature = await this.getFeature(FEATURE.batteryStatus);
     const batteryVoltageFeature = await this.getFeature(FEATURE.batteryVoltage);
     const adcMeasurementFeature = await this.getFeature(FEATURE.adcMeasurement);
     const dpiFeature = await this.resolveDpiFeature();
+    // Keyboards, headsets and receivers for other devices all speak HID++, so
+    // the picker cannot filter them out by descriptor. A sensor feature is what
+    // actually distinguishes a mouse, and it is only knowable once connected.
+    if (!dpiFeature.index) {
+      throw new NotAMouseError(this.device.productName || "That Logitech device");
+    }
     const reportRateFeature = await this.resolveReportRateFeature();
     const profilesFeature = await this.getFeature(FEATURE.onboardProfiles);
     const analogButtonsFeature = await this.getFeature(FEATURE.analogButtons);
@@ -212,12 +370,16 @@ export class LogitechHidppClient {
     const name = await this.readName(nameFeature.index);
     const identity = await this.readIdentity(firmwareFeature.index);
     const battery = batteryFeature.index
+      // Ordered by how directly each reports charge: 0x1004 and 0x1000 give a
+      // percentage outright, while the voltage features only allow an estimate.
       ? await this.readBattery(batteryFeature.index)
-      : batteryVoltageFeature.index
-        ? await this.readBatteryVoltage(batteryVoltageFeature.index)
-        : adcMeasurementFeature.index
-          ? await this.readAdcMeasurement(adcMeasurementFeature.index)
-        : { percent: null, state: "Unknown" as const, voltageMv: null };
+      : batteryStatusFeature.index
+        ? await this.readBatteryLevelStatus(batteryStatusFeature.index)
+        : batteryVoltageFeature.index
+          ? await this.readBatteryVoltage(batteryVoltageFeature.index)
+          : adcMeasurementFeature.index
+            ? await this.readAdcMeasurement(adcMeasurementFeature.index)
+            : { percent: null, state: "Unknown" as const, voltageMv: null };
     if (batteryVoltageFeature.index && battery.voltageMv === undefined) {
       battery.voltageMv = (await this.readBatteryVoltage(batteryVoltageFeature.index)).voltageMv;
     } else if (adcMeasurementFeature.index && battery.voltageMv === undefined) {
@@ -242,8 +404,18 @@ export class LogitechHidppClient {
       : undefined;
     const modeStatusFeature = await this.getFeature(FEATURE.modeStatus);
     const modeStatus = modeStatusFeature.index ? await this.readModeStatus(modeStatusFeature.index) : null;
+    // One extra request; the layout it selects is worth surfacing in diagnostics.
+    const onboardProfileFormat = profilesFeature.index
+      ? await this.request(profilesFeature.index, PROFILE_FN.getInfo)
+        .then((reply) => describeProfileFormat(parseProfilesInfo(reply).profileFormatId))
+        .catch(() => null)
+      : null;
     const isSuperstrike = this.isSuperstrike(identity);
     this.isSuperstrikeDevice = isSuperstrike;
+    // Keyed on the reported profile format, not the model, so another mouse on
+    // the same format gets the same limits without being named here.
+    this.lodCapabilities = capabilitiesForFormat(onboardProfileFormat?.id);
+    this.supportedLods = [...this.lodCapabilities.supportedLods];
     const wired = this.device.productId === 0xc0a8 || this.isDirectConnect;
 
     return {
@@ -267,7 +439,8 @@ export class LogitechHidppClient {
       dpiY: dpiState.dpiY,
       supportsSeparateDpiAxes,
       analogButtonTuning,
-      liftOffDistance: dpiState.liftOffDistance,
+      liftOffDistance: decodeLiftOffLevel(dpiState.lod, this.lodCapabilities),
+      onboardProfileFormat,
       gamingSurfaceMode: modeStatus === null ? null : decodeModeStatus(modeStatus, MODE_STATUS.gamingSurface),
       lightforceSwitchMode: modeStatus === null ? null : decodeModeStatus(modeStatus, MODE_STATUS.lightforce),
       // The USB connection exposes the Superstrike as a 1 kHz device. Its
@@ -279,7 +452,9 @@ export class LogitechHidppClient {
       // Lift-off distance is only reachable through extended DPI (0x2202). On a
       // mouse that exposes just legacy 0x2201 there is nothing to drive, so
       // report an empty set rather than offering buttons that can only fail.
-      supportedLiftOffDistances: dpiFeature.legacy ? [] : isSuperstrike ? ["Low", "High"] : undefined,
+      // Otherwise the levels come from the profile format, which is where the
+      // count and the byte encoding are both established.
+      supportedLiftOffDistances: dpiFeature.legacy ? [] : this.supportedLods,
       connectionType: wired ? "Wired" : "Wireless",
       // Without this the shell falls back to its "2.4 GHz receiver" wording,
       // which is wrong for a mouse plugged straight into USB.
@@ -415,13 +590,12 @@ export class LogitechHidppClient {
   }
 
   async setLiftOffDistance(liftOffDistance: NonNullable<LogitechMouseStatus["liftOffDistance"]>): Promise<NonNullable<LogitechMouseStatus["liftOffDistance"]>> {
-    if (liftOffDistance === "Low" && !this.isSuperstrikeDevice) {
-      throw new Error("This mouse does not support a Low lift-off distance.");
+    // Validate against the levels this device advertised, so adding a model
+    // means describing it in readStatus rather than editing this check.
+    if (!this.supportedLods.includes(liftOffDistance)) {
+      throw new Error(`This mouse supports only ${this.supportedLods.join(" and ")} lift-off distance.`);
     }
-    if (liftOffDistance === "Medium" && this.isSuperstrikeDevice) {
-      throw new Error("The Superstrike supports only Low and High lift-off distance.");
-    }
-    const lod = ({ Low: 0, Medium: 1, High: 2 } as const)[liftOffDistance];
+    const lod = this.lodCapabilities.lodEncoding[liftOffDistance];
     await this.ensureHostControl();
     const feature = await this.getFeature(FEATURE.extendedDpi);
     if (!feature.index) {
@@ -437,7 +611,7 @@ export class LogitechHidppClient {
       lod,
     ]);
     const confirmed = await this.readDpiConfiguration(feature.index);
-    const result = confirmed.lod === 0 ? "Low" : confirmed.lod === 1 ? "Medium" : confirmed.lod === 2 ? "High" : null;
+    const result = decodeLiftOffLevel(confirmed.lod, this.lodCapabilities);
     if (result !== liftOffDistance) {
       throw new Error(`The mouse kept ${result ?? "an unknown"} lift-off distance instead of ${liftOffDistance}.`);
     }
@@ -475,24 +649,428 @@ export class LogitechHidppClient {
     }
   }
 
-  async setGamingSurfaceMode(mode: GamingSurfaceMode): Promise<GamingSurfaceMode> {
-    return this.setModeStatusField(MODE_STATUS.gamingSurface, mode, "gaming surface mode");
+  /**
+   * Switches the mouse between running from profile flash and being driven live
+   * by software. This is what G HUB's "Onboard Memory Mode" toggle does.
+   */
+  async setOnboardMode(mode: "Onboard" | "Host"): Promise<"Onboard" | "Host"> {
+    const feature = await this.getFeature(FEATURE.onboardProfiles);
+    if (!feature.index) {
+      throw new Error("This mouse does not expose onboard-profile controls.");
+    }
+    const target = mode === "Onboard" ? ONBOARD_MODE.onboard : ONBOARD_MODE.host;
+    await this.request(feature.index, PROFILE_FN.setMode, target);
+
+    const confirmed = (await this.request(feature.index, PROFILE_FN.getMode))[3];
+    if (confirmed !== target) {
+      throw new Error(`The mouse stayed in ${confirmed === ONBOARD_MODE.onboard ? "onboard" : "host"} mode.`);
+    }
+    return mode;
   }
 
-  async setLightforceSwitchMode(mode: LightforceSwitchMode): Promise<LightforceSwitchMode> {
-    return this.setModeStatusField(MODE_STATUS.lightforce, mode, "LightForce switch mode");
+  /** Switches which stored profile the mouse runs. Volatile — no flash write. */
+  async setCurrentProfile(sector: number): Promise<void> {
+    const feature = await this.getFeature(FEATURE.onboardProfiles);
+    if (!feature.index) {
+      throw new Error("This mouse does not expose onboard-profile controls.");
+    }
+    await this.request(feature.index, PROFILE_FN.setCurrentProfile, (sector >> 8) & 0xff, sector & 0xff);
   }
 
   /**
-   * Read-modify-write of one field of modeStatus1, then verify.
-   * The change mask stops the firmware touching other bits.
+   * Enables or disables a profile slot.
+   *
+   * WRITES FLASH. The directory sector is read, one flag byte changed, the
+   * checksum recomputed and the whole sector written back — one erase/write
+   * cycle per call. See docs/logitech-onboard-profiles.md. The write sequence
+   * itself has not been verified on hardware; callers should confirm with the
+   * user first.
+   */
+  async setProfileEnabled(sector: number, enabled: boolean): Promise<void> {
+    const feature = await this.getFeature(FEATURE.onboardProfiles);
+    if (!feature.index) {
+      throw new Error("This mouse does not expose onboard-profile controls.");
+    }
+    const info = parseProfilesInfo(await this.request(feature.index, PROFILE_FN.getInfo));
+    const format = describeProfileFormat(info.profileFormatId);
+    if (!format.verified) {
+      throw new Error(`Profile format ${format.id} has not been verified on hardware; refusing to write.`);
+    }
+    const sectorSize = info.sectorSize > 0 && info.sectorSize <= 1024 ? info.sectorSize : 255;
+
+    const directory = await this.readProfileSector(feature.index, 0x0000, sectorSize);
+    if (profileCrc(directory) !== storedCrc(directory)) {
+      throw new Error("The profile directory failed its checksum; refusing to write.");
+    }
+    const updated = setDirectoryEnabled(directory, sector, enabled);
+    if (updated.every((byte, index) => byte === directory[index])) {
+      return; // already in the requested state: never spend a write cycle on a no-op
+    }
+
+    await this.writeProfileSector(feature.index, 0x0000, updated);
+
+    const confirmed = await this.readProfileSector(feature.index, 0x0000, sectorSize);
+    const entry = parseDirectory(confirmed).find((candidate) => candidate.sector === sector);
+    if (!entry || entry.enabled !== enabled) {
+      throw new Error("The mouse did not confirm the new profile state.");
+    }
+  }
+
+  /**
+   * Sets the bunny-hop timeout on the active profile.
+   *
+   * WRITES FLASH — one erase/write cycle. Stored as ms / 10, with 0 meaning
+   * off; G HUB's range is 100-1000 ms. The encoding is confirmed on hardware,
+   * but the write sequence itself is not, so callers should confirm first.
+   */
+  /**
+   * Reads the active profile and the context needed to write it back. Every
+   * profile write starts here so the format check, the checksum check and the
+   * sector-size fallback cannot drift apart between settings.
+   */
+  private async openActiveProfile(targetSector?: number): Promise<{
+    featureIndex: number;
+    sector: number;
+    sectorSize: number;
+    formatId: number;
+    profile: Uint8Array;
+  }> {
+    const feature = await this.getFeature(FEATURE.onboardProfiles);
+    if (!feature.index) {
+      throw new Error("This mouse does not expose onboard-profile controls.");
+    }
+    const info = parseProfilesInfo(await this.request(feature.index, PROFILE_FN.getInfo));
+    const format = describeProfileFormat(info.profileFormatId);
+    if (!format.verified) {
+      throw new Error(`Profile format ${format.id} has not been verified on hardware; refusing to write.`);
+    }
+
+    // A profile can be edited without the mouse being switched to it, so the
+    // caller names the sector; only the default follows the running profile.
+    let sector = targetSector;
+    if (sector === undefined) {
+      const active = await this.request(feature.index, PROFILE_FN.getCurrentProfile);
+      sector = ((active[3] ?? 0) << 8) | (active[4] ?? 0);
+    }
+    const sectorSize = info.sectorSize > 0 && info.sectorSize <= 1024 ? info.sectorSize : 255;
+
+    const profile = await this.readProfileSector(feature.index, sector, sectorSize);
+    if (profileCrc(profile) !== storedCrc(profile)) {
+      throw new Error("The profile failed its checksum; refusing to write.");
+    }
+    return { featureIndex: feature.index, sector, sectorSize, formatId: format.id, profile };
+  }
+
+  /**
+   * Writes every changed setting of the active profile in one sector write.
+   *
+   * Flash is erased a whole sector at a time, so settings that share the sector
+   * must be applied together: writing them one at a time would cost an erase
+   * cycle each, and each write would be built from a read the previous one had
+   * already invalidated.
+   */
+  async writeActiveProfile(values: {
+    bunnyHoppingMs?: number | null;
+    dpiStages?: DpiStagePlan | null;
+    reportRateWirelessHz?: number | null;
+    reportRateWiredHz?: number | null;
+    name?: string | null;
+    /** Defaults to the running profile when omitted. */
+    sector?: number;
+  }): Promise<void> {
+    const { featureIndex, sector, sectorSize, formatId, profile } = await this.openActiveProfile(values.sector);
+    let updated: Uint8Array = profile.slice();
+
+    if (values.bunnyHoppingMs !== null && values.bunnyHoppingMs !== undefined) {
+      const invalid = validateBunnyHoppingMs(values.bunnyHoppingMs);
+      if (invalid) throw new Error(invalid);
+      const offset = layoutForFormat(formatId).bunnyHopping;
+      if (offset === null) {
+        throw new Error("This profile format has no bunny-hop setting.");
+      }
+      updated[offset] = values.bunnyHoppingMs / 10;
+    }
+
+    if (values.dpiStages) {
+      const invalid = validateDpiStagePlan(values.dpiStages, capabilitiesForFormat(formatId).dpiStages);
+      if (invalid) throw new Error(invalid);
+      updated = encodeDpiStages(updated, formatId, values.dpiStages);
+    }
+
+    // The two links are stored separately, so each is set on its own.
+    if (values.reportRateWirelessHz) {
+      updated = encodeReportRate(updated, formatId, "wireless", values.reportRateWirelessHz);
+    }
+    if (values.reportRateWiredHz) {
+      updated = encodeReportRate(updated, formatId, "wired", values.reportRateWiredHz);
+    }
+
+    if (values.name !== null && values.name !== undefined) {
+      updated = encodeProfileName(updated, formatId, values.name);
+    }
+
+    applyCrc(updated);
+    // Encoding is deterministic, so an identical result means nothing changed
+    // and the write cycle can be skipped entirely.
+    if (updated.every((byte, index) => byte === profile[index])) return;
+
+    await this.writeProfileSector(featureIndex, sector, updated);
+    const confirmed = await this.readProfileSector(featureIndex, sector, sectorSize);
+    if (!confirmed.every((byte, index) => byte === updated[index])) {
+      throw new Error("The mouse did not store the profile as written.");
+    }
+  }
+
+  async setBunnyHoppingMs(milliseconds: number): Promise<void> {
+    await this.writeActiveProfile({ bunnyHoppingMs: milliseconds });
+  }
+
+  async setProfileDpiStages(plan: DpiStagePlan): Promise<void> {
+    await this.writeActiveProfile({ dpiStages: plan });
+  }
+
+  /**
+   * memoryAddrWrite declares the destination and length, memoryWrite streams
+   * 16 bytes at a time, memoryWriteEnd commits and validates the checksum.
+   */
+  private async writeProfileSector(featureIndex: number, sector: number, bytes: Uint8Array): Promise<void> {
+    await this.requestLong(featureIndex, PROFILE_FN.memoryAddrWrite, [
+      (sector >> 8) & 0xff,
+      sector & 0xff,
+      0x00,
+      0x00,
+      (bytes.length >> 8) & 0xff,
+      bytes.length & 0xff,
+    ]);
+
+    for (let offset = 0; offset < bytes.length; offset += 16) {
+      const chunk = new Uint8Array(16).fill(0xff);
+      chunk.set(bytes.slice(offset, offset + 16));
+      await this.requestLong(featureIndex, PROFILE_FN.memoryWrite, [...chunk]);
+    }
+
+    await this.request(featureIndex, PROFILE_FN.memoryWriteEnd);
+  }
+
+  /**
+   * Proves the profile write sequence on hardware.
+   *
+   * A no-op rewrite would be useless: writing a sector's own bytes back reads
+   * identical whether the write landed or was silently ignored. So this flips
+   * one byte, checks the change actually appears, then restores it and checks
+   * the restore appears too. Both halves must pass.
+   *
+   * The target is an unused sector — disabled, and never the active profile —
+   * so nothing the user relies on is at risk, and the original bytes are held
+   * in memory for restore if a step fails midway. Cost is two erase cycles of
+   * roughly 100,000, on a sector that is not in use.
+   */
+  async probeProfileWriteSequence(): Promise<ProfileWriteProbe> {
+    await this.open();
+    const feature = await this.getFeature(FEATURE.onboardProfiles);
+    if (!feature.index) {
+      throw new Error("This mouse does not expose onboard-profile controls.");
+    }
+    const info = parseProfilesInfo(await this.request(feature.index, PROFILE_FN.getInfo));
+    const sectorSize = info.sectorSize > 0 && info.sectorSize <= 1024 ? info.sectorSize : 255;
+
+    const active = await this.request(feature.index, PROFILE_FN.getCurrentProfile);
+    const currentSector = ((active[3] ?? 0) << 8) | (active[4] ?? 0);
+    const directory = parseDirectory(await this.readProfileSector(feature.index, 0x0000, sectorSize));
+    const target = directory.find((entry) => !entry.enabled && entry.sector !== currentSector);
+    if (!target) {
+      throw new Error(
+        "No spare profile to test on. Disable a profile you are not using, then run this again.",
+      );
+    }
+
+    const original = await this.readProfileSector(feature.index, target.sector, sectorSize);
+    if (profileCrc(original) !== storedCrc(original)) {
+      throw new Error("The spare profile failed its checksum; refusing to write to it.");
+    }
+
+    // Padding is the safest byte to disturb: it carries no setting, and if the
+    // restore fails the profile is disabled anyway.
+    let offset = -1;
+    for (let index = original.length - 3; index >= 0; index -= 1) {
+      if (original[index] === 0xff) { offset = index; break; }
+    }
+    if (offset < 0) offset = original.length - 3;
+    const originalByte = original[offset] ?? 0xff;
+    const probeByte = originalByte ^ 0x01;
+
+    const probe = original.slice();
+    probe[offset] = probeByte;
+    applyCrc(probe);
+
+    const steps: ProfileWriteProbeStep[] = [];
+    const runStep = async (name: string, expected: Uint8Array): Promise<boolean> => {
+      await this.writeProfileSector(feature.index, target.sector, expected);
+      const readBack = await this.readProfileSector(feature.index, target.sector, sectorSize);
+      const mismatches: ProfileWriteProbeMismatch[] = [];
+      for (let index = 0; index < expected.length; index += 1) {
+        const want = expected[index] ?? 0;
+        const got = readBack[index] ?? 0;
+        if (want !== got && mismatches.length < 16) mismatches.push({ offset: index, expected: want, actual: got });
+      }
+      const checksumValid = profileCrc(readBack) === storedCrc(readBack);
+      steps.push({ name, ok: mismatches.length === 0 && checksumValid, checksumValid, mismatches });
+      return mismatches.length === 0;
+    };
+
+    const changed = await runStep("write probe byte", probe);
+    const restored = await runStep("restore original", original);
+
+    return {
+      sector: target.sector,
+      sectorSize,
+      offset,
+      originalByte,
+      probeByte,
+      steps,
+      // Both halves matter: the first shows a write takes effect, the second
+      // shows it is repeatable and leaves the sector as it was found.
+      ok: changed && restored,
+      restored,
+    };
+  }
+
+  /**
+   * Reads and decodes every onboard profile. Deliberately not part of
+   * readStatus: a full pass is ~80 HID++ round trips, far too slow for the
+   * refresh loop, so the UI loads it on demand.
+   */
+  async readOnboardProfiles(): Promise<OnboardProfile[]> {
+    await this.open();
+    const feature = await this.getFeature(FEATURE.onboardProfiles);
+    if (!feature.index) return [];
+
+    const info = parseProfilesInfo(await this.request(feature.index, PROFILE_FN.getInfo));
+    if (!info.profileFormatId) return [];
+
+    const active = await this.request(feature.index, PROFILE_FN.getCurrentProfile);
+    const currentSector = ((active[3] ?? 0) << 8) | (active[4] ?? 0);
+    const sectorSize = info.sectorSize > 0 && info.sectorSize <= 1024 ? info.sectorSize : 255;
+
+    const directory = parseDirectory(await this.readProfileSector(feature.index, 0x0000, Math.min(sectorSize, 64)));
+    const profiles: OnboardProfile[] = [];
+    for (const entry of directory) {
+      const bytes = await this.readProfileSector(feature.index, entry.sector, sectorSize);
+      profiles.push(decodeOnboardProfile(bytes, info.profileFormatId, entry, entry.sector === currentSector));
+    }
+    return profiles;
+  }
+
+  /**
+   * Collects a self-contained, read-only dump for validating any profile
+   * format. Unlike readOnboardProfiles, this keeps the full directory and the
+   * raw protocol replies so a maintainer can verify geometry and parsing rather
+   * than trusting OpenMouse's current assumptions.
+   */
+  async readOnboardProfileVerification(): Promise<OnboardProfileVerification> {
+    await this.open();
+    const feature = await this.getFeature(FEATURE.onboardProfiles);
+    if (!feature.index) {
+      throw new Error("This mouse does not expose onboard-profile controls.");
+    }
+
+    const infoReply = await this.request(feature.index, PROFILE_FN.getInfo);
+    const info = parseProfilesInfo(infoReply);
+    if (!info.profileFormatId) {
+      throw new Error("The mouse did not report an onboard-profile format.");
+    }
+    const sectorSize = info.sectorSize > 0 && info.sectorSize <= 1024 ? info.sectorSize : 255;
+    const modeReply = await this.request(feature.index, PROFILE_FN.getMode);
+    const modeValue = modeReply[3] ?? 0;
+    const mode = modeValue === ONBOARD_MODE.onboard
+      ? "Onboard" as const
+      : modeValue === ONBOARD_MODE.host
+        ? "Host" as const
+        : "Unknown" as const;
+    const currentProfileReply = await this.request(feature.index, PROFILE_FN.getCurrentProfile);
+    const currentSector = ((currentProfileReply[3] ?? 0) << 8) | (currentProfileReply[4] ?? 0);
+
+    // The directory is evidence too: its flags establish which sectors exist,
+    // and its checksum confirms that the complete sector was read correctly.
+    const directory = await this.readProfileSector(feature.index, 0x0000, sectorSize);
+    const entries = parseDirectory(directory);
+    const profiles: OnboardProfile[] = [];
+    for (const entry of entries) {
+      const bytes = await this.readProfileSector(feature.index, entry.sector, sectorSize);
+      profiles.push(decodeOnboardProfile(bytes, info.profileFormatId, entry, entry.sector === currentSector));
+    }
+
+    return {
+      info,
+      infoReply,
+      mode,
+      modeValue,
+      modeReply,
+      currentSector,
+      currentProfileReply,
+      directory,
+      directoryCrcValid: profileCrc(directory) === storedCrc(directory),
+      profiles,
+    };
+  }
+
+  /**
+   * memoryRead returns 16 bytes per call and rejects a read running past the
+   * end of the sector, so a sector length that is not a multiple of 16 needs its
+   * tail fetched from `length - 16`, overlapping the previous chunk.
+   */
+  private async readProfileSector(featureIndex: number, sector: number, length: number): Promise<Uint8Array> {
+    const buffer = new Uint8Array(length);
+    const readChunk = async (offset: number): Promise<void> => {
+      const reply = await this.requestLong(featureIndex, PROFILE_FN.memoryRead, [
+        (sector >> 8) & 0xff,
+        sector & 0xff,
+        (offset >> 8) & 0xff,
+        offset & 0xff,
+      ]);
+      buffer.set(reply.slice(3, 3 + Math.min(16, length - offset)), offset);
+    };
+
+    let offset = 0;
+    for (; offset + 16 <= length; offset += 16) {
+      await readChunk(offset);
+    }
+    if (offset < length) {
+      await readChunk(length - 16);
+    }
+    return buffer;
+  }
+
+  async setGamingSurfaceMode(mode: GamingSurfaceMode): Promise<GamingSurfaceMode> {
+    await this.setModeStatus({ gamingSurface: mode });
+    return mode;
+  }
+
+  async setLightforceSwitchMode(mode: LightforceSwitchMode): Promise<LightforceSwitchMode> {
+    await this.setModeStatus({ lightforce: mode });
+    return mode;
+  }
+
+  /**
+   * Read-modify-write of modeStatus1, then verify. Both fields share the byte,
+   * so passing them together writes once instead of twice; the change mask
+   * stops the firmware touching bits neither field names.
    * Reading first keeps this correct if a future field spans bits we do not know about.
    */
-  private async setModeStatusField<T extends string>(
-    field: ModeStatusField<T>,
-    mode: T,
-    label: string,
-  ): Promise<T> {
+  async setModeStatus(values: {
+    gamingSurface?: GamingSurfaceMode | null;
+    lightforce?: LightforceSwitchMode | null;
+  }): Promise<void> {
+    const requested: Array<{ field: ModeStatusField<string>; mode: string; label: string }> = [];
+    if (values.gamingSurface) {
+      requested.push({ field: MODE_STATUS.gamingSurface, mode: values.gamingSurface, label: "gaming surface mode" });
+    }
+    if (values.lightforce) {
+      requested.push({ field: MODE_STATUS.lightforce, mode: values.lightforce, label: "LightForce switch mode" });
+    }
+    if (requested.length === 0) return;
+
+    const label = requested[0]?.label ?? "mode status";
     const feature = await this.getFeature(FEATURE.modeStatus);
     if (!feature.index) {
       throw new Error(`This mouse does not expose ${label} controls.`);
@@ -502,14 +1080,20 @@ export class LogitechHidppClient {
     if (current === null) {
       throw new Error(`The mouse did not report its current ${label}.`);
     }
-    await this.requestLong(feature.index, MODE_STATUS.set, buildModeStatusWrite(current, field, mode));
+    // Where the firmware persists 0x8090 is unknown, so it may cost a write
+    // cycle. Re-selecting the current value is a no-op worth skipping.
+    const changes = requested.filter((update) => decodeModeStatus(current, update.field) !== update.mode);
+    if (changes.length === 0) return;
+
+    await this.requestLong(feature.index, MODE_STATUS.set, buildModeStatusWriteMany(current, changes));
 
     const readBack = await this.readModeStatus(feature.index);
-    const confirmed = readBack === null ? null : decodeModeStatus(readBack, field);
-    if (confirmed !== mode) {
-      throw new Error(`The mouse kept ${confirmed ?? "an unknown"} ${label} instead of ${mode}.`);
+    for (const update of changes) {
+      const confirmed = readBack === null ? null : decodeModeStatus(readBack, update.field);
+      if (confirmed !== update.mode) {
+        throw new Error(`The mouse kept ${confirmed ?? "an unknown"} ${update.label} instead of ${update.mode}.`);
+      }
     }
-    return confirmed;
   }
 
   /** Byte 4 of getModeStatus, carrying both the surface and LightForce fields. */
@@ -550,18 +1134,14 @@ export class LogitechHidppClient {
   // --- Legacy Adjustable DPI (0x2201) ---------------------------------------
   // These mice expose a single sensor and no adjustable lift-off distance.
 
-  private async readLegacyDpi(featureIndex: number): Promise<{
-    dpi: number;
-    dpiY: number;
-    liftOffDistance: LogitechMouseStatus["liftOffDistance"];
-  }> {
+  private async readLegacyDpi(featureIndex: number): Promise<{ dpi: number; dpiY: number; lod: number | null }> {
     if (!featureIndex) {
       throw new Error("This Logitech mouse does not expose DPI controls.");
     }
     // getSensorDpi(sensor 0): reply data = [sensorIdx, dpiHi, dpiLo, defaultHi, defaultLo].
     const reply = await this.request(featureIndex, 0x20, 0x00);
     const dpi = ((reply[4] ?? 0) << 8) | (reply[5] ?? 0);
-    return { dpi, dpiY: dpi, liftOffDistance: null };
+    return { dpi, dpiY: dpi, lod: null };
   }
 
   private async readLegacyDpiList(featureIndex: number): Promise<number[]> {
@@ -668,17 +1248,40 @@ export class LogitechHidppClient {
     return new TextDecoder().decode(new Uint8Array(fragments));
   }
 
+  /**
+   * 0x1004 UNIFIED_BATTERY getStatus: [stateOfCharge, batteryLevel,
+   * chargingStatus, externalPower].
+   *
+   * The charging enum here is NOT the one 0x1000 uses, which is what this
+   * previously decoded: on 0x1004, 2 means charging slowly and 4 means a
+   * charging fault, where on 0x1000 those are "almost full" and "charging
+   * slowly". A slow charge was therefore reported as almost full.
+   */
   private async readBattery(featureIndex: number): Promise<BatteryReading> {
     const reply = await this.request(featureIndex, 0x10);
     const percentage = reply[3];
-    const state = ({
-      0x00: "Discharging",
-      0x01: "Charging",
-      0x02: "Almost full",
-      0x03: "Full",
-      0x04: "Charging slowly",
-    } as const)[reply[5] ?? -1] ?? "Unknown";
-    return { percent: percentage <= 100 ? percentage : null, state };
+    return {
+      percent: percentage <= 100 ? percentage : null,
+      state: decodeUnifiedBatteryState(reply[5] ?? -1),
+    };
+  }
+
+  /**
+   * 0x1000 BATTERY_LEVEL_STATUS getBatteryLevelStatus:
+   * [dischargeLevel, nextLevel, batteryStatus].
+   *
+   * Older mice expose only this. Without it they reported no battery at all,
+   * because the driver probed 0x1004, 0x1001 and 0x1f20 and nothing else.
+   */
+  private async readBatteryLevelStatus(featureIndex: number): Promise<BatteryReading> {
+    const reply = await this.request(featureIndex, 0x00);
+    const percentage = reply[3] ?? 0xff;
+    // A mouse that reports level in coarse steps sends 0 with a status, which
+    // is a real reading; only an out-of-range value means "no percentage".
+    return {
+      percent: percentage <= 100 ? percentage : null,
+      state: decodeBatteryLevelState(reply[5] ?? -1),
+    };
   }
 
   private async readBatteryVoltage(featureIndex: number): Promise<BatteryReading> {
@@ -728,16 +1331,15 @@ export class LogitechHidppClient {
     return 0;
   }
 
-  private async readDpi(featureIndex: number): Promise<{ dpi: number; dpiY: number; liftOffDistance: LogitechMouseStatus["liftOffDistance"] }> {
+  private async readDpi(featureIndex: number): Promise<{ dpi: number; dpiY: number; lod: number | null }> {
     if (!featureIndex) {
       throw new Error("This Logitech mouse does not expose extended DPI controls.");
     }
 
     const configuration = await this.readDpiConfiguration(featureIndex);
-    const dpi = configuration.x;
-    const lod = configuration.lod;
-    const liftOffDistance = lod === 0 ? "Low" : lod === 1 ? "Medium" : lod === 2 ? "High" : null;
-    return { dpi, dpiY: configuration.y, liftOffDistance };
+    // The raw byte is returned rather than a level: which byte means which
+    // level depends on the profile format, which is read later in readStatus.
+    return { dpi: configuration.x, dpiY: configuration.y, lod: configuration.lod };
   }
 
   private async readAnalogButtonTuning(featureIndex: number): Promise<AnalogButtonTuning> {
@@ -937,7 +1539,7 @@ export class LogitechHidppClient {
         if (index >= 0) {
           this.waiters.splice(index, 1);
         }
-        reject(new Error(this.isDirectConnect
+        reject(new HidppTimeoutError(this.isDirectConnect
           ? "The mouse did not answer. Close Logitech G HUB or Logitech Gaming Software, then try again."
           : "The mouse did not answer. Move it or click a button, then try again."));
       }, 6000);

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -7,7 +7,9 @@ import {
   decodeUnifiedBatteryState,
   hidppDeviceIndex,
   hidppErrorMessage,
+  isDirectConnection,
   isDirectConnectProduct,
+  OnboardOnlyError,
   legacyDpiFallback,
   withSoftwareId,
 } from "./protocol.ts";
@@ -192,6 +194,8 @@ export class LogitechHidppClient {
   private livePollingRateHz: number | null = null;
   /** Discovered by resolveDeviceIndex; null until the mouse has answered. */
   private resolvedDeviceIndex: number | null = null;
+  /** Last format read from 0x8100, so a refusal can name it. */
+  private profileFormatId: number | null = null;
   private isSuperstrikeDevice = false;
   /** Lift-off levels this device advertised; the single source of truth for both UI and validation. */
   private lodCapabilities: ProfileFormatCapabilities = capabilitiesForFormat(null);
@@ -253,7 +257,7 @@ export class LogitechHidppClient {
    * field initializers before the `device` parameter property is assigned.
    */
   private get isDirectConnect(): boolean {
-    return isDirectConnectProduct(this.device.productId);
+    return isDirectConnection(this.device.productId, this.resolvedDeviceIndex);
   }
 
   /** HID++ device index: the receiver's first slot, or the mouse itself. */
@@ -275,12 +279,14 @@ export class LogitechHidppClient {
    */
   private async resolveDeviceIndex(): Promise<void> {
     if (this.resolvedDeviceIndex !== null) return;
-    // Start with whichever the product id suggests, so the common paths answer
-    // on the first try and only an unknown device pays for the second.
-    const first = hidppDeviceIndex(this.device.productId);
-    const candidates = first === DEVICE_INDEX_DIRECT
-      ? [DEVICE_INDEX_DIRECT, DEVICE_INDEX_RECEIVER]
-      : [DEVICE_INDEX_RECEIVER, DEVICE_INDEX_DIRECT];
+    // Only a receiver forwards to a pairing slot; anything else is the mouse's
+    // own endpoint and answers as itself. Ordering by "is this a known
+    // receiver" rather than by the direct-connect id list matters for mice that
+    // are on neither list — a wired G102 is its own endpoint, and asking it as
+    // though it were behind a receiver is what made it look mode-locked.
+    const candidates = LOGITECH_RECEIVER_PRODUCT_IDS.has(this.device.productId)
+      ? [DEVICE_INDEX_RECEIVER, DEVICE_INDEX_DIRECT]
+      : [DEVICE_INDEX_DIRECT, DEVICE_INDEX_RECEIVER];
 
     for (const candidate of candidates) {
       this.resolvedDeviceIndex = candidate;
@@ -415,6 +421,7 @@ export class LogitechHidppClient {
     this.isSuperstrikeDevice = isSuperstrike;
     // Keyed on the reported profile format, not the model, so another mouse on
     // the same format gets the same limits without being named here.
+    this.profileFormatId = onboardProfileFormat?.id ?? null;
     this.lodCapabilities = capabilitiesForFormat(onboardProfileFormat?.id);
     this.supportedLods = [...this.lodCapabilities.supportedLods];
     const wired = this.device.productId === 0xc0a8 || this.isDirectConnect;
@@ -1551,10 +1558,16 @@ export class LogitechHidppClient {
     if (!profiles.index) return;
     const mode = await this.request(profiles.index, 0x20);
     if (mode[3] === 0x02) return;
-    await this.request(profiles.index, 0x10, 0x02);
-    const confirmed = await this.request(profiles.index, 0x20);
-    if (confirmed[3] !== 0x02) {
-      throw new Error("The mouse did not enter host-control mode.");
+
+    // Some mice refuse to hand control to software at all — a G102 answers this
+    // with "request unavailable". Writing anyway is not the answer: the setting
+    // would land in an onboard profile whose layout we have not decoded, so we
+    // would be changing bytes we do not understand. Stop, and say what would
+    // make it work.
+    const refused = await this.request(profiles.index, 0x10, 0x02).then(() => false, () => true);
+    const confirmed = refused ? null : await this.request(profiles.index, 0x20).catch(() => null);
+    if (refused || confirmed?.[3] !== 0x02) {
+      throw new OnboardOnlyError(this.profileFormatId);
     }
   }
 

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -30,6 +30,7 @@ import {
   encodeDpiStages,
   encodeProfileName,
   encodeReportRate,
+  factoryProfileForFormat,
   validateDpiStagePlan,
   type DpiStagePlan,
   layoutForFormat,
@@ -713,6 +714,88 @@ export class LogitechHidppClient {
     const entry = parseDirectory(confirmed).find((candidate) => candidate.sector === sector);
     if (!entry || entry.enabled !== enabled) {
       throw new Error("The mouse did not confirm the new profile state.");
+    }
+  }
+
+  /**
+   * Restores every onboard profile byte-for-byte to the vendor's captured
+   * defaults, then leaves only the first profile enabled and running.
+   *
+   * WRITES FLASH. Support is deliberately limited to a profile format and
+   * sector geometry for which a complete vendor reset was captured. Using a
+   * decoded subset here would leave unknown button or lighting settings behind.
+   */
+  async resetAllOnboardProfiles(): Promise<void> {
+    await this.open();
+    const feature = await this.getFeature(FEATURE.onboardProfiles);
+    if (!feature.index) {
+      throw new Error("This Logitech mouse does not expose onboard-profile controls.");
+    }
+
+    const info = parseProfilesInfo(await this.request(feature.index, PROFILE_FN.getInfo));
+    const sectorSize = info.sectorSize > 0 && info.sectorSize <= 1024 ? info.sectorSize : 255;
+    const factoryProfile = factoryProfileForFormat(info.profileFormatId, sectorSize);
+    if (!factoryProfile) {
+      throw new Error(`A complete factory reset has not been captured for profile format ${info.profileFormatId}.`);
+    }
+    if (profileCrc(factoryProfile) !== storedCrc(factoryProfile)) {
+      throw new Error("The built-in factory profile failed its checksum; refusing to write.");
+    }
+
+    const directory = await this.readProfileSector(feature.index, 0x0000, sectorSize);
+    if (profileCrc(directory) !== storedCrc(directory)) {
+      throw new Error("The profile directory failed its checksum; refusing to reset.");
+    }
+    const entries = parseDirectory(directory);
+    if (entries.length === 0) throw new Error("The mouse reported no onboard profiles to reset.");
+    const firstSector = entries[0].sector;
+
+    // Host mode keeps the mouse from loading a sector while it is being
+    // replaced. The operation deliberately finishes in the vendor-reset state:
+    // onboard mode, first sector current, and only that sector enabled.
+    await this.setOnboardMode("Host");
+    let finished = false;
+    try {
+      for (const entry of entries) {
+        const existing = await this.readProfileSector(feature.index, entry.sector, sectorSize);
+        if (!existing.every((byte, index) => byte === factoryProfile[index])) {
+          await this.writeProfileSector(feature.index, entry.sector, factoryProfile);
+        }
+        const confirmed = await this.readProfileSector(feature.index, entry.sector, sectorSize);
+        if (!confirmed.every((byte, index) => byte === factoryProfile[index])) {
+          throw new Error(`Profile ${entry.sector} did not confirm its factory reset.`);
+        }
+      }
+
+      // Make the future current profile selectable before disabling the others.
+      let updatedDirectory = setDirectoryEnabled(directory, firstSector, true);
+      if (!updatedDirectory.every((byte, index) => byte === directory[index])) {
+        await this.writeProfileSector(feature.index, 0x0000, updatedDirectory);
+      }
+      await this.request(feature.index, PROFILE_FN.setCurrentProfile, (firstSector >> 8) & 0xff, firstSector & 0xff);
+
+      for (const entry of entries) {
+        updatedDirectory = setDirectoryEnabled(updatedDirectory, entry.sector, entry.sector === firstSector);
+      }
+      if (!updatedDirectory.every((byte, index) => byte === directory[index])) {
+        await this.writeProfileSector(feature.index, 0x0000, updatedDirectory);
+      }
+      const confirmedDirectory = await this.readProfileSector(feature.index, 0x0000, sectorSize);
+      if (!confirmedDirectory.every((byte, index) => byte === updatedDirectory[index])) {
+        throw new Error("The mouse did not confirm the reset profile directory.");
+      }
+
+      await this.setOnboardMode("Onboard");
+      const current = await this.request(feature.index, PROFILE_FN.getCurrentProfile);
+      const currentSector = ((current[3] ?? 0) << 8) | (current[4] ?? 0);
+      if (currentSector !== firstSector) {
+        throw new Error("The profiles were reset, but the mouse did not select the first profile.");
+      }
+      finished = true;
+    } finally {
+      // A failed sector write must not strand the mouse in software-controlled
+      // host mode. Preserve the original error if recovery also fails.
+      if (!finished) await this.setOnboardMode("Onboard").catch(() => undefined);
     }
   }
 

--- a/src/devices/logitech/mode-status.ts
+++ b/src/devices/logitech/mode-status.ts
@@ -52,3 +52,24 @@ export function buildModeStatusWrite<T extends string>(
 ): number[] {
   return [0x00, encodeModeStatus(statusByte, field, mode), 0x00, field.mask];
 }
+
+export interface ModeStatusUpdate {
+  field: ModeStatusField<string>;
+  mode: string;
+}
+
+/**
+ * One write covering several fields of the byte, with the change mask naming
+ * every bit touched. Both settings here share modeStatus1, so writing them
+ * separately costs two writes to a byte whose persistence is unknown, and the
+ * second is built from a read the first already invalidated.
+ */
+export function buildModeStatusWriteMany(statusByte: number, updates: ModeStatusUpdate[]): number[] {
+  let value = statusByte;
+  let mask = 0;
+  for (const update of updates) {
+    value = encodeModeStatus(value, update.field, update.mode);
+    mask |= update.field.mask;
+  }
+  return [0x00, value, 0x00, mask];
+}

--- a/src/devices/logitech/onboard-profiles.test.ts
+++ b/src/devices/logitech/onboard-profiles.test.ts
@@ -17,6 +17,7 @@ import {
   encodeDpiStages,
   encodeProfileName,
   encodeReportRate,
+  factoryProfileForFormat,
   reportRatesFor,
   validateBunnyHoppingMs,
   validateProfileName,
@@ -219,6 +220,22 @@ test("our encoders reproduce each observed transition byte for byte", () => {
     const after = sectorState(OBSERVED_STATES[index]);
     assert.deepEqual([...reproduceProfile(before, after, 7)], [...after], `transition ${index}`);
   }
+});
+
+test("factory reset image is exact, CRC-valid and limited to captured geometry", () => {
+  const factory = factoryProfileForFormat(7, 255);
+  assert.ok(factory);
+  assert.deepEqual([...factory], [...SECTOR_2]);
+  assert.equal(profileCrc(factory), storedCrc(factory));
+  assert.equal(factoryProfileForFormat(7, 256), null);
+  assert.equal(factoryProfileForFormat(8, 255), null);
+});
+
+test("factory reset reproduces erased name, bunny-hop and G-Shift regions", () => {
+  // Captured from G HUB/Onboard Memory Manager resetting every profile. The
+  // configured sector becomes byte-identical to an untouched factory sector.
+  const reproduced = reproduceProfile(SECTOR_3, SECTOR_2, 7);
+  assert.deepEqual([...reproduced], [...SECTOR_2]);
 });
 
 test("bunny-hop timeout decodes as milliseconds", () => {

--- a/src/devices/logitech/onboard-profiles.test.ts
+++ b/src/devices/logitech/onboard-profiles.test.ts
@@ -1,0 +1,557 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyCrc,
+  decodeOnboardProfile,
+  parseDirectory,
+  parseProfilesInfo,
+  profileCrc,
+  reproduceProfile,
+  setDirectoryEnabled,
+  storedCrc,
+  capabilitiesForFormat,
+  clampBunnyHopMs,
+  clampDpi,
+  decodeLiftOffLevel,
+  encodeDpiStages,
+  encodeProfileName,
+  encodeReportRate,
+  reportRatesFor,
+  validateBunnyHoppingMs,
+  validateProfileName,
+  validateReportRate,
+  PROFILE_NAME_MAX_CHARS,
+  validateDpiStagePlan,
+} from "./onboard-profiles.ts";
+
+function bytes(hex: string): Uint8Array {
+  return new Uint8Array(hex.trim().split(/\s+/).map((byte) => parseInt(byte, 16)));
+}
+
+/** getOnboardProfilesInfo reply from a Pro X Superlight 2 (3-byte header + payload). */
+const INFO_REPLY = bytes("01 0d 00  01 07 01 05 01 05 10 00 ff 0a 04 00 00");
+
+/** Directory sector 0x0000: five profiles, only sector 3 enabled. */
+const DIRECTORY = bytes(`
+  00 01 00 ff 00 02 00 ff 00 03 01 ff 00 04 00 ff
+  00 05 00 ff ff ff ff ff ff ff ff ff ff ff ff ff
+`);
+
+/**
+ * Profile sector 3, the configured profile: named "myp", a single 1600 DPI
+ * stage, G-Shift bindings populated. 255 bytes, CRC 0x20c7.
+ */
+const SECTOR_3 = bytes(`
+  03 03 00 00 40 06 40 06 02 00 00 00 00 00 00 00
+  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  00 ff 00 ff ff 00 ff ff ff ff ff ff 3c 00 2c 01
+  80 01 00 01 80 01 00 02 80 01 00 04 80 01 00 08
+  80 01 00 10 ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  80 01 00 01 80 01 00 02 80 01 00 04 80 01 00 08
+  80 01 00 10 ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  6d 00 79 00 70 00 00 00 00 00 00 00 00 00 00 00
+  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  03 00 00 00 00 00 1f 40 00 00 00 03 00 00 00 00
+  00 1f 40 00 00 00 03 00 00 00 00 00 1f 40 32 00
+  00 03 00 00 00 00 00 1f 40 32 00 00 03 20 c7
+`);
+
+/** An untouched factory profile: no name, five default DPI stages. CRC 0x84db. */
+const SECTOR_2 = bytes(`
+  03 03 00 00 20 03 20 03 02 b0 04 b0 04 02 40 06
+  40 06 02 60 09 60 09 02 80 0c 80 0c 02 00 00 00
+  00 ff 00 ff ff ff ff ff ff ff ff ff 3c 00 2c 01
+  80 01 00 01 80 01 00 02 80 01 00 04 80 01 00 08
+  80 01 00 10 ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  03 00 00 00 00 00 1f 40 00 00 00 03 00 00 00 00
+  00 1f 40 00 00 00 03 00 00 00 00 00 1f 40 32 00
+  00 03 00 00 00 00 00 1f 40 32 00 00 03 84 db
+`);
+
+test("parses getOnboardProfilesInfo", () => {
+  assert.deepEqual(parseProfilesInfo(INFO_REPLY), {
+    memoryModelId: 1,
+    profileFormatId: 7,
+    profileCount: 5,
+    sectorCount: 16,
+    sectorSize: 255,
+  });
+});
+
+test("parses the profile directory and its enabled flags", () => {
+  const entries = parseDirectory(DIRECTORY);
+  assert.deepEqual(entries, [
+    { sector: 1, enabled: false },
+    { sector: 2, enabled: false },
+    { sector: 3, enabled: true },
+    { sector: 4, enabled: false },
+    { sector: 5, enabled: false },
+  ]);
+});
+
+test("CRC-16/CCITT-FALSE matches the checksum stored on hardware", () => {
+  assert.equal(SECTOR_3.length, 255);
+  assert.equal(storedCrc(SECTOR_3), 0x20c7);
+  assert.equal(profileCrc(SECTOR_3), 0x20c7);
+  assert.equal(storedCrc(SECTOR_2), 0x84db);
+  assert.equal(profileCrc(SECTOR_2), 0x84db);
+});
+
+test("decodes a configured profile", () => {
+  const profile = decodeOnboardProfile(SECTOR_3, 7, { sector: 3, enabled: true }, true);
+  assert.equal(profile.name, "myp");
+  assert.equal(profile.crcValid, true);
+  assert.equal(profile.enabled, true);
+  assert.equal(profile.isCurrent, true);
+  assert.deepEqual(profile.dpiStages, [{ x: 1600, y: 1600, lod: 2 }]);
+  assert.equal(profile.reportRateWireless, 1000);
+  assert.equal(profile.reportRateWired, 1000);
+  assert.equal(profile.powerSaveTimeoutSeconds, 60);
+  assert.equal(profile.powerOffTimeoutSeconds, 300);
+  assert.equal(profile.angleSnapping, false);
+});
+
+test("decodes an untouched factory profile", () => {
+  const profile = decodeOnboardProfile(SECTOR_2, 7, { sector: 2, enabled: false }, false);
+  assert.equal(profile.name, null, "an all-0xff name must not decode as text");
+  assert.equal(profile.crcValid, true);
+  assert.equal(profile.enabled, false);
+  // Little-endian DPI: 20 03 -> 800, not 8195.
+  assert.deepEqual(profile.dpiStages, [
+    { x: 800, y: 800, lod: 2 },
+    { x: 1200, y: 1200, lod: 2 },
+    { x: 1600, y: 1600, lod: 2 },
+    { x: 2400, y: 2400, lod: 2 },
+    { x: 3200, y: 3200, lod: 2 },
+  ]);
+  assert.equal(profile.defaultDpiIndex, 0);
+});
+
+test("toggling a directory entry rewrites only that flag, plus the CRC", () => {
+  // A full 255-byte directory sector with a valid checksum.
+  const directory = new Uint8Array(255).fill(0xff);
+  directory.set(DIRECTORY.slice(0, 20), 0);
+  applyCrc(directory);
+
+  const updated = setDirectoryEnabled(directory, 1, true);
+  assert.equal(parseDirectory(updated)[0].enabled, true);
+  assert.equal(profileCrc(updated), storedCrc(updated), "checksum must be recomputed");
+
+  // Only the flag byte and the two CRC bytes may differ.
+  const changed = [...updated].flatMap((byte, index) => (byte === directory[index] ? [] : [index]));
+  assert.deepEqual(changed, [2, 253, 254]);
+});
+
+test("toggling refuses a sector the directory does not list", () => {
+  const directory = applyCrc(new Uint8Array(255).fill(0xff));
+  assert.throws(() => setDirectoryEnabled(directory, 9, true), /not listed/);
+});
+
+/**
+ * A real capture: wireless polling was 8000 Hz (byte 0x00 = 0x06, CRC 0x6e7c)
+ * and G HUB changed it to 1000 Hz (0x03, CRC 0x20c7). Rebuilding the "before"
+ * state reproduces the checksum G HUB wrote for a sector we never dumped.
+ */
+test("the CRC reproduces a vendor-written checksum we never read", () => {
+  const before = SECTOR_3.slice();
+  before[0x00] = 0x06;
+  applyCrc(before);
+  assert.equal(storedCrc(before), 0x6e7c);
+});
+
+test("our encoders reproduce a vendor write byte for byte", () => {
+  const before = SECTOR_3.slice();
+  before[0x00] = 0x06;
+  applyCrc(before);
+
+  // Apply the change with our own encoding rather than copying bytes.
+  const reproduced = reproduceProfile(before, SECTOR_3, 7);
+  assert.deepEqual([...reproduced], [...SECTOR_3], "write path must match what G HUB produced");
+});
+
+/**
+ * States of sector 3 observed while G HUB changed one setting at a time. Only
+ * the first was ever dumped in full; the rest are reconstructed, so matching
+ * their checksums confirms the CRC independently each time.
+ */
+const OBSERVED_STATES: ReadonlyArray<{ rate: number; bunnyHopping: number; crc: number }> = [
+  { rate: 0x03, bunnyHopping: 0x00, crc: 0x20c7 },
+  { rate: 0x06, bunnyHopping: 0x00, crc: 0x6e7c },
+  { rate: 0x06, bunnyHopping: 0x0a, crc: 0xd92c },
+  { rate: 0x06, bunnyHopping: 0x14, crc: 0x10fd },
+];
+
+const ENTRY = { sector: 3, enabled: true };
+
+function sectorState(state: { rate: number; bunnyHopping: number }): Uint8Array {
+  const bytes = SECTOR_3.slice();
+  bytes[0x00] = state.rate;
+  bytes[0x25] = state.bunnyHopping;
+  return applyCrc(bytes);
+}
+
+test("the CRC matches every checksum G HUB wrote", () => {
+  for (const state of OBSERVED_STATES) {
+    assert.equal(
+      storedCrc(sectorState(state)),
+      state.crc,
+      `rate 0x${state.rate.toString(16)} bunny 0x${state.bunnyHopping.toString(16)}`,
+    );
+  }
+});
+
+test("our encoders reproduce each observed transition byte for byte", () => {
+  for (let index = 1; index < OBSERVED_STATES.length; index += 1) {
+    const before = sectorState(OBSERVED_STATES[index - 1]);
+    const after = sectorState(OBSERVED_STATES[index]);
+    assert.deepEqual([...reproduceProfile(before, after, 7)], [...after], `transition ${index}`);
+  }
+});
+
+test("bunny-hop timeout decodes as milliseconds", () => {
+  // Captured from G HUB: 100 ms stored as 0x0a, 200 ms as 0x14.
+  const at100 = decodeOnboardProfile(sectorState({ rate: 0x06, bunnyHopping: 0x0a }), 7, ENTRY, true);
+  const at200 = decodeOnboardProfile(sectorState({ rate: 0x06, bunnyHopping: 0x14 }), 7, ENTRY, true);
+  assert.equal(at100.bunnyHoppingMs, 100);
+  assert.equal(at200.bunnyHoppingMs, 200);
+
+  // G HUB's range is 100-1000 ms, so the byte tops out at 0x64.
+  const atMax = decodeOnboardProfile(sectorState({ rate: 0x06, bunnyHopping: 0x64 }), 7, ENTRY, true);
+  assert.equal(atMax.bunnyHoppingMs, 1000);
+
+  // Turning the feature off in G HUB stores 0x00, distinct from unwritten.
+  const off = decodeOnboardProfile(sectorState({ rate: 0x06, bunnyHopping: 0x00 }), 7, ENTRY, true);
+  assert.equal(off.bunnyHoppingMs, 0);
+
+  // Unwritten flash must not decode as a 2550 ms timeout.
+  const unwritten = decodeOnboardProfile(sectorState({ rate: 0x06, bunnyHopping: 0xff }), 7, ENTRY, true);
+  assert.equal(unwritten.bunnyHoppingMs, null);
+});
+
+test("turning bunny hopping off round-trips back to the earlier checksum", () => {
+  const on = sectorState({ rate: 0x06, bunnyHopping: 0x14 });
+  const off = sectorState({ rate: 0x06, bunnyHopping: 0x00 });
+  assert.equal(storedCrc(on), 0x10fd);
+  assert.equal(storedCrc(off), 0x6e7c, "off must return the sector to its earlier state");
+  assert.deepEqual([...reproduceProfile(on, off, 7)], [...off]);
+});
+
+test("bunny-hop times off the 10 ms step are rejected", () => {
+  assert.equal(validateBunnyHoppingMs(100), null);
+  assert.equal(validateBunnyHoppingMs(1000), null);
+  assert.equal(validateBunnyHoppingMs(0), null, "0 is off");
+
+  assert.match(validateBunnyHoppingMs(105) ?? "", /multiple of 10/);
+  assert.match(validateBunnyHoppingMs(100.5) ?? "", /whole number/);
+  assert.match(validateBunnyHoppingMs(Number.NaN) ?? "", /whole number/);
+  // In range but the byte cannot hold it, and out of range entirely.
+  assert.match(validateBunnyHoppingMs(50) ?? "", /between 100 and 1000/);
+  assert.match(validateBunnyHoppingMs(1010) ?? "", /between 100 and 1000/);
+});
+
+test("rewriting the DPI stages byte-for-byte leaves the sector unchanged", () => {
+  // The captured sector is the ground truth: decoding it and encoding the same
+  // values back must reproduce it exactly, checksum included.
+  const decoded = decodeOnboardProfile(SECTOR_3, 7, ENTRY, true);
+  assert.equal(decoded.defaultDpiIndex !== null, true);
+  const rewritten = encodeDpiStages(SECTOR_3, 7, {
+    stages: decoded.dpiStages,
+    defaultIndex: decoded.defaultDpiIndex ?? 0,
+  });
+  assert.deepEqual([...rewritten], [...SECTOR_3]);
+});
+
+/** The captured sector uses a single slot, so extra slots are built here. */
+const FIVE_STAGES = [
+  { x: 800, y: 800, lod: 1 },
+  { x: 1200, y: 1200, lod: 2 },
+  { x: 1600, y: 1600, lod: 2 },
+  { x: 2400, y: 2400, lod: 2 },
+  { x: 3200, y: 3200, lod: 3 },
+];
+
+test("every DPI slot round-trips through encode and decode", () => {
+  const filled = encodeDpiStages(SECTOR_3, 7, { stages: FIVE_STAGES, defaultIndex: 2 });
+  const decoded = decodeOnboardProfile(filled, 7, ENTRY, true);
+  assert.deepEqual(decoded.dpiStages, FIVE_STAGES);
+  assert.equal(decoded.defaultDpiIndex, 2);
+  assert.equal(storedCrc(filled), profileCrc(filled), "checksum reapplied");
+});
+
+test("dropping DPI slots zeroes the stages that fall out of use", () => {
+  const filled = encodeDpiStages(SECTOR_3, 7, { stages: FIVE_STAGES, defaultIndex: 0 });
+  const twoSlots = encodeDpiStages(filled, 7, { stages: FIVE_STAGES.slice(0, 2), defaultIndex: 0 });
+
+  // A stage is marked unused by zeroing x, y and lod together.
+  for (let stage = 2; stage < 5; stage += 1) {
+    const base = 0x02 + 2 + stage * 5;
+    assert.deepEqual([...twoSlots.slice(base, base + 5)], [0, 0, 0, 0, 0], `stage ${stage + 1}`);
+  }
+
+  // Reading it back reports exactly the slots that remain.
+  const reread = decodeOnboardProfile(twoSlots, 7, ENTRY, true);
+  assert.deepEqual(reread.dpiStages, FIVE_STAGES.slice(0, 2));
+  assert.equal(storedCrc(twoSlots), profileCrc(twoSlots), "checksum reapplied");
+});
+
+test("shrinking the slot count pulls the g-shift index back into range", () => {
+  const filled = encodeDpiStages(SECTOR_3, 7, { stages: FIVE_STAGES, defaultIndex: 0 });
+  const withGShift = filled.slice();
+  withGShift[0x03] = 4; // points at the last slot
+
+  // Left pointing at slot 5 it would select a stage this write just zeroed.
+  const oneSlot = encodeDpiStages(withGShift, 7, { stages: FIVE_STAGES.slice(0, 1), defaultIndex: 0 });
+  assert.equal(oneSlot[0x03], 0);
+
+  // A g-shift index still inside the slots in use is left alone.
+  const kept = encodeDpiStages(withGShift, 7, { stages: FIVE_STAGES, defaultIndex: 0 });
+  assert.equal(kept[0x03], 4);
+});
+
+test("bunny hop and DPI slots survive being written into one sector", () => {
+  // They share the profile sector, so a flash writes them together. Applying
+  // one must not discard the other, and the checksum must cover both.
+  const withBunnyHop = SECTOR_3.slice();
+  withBunnyHop[0x25] = 20; // 200 ms
+  const combined = encodeDpiStages(withBunnyHop, 7, { stages: FIVE_STAGES, defaultIndex: 1 });
+
+  const decoded = decodeOnboardProfile(combined, 7, ENTRY, true);
+  assert.equal(decoded.bunnyHoppingMs, 200, "the bunny-hop byte was not clobbered");
+  assert.deepEqual(decoded.dpiStages, FIVE_STAGES);
+  assert.equal(decoded.defaultDpiIndex, 1);
+  assert.equal(storedCrc(combined), profileCrc(combined));
+});
+
+test("bunny-hop support is a format trait, not a stored value", () => {
+  // A profile that never had bunny hop written reads 0xff there, which decodes
+  // to null. That must not be read as "the format has no bunny hop" — doing so
+  // hid the control on every profile the setting had not been used on.
+  const unwritten = SECTOR_3.slice();
+  unwritten[0x25] = 0xff;
+  applyCrc(unwritten);
+  assert.equal(decodeOnboardProfile(unwritten, 7, ENTRY, true).bunnyHoppingMs, null);
+  assert.equal(capabilitiesForFormat(7).bunnyHop, true, "format 7 still supports it");
+
+  assert.equal(capabilitiesForFormat(8).bunnyHop, true);
+  // Below 7 the byte does not exist at all.
+  assert.equal(capabilitiesForFormat(6).bunnyHop, false);
+  assert.equal(capabilitiesForFormat(null).bunnyHop, false);
+});
+
+test("report-rate ceilings differ per link and per format", () => {
+  const rates = capabilitiesForFormat(7).reportRates;
+  assert.deepEqual(rates, { wirelessMaxHz: 8000, wiredMaxHz: 1000 });
+
+  // The cable is the slower link, so it offers fewer options than the radio.
+  assert.deepEqual(reportRatesFor(rates, "wireless"), [125, 250, 500, 1000, 2000, 4000, 8000]);
+  assert.deepEqual(reportRatesFor(rates, "wired"), [125, 250, 500, 1000]);
+
+  assert.equal(validateReportRate(8000, rates, "wireless"), null);
+  assert.match(validateReportRate(8000, rates, "wired") ?? "", /Wired report rate/);
+  assert.equal(validateReportRate(1000, rates, "wired"), null);
+
+  // Formats whose ceilings were never captured offer nothing.
+  assert.equal(capabilitiesForFormat(8).reportRates, null);
+  assert.deepEqual(reportRatesFor(null, "wireless"), []);
+  assert.match(validateReportRate(1000, null, "wireless") ?? "", /not known/);
+});
+
+test("the two report-rate bytes match what the vendor tool writes", () => {
+  // Captured from the vendor tool on a Pro X Superlight 2 (format 7), sector 1,
+  // setting wireless to 8000 Hz and wired to 250 Hz:
+  //   0x00  03 -> 06   report_rate_wireless
+  //   0x01  03 -> 01   report_rate_wired
+  const before = SECTOR_3.slice();
+  before[0x00] = 0x03;
+  before[0x01] = 0x03;
+  applyCrc(before);
+
+  const after = encodeReportRate(encodeReportRate(before, 7, "wireless", 8000), 7, "wired", 250);
+  assert.equal(after[0x00], 0x06, "wireless index");
+  assert.equal(after[0x01], 0x01, "wired index");
+  // Every other byte of the profile is left exactly as it was.
+  for (let index = 2; index < after.length - 2; index += 1) {
+    assert.equal(after[index], before[index], `byte 0x${index.toString(16)}`);
+  }
+});
+
+test("each link's report rate is written without disturbing the other", () => {
+  const wireless = encodeReportRate(SECTOR_3, 7, "wireless", 4000);
+  const wired = encodeReportRate(wireless, 7, "wired", 500);
+
+  const decoded = decodeOnboardProfile(wired, 7, ENTRY, true);
+  assert.equal(decoded.reportRateWireless, 4000);
+  assert.equal(decoded.reportRateWired, 500);
+  assert.equal(storedCrc(wired), profileCrc(wired));
+
+  assert.throws(() => encodeReportRate(SECTOR_3, 7, "wired", 8000), /Wired report rate/);
+});
+
+test("profile names round-trip and are held to the region's size", () => {
+  const named = encodeProfileName(SECTOR_3, 7, "FPS");
+  assert.equal(decodeOnboardProfile(named, 7, ENTRY, true).name, "FPS");
+  assert.equal(storedCrc(named), profileCrc(named));
+
+  // A shorter name must not leave the tail of the previous one behind.
+  const shorter = encodeProfileName(encodeProfileName(SECTOR_3, 7, "LONG NAME HERE"), 7, "AB");
+  assert.equal(decodeOnboardProfile(shorter, 7, ENTRY, true).name, "AB");
+
+  assert.equal(PROFILE_NAME_MAX_CHARS, 23);
+  assert.equal(validateProfileName("x".repeat(23), 23), null);
+  assert.match(validateProfileName("x".repeat(24), 23) ?? "", /at most 23/);
+  assert.match(validateProfileName("   ", 23) ?? "", /Enter a profile name/);
+  // Astral characters take two UTF-16 units and would be split by the limit.
+  assert.match(validateProfileName("game 🎮", 23) ?? "", /emoji/);
+  assert.match(validateProfileName("x", null) ?? "", /no name field/);
+
+  const full = encodeProfileName(SECTOR_3, 7, "x".repeat(23));
+  assert.equal(decodeOnboardProfile(full, 7, ENTRY, true).name, "x".repeat(23));
+});
+
+test("DPI slot limits are per format, not global", () => {
+  const format7 = capabilitiesForFormat(7).dpiStages;
+  assert.deepEqual(format7, { maxStages: 5, minDpi: 100, maxDpi: 32000, stepDpi: 50 });
+
+  // Base v1 has no stage table, and no other format's range was ever captured,
+  // so slots must not be offered rather than borrowing format 7's numbers.
+  assert.equal(capabilitiesForFormat(8).dpiStages, null);
+  assert.equal(capabilitiesForFormat(1).dpiStages, null);
+  assert.equal(capabilitiesForFormat(6).dpiStages, null);
+  assert.equal(capabilitiesForFormat(null).dpiStages, null);
+
+  const stage = { x: 800, y: 800, lod: 1 };
+  assert.match(validateDpiStagePlan({ stages: [stage], defaultIndex: 0 }, null) ?? "", /not known/);
+  assert.throws(() => encodeDpiStages(SECTOR_3, 8, { stages: [stage], defaultIndex: 0 }), /not known/);
+
+  // A hypothetical older format with tighter limits is held to its own.
+  const narrow = { maxStages: 2, minDpi: 200, maxDpi: 4000, stepDpi: 100 };
+  assert.match(validateDpiStagePlan({ stages: Array(3).fill(stage), defaultIndex: 0 }, narrow) ?? "", /1 to 2/);
+  assert.match(validateDpiStagePlan({ stages: [{ ...stage, x: 8000 }], defaultIndex: 0 }, narrow) ?? "", /between 200 and 4000/);
+  assert.match(validateDpiStagePlan({ stages: [{ ...stage, x: 850 }], defaultIndex: 0 }, narrow) ?? "", /multiple of 100/);
+  assert.equal(validateDpiStagePlan({ stages: [{ x: 800, y: 800, lod: 1 }], defaultIndex: 0 }, narrow), null);
+
+  assert.equal(clampDpi(60, narrow), 200);
+  assert.equal(clampDpi(9000, narrow), 4000);
+  assert.equal(clampDpi(849, narrow), 800);
+  assert.equal(clampDpi(Number.NaN, narrow), 200);
+});
+
+test("unwritable DPI stage plans are rejected before they reach flash", () => {
+  const limits = capabilitiesForFormat(7).dpiStages;
+  const stage = { x: 800, y: 800, lod: 1 };
+  assert.equal(validateDpiStagePlan({ stages: [stage], defaultIndex: 0 }, limits), null);
+
+  assert.match(validateDpiStagePlan({ stages: [], defaultIndex: 0 }, limits) ?? "", /1 to 5/);
+  assert.match(validateDpiStagePlan({ stages: Array(6).fill(stage), defaultIndex: 0 }, limits) ?? "", /1 to 5/);
+  assert.match(validateDpiStagePlan({ stages: [stage], defaultIndex: 1 }, limits) ?? "", /default slot/);
+
+  assert.match(validateDpiStagePlan({ stages: [{ ...stage, x: 60 }], defaultIndex: 0 }, limits) ?? "", /between 100 and 32000/);
+  assert.match(validateDpiStagePlan({ stages: [{ ...stage, y: 825 }], defaultIndex: 0 }, limits) ?? "", /multiple of 50/);
+  // 0 means "unused", so it cannot be the level of a slot in use.
+  assert.match(validateDpiStagePlan({ stages: [{ ...stage, lod: 0 }], defaultIndex: 0 }, limits) ?? "", /lift-off/);
+  assert.match(validateDpiStagePlan({ stages: [{ ...stage, lod: 4 }], defaultIndex: 0 }, limits) ?? "", /lift-off/);
+
+  assert.throws(() => encodeDpiStages(SECTOR_3, 7, { stages: [], defaultIndex: 0 }), /1 to 5/);
+});
+
+test("lift-off limits come from the profile format, not the model", () => {
+  // Format 7 (Pro X Superlight 2) offers all three levels.
+  assert.deepEqual(capabilitiesForFormat(7).supportedLods, ["Low", "Medium", "High"]);
+
+  // Format 8 carries the analog-button block, so it is the Superstrike format.
+  assert.deepEqual(capabilitiesForFormat(8).supportedLods, ["Low", "High"]);
+
+  // Anything else keeps what the driver assumed before limits were per format.
+  assert.deepEqual(capabilitiesForFormat(1).supportedLods, ["Medium", "High"]);
+
+  // getInfo is allowed to fail, so an absent format must not throw.
+  assert.deepEqual(capabilitiesForFormat(null).supportedLods, ["Medium", "High"]);
+  assert.deepEqual(capabilitiesForFormat(undefined).supportedLods, ["Medium", "High"]);
+  assert.deepEqual(capabilitiesForFormat(99).supportedLods, ["Medium", "High"]);
+});
+
+test("format 7 counts lift-off levels from one", () => {
+  // Captured from G HUB writing the profile on a Pro X Superlight 2: medium to
+  // low wrote 0x02 -> 0x01, and low to high wrote 0x01 -> 0x03.
+  const format7 = capabilitiesForFormat(7);
+  assert.deepEqual(format7.lodEncoding, { Low: 1, Medium: 2, High: 3 });
+
+  for (const [level, raw] of [["Low", 1], ["Medium", 2], ["High", 3]] as const) {
+    assert.equal(decodeLiftOffLevel(raw, format7), level);
+  }
+
+  // 0 marks an unused DPI stage on this format, so it is not a level.
+  assert.equal(decodeLiftOffLevel(0, format7), null);
+  assert.equal(decodeLiftOffLevel(null, format7), null);
+  assert.equal(decodeLiftOffLevel(undefined, format7), null);
+});
+
+test("formats without a confirmed encoding still count from zero", () => {
+  const fallback = capabilitiesForFormat(null);
+  assert.deepEqual(fallback.lodEncoding, { Low: 0, Medium: 1, High: 2 });
+  assert.equal(decodeLiftOffLevel(1, fallback), "Medium");
+  assert.equal(decodeLiftOffLevel(2, fallback), "High");
+  assert.equal(decodeLiftOffLevel(3, fallback), null);
+});
+
+test("typed bunny-hop times are snapped into range and onto the step", () => {
+  assert.equal(clampBunnyHopMs(200), 200, "an already valid value is untouched");
+  assert.equal(clampBunnyHopMs(105), 110, "off-step values round to the nearest step");
+  assert.equal(clampBunnyHopMs(104), 100);
+
+  // Out of range in either direction snaps to the nearest limit rather than
+  // being rejected, so the field can never hold a value the byte cannot store.
+  assert.equal(clampBunnyHopMs(50), 100);
+  assert.equal(clampBunnyHopMs(0), 100);
+  assert.equal(clampBunnyHopMs(-40), 100);
+  assert.equal(clampBunnyHopMs(5000), 1000);
+
+  // An empty field reads back as NaN.
+  assert.equal(clampBunnyHopMs(Number.NaN), 100);
+
+  // Whatever comes out must satisfy the validator.
+  for (const input of [50, 104, 105, 333, 999, 5000, Number.NaN]) {
+    assert.equal(validateBunnyHoppingMs(clampBunnyHopMs(input)), null, `clamped ${input}`);
+  }
+});
+
+test("bunny hopping is not modelled on formats below 7", () => {
+  const before = SECTOR_3.slice();
+  const after = SECTOR_3.slice();
+  after[0x25] = 0x0a;
+  applyCrc(after);
+
+  const reproduced = reproduceProfile(before, after, 6);
+  assert.notDeepEqual([...reproduced], [...after], "format 6 has no bunny_hopping component");
+});
+
+test("reproducing reports the bytes we cannot yet write", () => {
+  const before = SECTOR_3.slice();
+  const after = SECTOR_3.slice();
+  // Lighting is not modelled by any encoder, so it must show up as a difference.
+  after[0xd2] ^= 0xff;
+  applyCrc(after);
+
+  const reproduced = reproduceProfile(before, after, 7);
+  const changed = [...reproduced].flatMap((byte, index) => (byte === after[index] ? [] : [index]));
+  assert.ok(changed.includes(0xd2), "an unmodelled field must not silently pass");
+});
+
+test("a corrupted byte invalidates the CRC", () => {
+  const tampered = SECTOR_3.slice();
+  tampered[0x04] ^= 0xff;
+  assert.equal(decodeOnboardProfile(tampered, 7, { sector: 3, enabled: true }, true).crcValid, false);
+});

--- a/src/devices/logitech/onboard-profiles.test.ts
+++ b/src/devices/logitech/onboard-profiles.test.ts
@@ -82,6 +82,31 @@ const SECTOR_2 = bytes(`
   00 03 00 00 00 00 00 1f 40 32 00 00 03 84 db
 `);
 
+/** G402 format-1 sector captured by OpenMouse; remaining bytes are erased. */
+const G402_SECTOR = (() => {
+  const sector = new Uint8Array(1024).fill(0xff);
+  sector.set(bytes(`
+    01 02 00 a4 01 48 03 3c 06 78 0c 00 00 ff ff ff
+    ff 00 ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+    80 01 00 01 80 01 00 02 80 01 00 04 80 01 00 08
+    80 01 00 10 90 07 ff ff 90 04 ff ff 90 03 ff ff
+    ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+    ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+    ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+    ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+    ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+    ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+    01 01 01 ff ff ff 00 00 00 02 00 00 00 00 00 df
+    00 08 e1 d2 00 08 15 d3 00 08 01 00 00 02 00 00
+    00 00 14 df 00 08 25 d3 00 08 2d d3 00 08 03 00
+    00 02 00 00 00 00 28 df 00 08 51 d3 00 08 59 d3
+    00 08 05 00 00 03 00 00 00 00 3c df 00 08 67 d3
+    00 08 93 d3 00 08 7d d3 00 08 c1 00 00 02 00 ff
+  `), 0);
+  sector.set([0x4e, 0xba], sector.length - 2);
+  return sector;
+})();
+
 test("parses getOnboardProfilesInfo", () => {
   assert.deepEqual(parseProfilesInfo(INFO_REPLY), {
     memoryModelId: 1,
@@ -220,6 +245,20 @@ test("our encoders reproduce each observed transition byte for byte", () => {
     const after = sectorState(OBSERVED_STATES[index]);
     assert.deepEqual([...reproduceProfile(before, after, 7)], [...after], `transition ${index}`);
   }
+});
+
+test("decodes the captured G402 format-1 profile without v6 mojibake", () => {
+  const profile = decodeOnboardProfile(G402_SECTOR, 1, { sector: 1, enabled: true }, false);
+  assert.equal(G402_SECTOR.length, 1024);
+  assert.equal(profile.crcValid, true);
+  assert.equal(profile.name, null);
+  assert.equal(profile.defaultDpiIndex, 2);
+  assert.deepEqual(profile.dpiStages, [420, 840, 1596, 3192].map((dpi) => ({ x: dpi, y: dpi, lod: 0 })));
+  assert.equal(profile.reportRateWireless, null);
+  assert.equal(profile.reportRateWired, 1000);
+  assert.equal(profile.angleSnapping, false);
+  assert.equal(profile.powerSaveTimeoutSeconds, null);
+  assert.equal(profile.powerOffTimeoutSeconds, null);
 });
 
 test("factory reset image is exact, CRC-valid and limited to captured geometry", () => {
@@ -516,12 +555,20 @@ test("format 7 counts lift-off levels from one", () => {
   assert.equal(decodeLiftOffLevel(undefined, format7), null);
 });
 
-test("formats without a confirmed encoding still count from zero", () => {
-  const fallback = capabilitiesForFormat(null);
-  assert.deepEqual(fallback.lodEncoding, { Low: 0, Medium: 1, High: 2 });
-  assert.equal(decodeLiftOffLevel(1, fallback), "Medium");
-  assert.equal(decodeLiftOffLevel(2, fallback), "High");
-  assert.equal(decodeLiftOffLevel(3, fallback), null);
+test("every format counts lift-off levels from one", () => {
+  // 0x2202's enum belongs to the feature, not to a profile format, so the
+  // fallback and format 8 use the same numbering format 7 was confirmed on.
+  // Counting from zero made "Low" write 0 — the feature's "not supported"
+  // value — and reported every level one step too high.
+  for (const format of [null, 8, 1, 99]) {
+    const capabilities = capabilitiesForFormat(format);
+    assert.deepEqual(capabilities.lodEncoding, { Low: 1, Medium: 2, High: 3 }, `format ${format}`);
+    assert.equal(decodeLiftOffLevel(1, capabilities), "Low");
+    assert.equal(decodeLiftOffLevel(2, capabilities), "Medium");
+    assert.equal(decodeLiftOffLevel(3, capabilities), "High");
+    // 0 means the sensor has no lift-off control, so it is not a level.
+    assert.equal(decodeLiftOffLevel(0, capabilities), null);
+  }
 });
 
 test("typed bunny-hop times are snapped into range and onto the step", () => {

--- a/src/devices/logitech/onboard-profiles.ts
+++ b/src/devices/logitech/onboard-profiles.ts
@@ -390,6 +390,41 @@ export function applyCrc(bytes: Uint8Array): Uint8Array {
 }
 
 /**
+ * Complete factory profile captured after G HUB/Onboard Memory Manager's
+ * "reset all profiles" action on profile format 7. This is intentionally an
+ * exact sector image rather than a list of guessed defaults: it resets button
+ * assignments, G-Shift, lighting and currently-undecoded fields as well as the
+ * settings OpenMouse exposes in the UI.
+ */
+const FACTORY_PROFILE_FORMAT_7 = `
+  03 03 00 00 20 03 20 03 02 b0 04 b0 04 02 40 06
+  40 06 02 60 09 60 09 02 80 0c 80 0c 02 00 00 00
+  00 ff 00 ff ff ff ff ff ff ff ff ff 3c 00 2c 01
+  80 01 00 01 80 01 00 02 80 01 00 04 80 01 00 08
+  80 01 00 10 ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+  03 00 00 00 00 00 1f 40 00 00 00 03 00 00 00 00
+  00 1f 40 00 00 00 03 00 00 00 00 00 1f 40 32 00
+  00 03 00 00 00 00 00 1f 40 32 00 00 03 84 db
+`;
+
+/** Returns a fresh, CRC-valid factory sector only for a captured geometry. */
+export function factoryProfileForFormat(profileFormatId: number, sectorSize: number): Uint8Array | null {
+  if (profileFormatId !== 7 || sectorSize !== 255) return null;
+  return Uint8Array.from(
+    FACTORY_PROFILE_FORMAT_7.trim().split(/\s+/),
+    (byte) => Number.parseInt(byte, 16),
+  );
+}
+
+/**
  * Returns a copy of the directory sector with one profile's enabled flag
  * changed and the checksum recomputed. Every other byte is carried through
  * untouched, so unknown directory fields survive.
@@ -690,6 +725,8 @@ function writeUint16LE(bytes: Uint8Array, offset: number, value: number): void {
 export function reproduceProfile(before: Uint8Array, after: Uint8Array, profileFormatId: number): Uint8Array {
   const layout = layoutForFormat(profileFormatId);
   const result = before.slice();
+  const isErased = (offset: number, size: number): boolean =>
+    after.slice(offset, offset + size).every((byte) => byte === 0xff);
 
   const copyRate = (offset: number | null): void => {
     if (offset === null) return;
@@ -722,6 +759,9 @@ export function reproduceProfile(before: Uint8Array, after: Uint8Array, profileF
   if (layout.bunnyHopping !== null) {
     const milliseconds = decodeBunnyHoppingMs(after, layout.bunnyHopping);
     if (milliseconds !== null) result[layout.bunnyHopping] = Math.round(milliseconds / 10);
+    // Factory reset returns the optional component to erased flash rather than
+    // encoding "off" as zero. That distinction is visible in a vendor diff.
+    else if (after[layout.bunnyHopping] === 0xff) result[layout.bunnyHopping] = 0xff;
   }
 
   for (const offset of [layout.powerSaveTimeout, layout.powerOffTimeout]) {
@@ -740,6 +780,18 @@ export function reproduceProfile(before: Uint8Array, after: Uint8Array, profileF
       encoded[index * 2 + 1] = (code >> 8) & 0xff;
     }
     result.set(encoded, layout.profileName);
+  } else if (isErased(layout.profileName, PROFILE_NAME_BYTES)) {
+    // An unnamed factory profile uses erased bytes, not a zero-filled empty
+    // UTF-16 string. Reproduce that representation exactly so its CRC matches.
+    result.fill(0xff, layout.profileName, layout.profileName + PROFILE_NAME_BYTES);
+  }
+
+  // Reset-to-factory erases the complete G-Shift assignment component. We do
+  // not claim to encode individual assignments yet, but an all-0xff target is
+  // unambiguous and safe to reproduce for capture verification.
+  const gShift = componentsForFormat(profileFormatId).find((component) => component.name === "g_shift_function");
+  if (gShift && isErased(gShift.offset, gShift.size)) {
+    result.fill(0xff, gShift.offset, gShift.offset + gShift.size);
   }
 
   return applyCrc(result);

--- a/src/devices/logitech/onboard-profiles.ts
+++ b/src/devices/logitech/onboard-profiles.ts
@@ -101,7 +101,11 @@ export interface ReportRateCapabilities {
 
 export interface ProfileFormatCapabilities {
   supportedLods: LiftOffLevel[];
-  /** Byte feature 0x2202 uses for each level. Not the same on every format. */
+  /**
+   * Byte feature 0x2202 uses for each level. The same on every device — it is
+   * the feature's enum, not the format's — but kept here so a format that ever
+   * turns out to differ has somewhere to say so.
+   */
   lodEncoding: Record<LiftOffLevel, number>;
   dpiStages: DpiStageCapabilities | null;
   reportRates: ReportRateCapabilities | null;
@@ -120,28 +124,34 @@ export interface ProfileFormatCapabilities {
 const PROFILE_NAME_BYTES = 0x30;
 export const PROFILE_NAME_MAX_CHARS = PROFILE_NAME_BYTES / 2 - 1;
 
-/** The encoding the driver has always used: levels counted from zero. */
-const LOD_FROM_ZERO: Record<LiftOffLevel, number> = { Low: 0, Medium: 1, High: 2 };
-
 /**
- * Levels counted from one, matching the profile layout where 0 means "stage
- * unused" rather than a level. Confirmed on a Pro X Superlight 2 (format 7),
- * which offers three levels while only two are reachable counting from zero —
- * writing 0 is rejected, so the third level was invisible.
+ * Feature 0x2202's lift-off enum: 0 means the sensor has no lift-off control,
+ * and the levels count from one. This belongs to the feature, not to a profile
+ * format — every device that exposes 0x2202 uses the same numbering.
+ *
+ * Confirmed twice over: captured from G HUB writing a Pro X Superlight 2
+ * profile (02 -> 01 for medium to low, 01 -> 03 for low to high), and matching
+ * OpenLogi's Lod enum { NotSupported = 0, Low = 1, Medium = 2, High = 3 }.
+ *
+ * The driver previously counted from zero, which made "Low" write 0 — a value
+ * meaning "unsupported" that the mouse rejects — and reported every level one
+ * step too high.
  */
-const LOD_FROM_ONE: Record<LiftOffLevel, number> = { Low: 1, Medium: 2, High: 3 };
+const LOD_ENCODING: Record<LiftOffLevel, number> = { Low: 1, Medium: 2, High: 3 };
 
 /**
  * Applied when the mouse does not report a format, or reports one whose limits
- * were never established: the behaviour the driver had before the limits were
- * split per format. Suspected to be the same off-by-one as format 7, but that
- * is unproven per format, so it is left alone rather than changed blind.
+ * were never established.
+ *
+ * Only two levels are offered because no third was ever confirmed on such a
+ * device — not because Low is unreachable. That was the old off-by-one talking:
+ * Low used to write 0, which means "no lift-off control", so it always failed.
  */
 const DEFAULT_FORMAT_CAPABILITIES: ProfileFormatCapabilities = {
   supportedLods: ["Medium", "High"],
-  lodEncoding: LOD_FROM_ZERO,
-  // Base v1 has no DPI stage table at all, and the range a v6 format allows
-  // depends on the sensor, so an unrecognised format offers no slots.
+  lodEncoding: LOD_ENCODING,
+  // Base v1 has a scalar DPI table, but its sensor-specific conversion and
+  // writable range are not verified. Unknown formats therefore offer no edits.
   dpiStages: null,
   // Ceilings are a property of the radio and the USB interface, so they cannot
   // be carried over from another mouse.
@@ -155,7 +165,7 @@ const FORMAT_CAPABILITIES: Record<number, ProfileFormatCapabilities> = {
   // 5x5 stage table in the registration and confirmed against a real profile.
   7: {
     supportedLods: ["Low", "Medium", "High"],
-    lodEncoding: LOD_FROM_ONE,
+    lodEncoding: LOD_ENCODING,
     dpiStages: { maxStages: 5, minDpi: 100, maxDpi: 32000, stepDpi: 50 },
     // Reported on hardware: the Lightspeed link runs to 8 kHz, the USB cable
     // is a 1 kHz charging connection rather than a full-rate wired mode.
@@ -164,12 +174,13 @@ const FORMAT_CAPABILITIES: Record<number, ProfileFormatCapabilities> = {
     bunnyHop: true,
   },
   // Format 8 carries the analog-button block, so it is the PRO X 2 Superstrike
-  // format. Its two levels predate the format table and were never rechecked
-  // against the encoding, and its sensor range was never captured, so slots
-  // stay unavailable rather than being assumed to match format 7.
+  // format. Its two levels are what the driver has always offered and were
+  // never checked against a real device; its sensor range was never captured
+  // either, so slots stay unavailable rather than being assumed to match
+  // format 7.
   8: {
     supportedLods: ["Low", "High"],
-    lodEncoding: LOD_FROM_ZERO,
+    lodEncoding: LOD_ENCODING,
     dpiStages: null,
     reportRates: null,
     // The name region is part of base v6, which format 8 shares.
@@ -191,8 +202,9 @@ export function decodeLiftOffLevel(
   if (raw === null || raw === undefined) return null;
   const level = (Object.keys(capabilities.lodEncoding) as LiftOffLevel[])
     .find((name) => capabilities.lodEncoding[name] === raw);
-  // An unmapped byte is reported as unknown rather than guessed at: on a
-  // count-from-one format 0 means the stage is unused.
+  // 0 is the feature's "not supported" value, and anything else unmapped is
+  // simply unknown. Either way it is reported as no level rather than guessed
+  // at — reading 0 as "Low" is how the off-by-one used to hide itself.
   return level ?? null;
 }
 
@@ -261,11 +273,11 @@ interface ProfileLayout {
 
 const LAYOUT_V1: ProfileLayout = {
   reportRateWireless: null,
-  reportRateWired: null,
-  dpi: null,
+  reportRateWired: 0x00,
+  dpi: 0x01,
   angleSnapping: 0x11,
-  powerSaveTimeout: null,
-  powerOffTimeout: null,
+  powerSaveTimeout: 0x1c,
+  powerOffTimeout: 0x1e,
   profileName: 0xa0,
   bunnyHopping: null,
 };
@@ -294,10 +306,12 @@ export interface ComponentSpec {
 
 const COMPONENTS_V1: ComponentSpec[] = [
   { offset: 0x00, size: 1, name: "report_rate" },
-  { offset: 0x01, size: 0x0a, name: "dpi_v1" },
+  { offset: 0x01, size: 0x0c, name: "dpi_v1" },
   { offset: 0x0d, size: 3, name: "color" },
   { offset: 0x10, size: 1, name: "power_mode" },
   { offset: 0x11, size: 1, name: "angle_snapping" },
+  { offset: 0x1c, size: 2, name: "power_save_timeout" },
+  { offset: 0x1e, size: 2, name: "power_off_timeout" },
   { offset: 0x20, size: 0x40, name: "button_functions" },
   { offset: 0x60, size: 0x40, name: "g_shift_function" },
   { offset: 0xa0, size: 0x30, name: "profile_name" },
@@ -473,10 +487,34 @@ function decodeDpi(bytes: Uint8Array, offset: number): { stages: DpiStage[]; def
   return { stages, defaultIndex: defaultIndex === 0xff ? null : defaultIndex };
 }
 
+/** Formats 1-5 store one little-endian DPI value per slot, without X/Y or LOD. */
+function decodeDpiV1(bytes: Uint8Array, offset: number): { stages: DpiStage[]; defaultIndex: number | null } {
+  const rawDefaultIndex = bytes[offset];
+  const stages: DpiStage[] = [];
+  for (let stage = 0; stage < DPI_STAGE_SLOTS; stage += 1) {
+    const dpi = readUint16LE(bytes, offset + 2 + stage * 2);
+    if (dpi === null || dpi === 0) continue;
+    stages.push({ x: dpi, y: dpi, lod: 0 });
+  }
+  return {
+    stages,
+    defaultIndex: rawDefaultIndex === undefined || rawDefaultIndex === 0xff ? null : rawDefaultIndex,
+  };
+}
+
 function decodeReportRate(bytes: Uint8Array, offset: number | null): number | null {
   if (offset === null) return null;
   const raw = bytes[offset];
   return raw === undefined || raw === 0xff ? null : REPORT_RATE_HZ[raw] ?? null;
+}
+
+/** Formats 1-5 store the USB polling interval in milliseconds. */
+function decodeReportRateV1(bytes: Uint8Array, offset: number | null): number | null {
+  if (offset === null) return null;
+  const intervalMs = bytes[offset];
+  if (intervalMs === undefined || intervalMs === 0xff || intervalMs === 0) return null;
+  const hz = 1000 / intervalMs;
+  return Number.isInteger(hz) ? hz : null;
 }
 
 /** Rates the byte can index, filtered to the ceiling for that connection. */
@@ -725,30 +763,37 @@ function writeUint16LE(bytes: Uint8Array, offset: number, value: number): void {
 export function reproduceProfile(before: Uint8Array, after: Uint8Array, profileFormatId: number): Uint8Array {
   const layout = layoutForFormat(profileFormatId);
   const result = before.slice();
+  const legacyLayout = profileFormatId < 6;
   const isErased = (offset: number, size: number): boolean =>
     after.slice(offset, offset + size).every((byte) => byte === 0xff);
 
   const copyRate = (offset: number | null): void => {
     if (offset === null) return;
-    const hz = decodeReportRate(after, offset);
-    const index = hz === null ? null : REPORT_RATE_HZ.indexOf(hz as (typeof REPORT_RATE_HZ)[number]);
-    if (index !== null && index >= 0) result[offset] = index;
+    const hz = legacyLayout ? decodeReportRateV1(after, offset) : decodeReportRate(after, offset);
+    if (hz === null) return;
+    if (legacyLayout) result[offset] = 1000 / hz;
+    else {
+      const index = REPORT_RATE_HZ.indexOf(hz as (typeof REPORT_RATE_HZ)[number]);
+      if (index >= 0) result[offset] = index;
+    }
   };
   copyRate(layout.reportRateWireless);
   copyRate(layout.reportRateWired);
 
   if (layout.dpi !== null) {
-    const dpi = decodeDpi(after, layout.dpi);
+    const dpi = legacyLayout ? decodeDpiV1(after, layout.dpi) : decodeDpi(after, layout.dpi);
     if (dpi.defaultIndex !== null) result[layout.dpi] = dpi.defaultIndex;
     result[layout.dpi + 1] = after[layout.dpi + 1];
-    // Stages are re-encoded from decoded values, not copied, so the little
-    // endian x/y/lod encoding is what is actually under test.
+    // Stages are re-encoded from decoded values, not copied, so their
+    // little-endian representation is what is actually under test.
     let stage = 0;
     for (const { x, y, lod } of dpi.stages) {
-      const base = layout.dpi + 2 + stage * 5;
+      const base = layout.dpi + 2 + stage * (legacyLayout ? 2 : 5);
       writeUint16LE(result, base, x);
-      writeUint16LE(result, base + 2, y);
-      result[base + 4] = lod;
+      if (!legacyLayout) {
+        writeUint16LE(result, base + 2, y);
+        result[base + 4] = lod;
+      }
       stage += 1;
     }
   }
@@ -770,7 +815,7 @@ export function reproduceProfile(before: Uint8Array, after: Uint8Array, profileF
     if (seconds !== null) writeUint16LE(result, offset, seconds);
   }
 
-  const name = decodeName(after, layout.profileName);
+  const name = legacyLayout ? null : decodeName(after, layout.profileName);
   if (name !== null) {
     const encoded = new Uint8Array(0x30);
     encoded.set(after.slice(layout.profileName, layout.profileName + 0x30).map(() => 0));
@@ -804,20 +849,27 @@ export function decodeOnboardProfile(
   isCurrent: boolean,
 ): OnboardProfile {
   const layout = layoutForFormat(profileFormatId);
+  const legacyLayout = profileFormatId < 6;
   const dpi = layout.dpi === null
     ? { stages: [], defaultIndex: null }
-    : decodeDpi(bytes, layout.dpi);
+    : legacyLayout ? decodeDpiV1(bytes, layout.dpi) : decodeDpi(bytes, layout.dpi);
   const angleSnappingByte = bytes[layout.angleSnapping];
 
   return {
     sector: entry.sector,
     enabled: entry.enabled,
     isCurrent,
-    name: decodeName(bytes, layout.profileName),
+    // The v1 region is byte text, not UTF-16. This G402 capture contains
+    // non-text device data there, so do not manufacture a mojibake name.
+    name: legacyLayout ? null : decodeName(bytes, layout.profileName),
     dpiStages: dpi.stages,
     defaultDpiIndex: dpi.defaultIndex,
-    reportRateWireless: decodeReportRate(bytes, layout.reportRateWireless),
-    reportRateWired: decodeReportRate(bytes, layout.reportRateWired),
+    reportRateWireless: legacyLayout
+      ? decodeReportRateV1(bytes, layout.reportRateWireless)
+      : decodeReportRate(bytes, layout.reportRateWireless),
+    reportRateWired: legacyLayout
+      ? decodeReportRateV1(bytes, layout.reportRateWired)
+      : decodeReportRate(bytes, layout.reportRateWired),
     angleSnapping: angleSnappingByte === undefined || angleSnappingByte === 0xff
       ? null
       : angleSnappingByte !== 0,

--- a/src/devices/logitech/onboard-profiles.ts
+++ b/src/devices/logitech/onboard-profiles.ts
@@ -1,0 +1,782 @@
+/**
+ * HID++ 0x8100 onboard profile decoding.
+ *
+ * Layouts recovered from Logitech's own registration code and verified against
+ * a Pro X Superlight 2 (profile format 7) — see
+ * docs/logitech-onboard-profiles.md. Pure functions only: the transport lives
+ * in hidpp.ts, so everything here is testable against captured bytes.
+ */
+
+/** 0x8100 function ids. Write functions are deliberately absent. */
+export const PROFILE_FN = {
+  getInfo: 0x00,
+  setMode: 0x10,
+  getMode: 0x20,
+  setCurrentProfile: 0x30,
+  getCurrentProfile: 0x40,
+  memoryRead: 0x50,
+  memoryAddrWrite: 0x60,
+  memoryWrite: 0x70,
+  memoryWriteEnd: 0x80,
+} as const;
+
+export const ONBOARD_MODE = { onboard: 0x01, host: 0x02 } as const;
+
+/**
+ * Names from the library's PROFILE_FORMAT enum, which stops at 6 — the
+ * dispatcher handles 8. Ids 7 and 8 are newer formats the managed wrapper was
+ * never updated for, so they are described by what they carry instead.
+ */
+const PROFILE_FORMAT_NAMES: Record<number, string> = {
+  1: "PROTOSS_HYJAL",
+  2: "LOGAN",
+  3: "HEAT",
+  4: "HARPY",
+  5: "HOST_LAYER",
+  6: "BAYMAX",
+  7: "FORMAT 7", // (v6 + bunny hopping)
+  8: "FORMAT 8", // (v6 + bunny hopping + analog buttons)
+};
+
+/**
+ * Formats whose layout has been confirmed by decoding a real profile whose
+ * checksum validates. Everything else is read out of vendor code only — the v6
+ * base was wrong in two ways (DPI offset and endianness) until hardware
+ * corrected it, so treat unverified layouts as display-only.
+ *
+ * Add a format here only after a dump from that device decodes sensibly with a
+ * matching CRC.
+ */
+const VERIFIED_FORMATS = new Set([7]);
+
+export interface ProfileFormat {
+  id: number;
+  name: string;
+  /** Which base layout applies; decides how a profile sector is decoded. */
+  base: "v1" | "v6";
+  /** A layout exists for this format. */
+  supported: boolean;
+  /** The layout has been confirmed against real hardware. */
+  verified: boolean;
+}
+
+export function describeProfileFormat(profileFormatId: number): ProfileFormat {
+  return {
+    id: profileFormatId,
+    name: PROFILE_FORMAT_NAMES[profileFormatId] ?? "unknown",
+    base: profileFormatId >= 6 ? "v6" : "v1",
+    supported: profileFormatId >= 1 && profileFormatId <= 8,
+    verified: VERIFIED_FORMATS.has(profileFormatId),
+  };
+}
+
+export type LiftOffLevel = "Low" | "Medium" | "High";
+
+/**
+ * Setting limits that vary by profile format rather than by model, keyed on the
+ * format the mouse reports through 0x8100 getInfo. A new mouse on a known
+ * format inherits them without a model check.
+ */
+/**
+ * DPI slot limits for one format. Slot count and DPI range are properties of
+ * the mouse, not of the app: an older format can hold fewer slots and a much
+ * narrower range. Null means we have not established them for that format, in
+ * which case slots are not offered at all rather than guessed at.
+ */
+export interface DpiStageCapabilities {
+  maxStages: number;
+  minDpi: number;
+  maxDpi: number;
+  stepDpi: number;
+}
+
+/**
+ * Report-rate ceilings, which differ per connection: the radio and the USB
+ * interface are not equally fast. Null when never established for a format.
+ */
+export interface ReportRateCapabilities {
+  wirelessMaxHz: number;
+  wiredMaxHz: number;
+}
+
+export interface ProfileFormatCapabilities {
+  supportedLods: LiftOffLevel[];
+  /** Byte feature 0x2202 uses for each level. Not the same on every format. */
+  lodEncoding: Record<LiftOffLevel, number>;
+  dpiStages: DpiStageCapabilities | null;
+  reportRates: ReportRateCapabilities | null;
+  /** Characters the name region holds, or null when the format has no name. */
+  maxNameLength: number | null;
+  /**
+   * Whether the format has a bunny-hop byte at all. Kept separate from the
+   * stored value: an unwritten byte reads 0xff and decodes to null, which
+   * means "never set", not "not supported".
+   */
+  bunnyHop: boolean;
+}
+
+/** The name region is 0x30 bytes of UTF-16LE: 24 units, one kept for the
+ * terminator so a full-length name still reads back with a clear end. */
+const PROFILE_NAME_BYTES = 0x30;
+export const PROFILE_NAME_MAX_CHARS = PROFILE_NAME_BYTES / 2 - 1;
+
+/** The encoding the driver has always used: levels counted from zero. */
+const LOD_FROM_ZERO: Record<LiftOffLevel, number> = { Low: 0, Medium: 1, High: 2 };
+
+/**
+ * Levels counted from one, matching the profile layout where 0 means "stage
+ * unused" rather than a level. Confirmed on a Pro X Superlight 2 (format 7),
+ * which offers three levels while only two are reachable counting from zero —
+ * writing 0 is rejected, so the third level was invisible.
+ */
+const LOD_FROM_ONE: Record<LiftOffLevel, number> = { Low: 1, Medium: 2, High: 3 };
+
+/**
+ * Applied when the mouse does not report a format, or reports one whose limits
+ * were never established: the behaviour the driver had before the limits were
+ * split per format. Suspected to be the same off-by-one as format 7, but that
+ * is unproven per format, so it is left alone rather than changed blind.
+ */
+const DEFAULT_FORMAT_CAPABILITIES: ProfileFormatCapabilities = {
+  supportedLods: ["Medium", "High"],
+  lodEncoding: LOD_FROM_ZERO,
+  // Base v1 has no DPI stage table at all, and the range a v6 format allows
+  // depends on the sensor, so an unrecognised format offers no slots.
+  dpiStages: null,
+  // Ceilings are a property of the radio and the USB interface, so they cannot
+  // be carried over from another mouse.
+  reportRates: null,
+  maxNameLength: null,
+  bunnyHop: false,
+};
+
+const FORMAT_CAPABILITIES: Record<number, ProfileFormatCapabilities> = {
+  // Pro X Superlight 2. Three levels, counted from one. Five slots, from the
+  // 5x5 stage table in the registration and confirmed against a real profile.
+  7: {
+    supportedLods: ["Low", "Medium", "High"],
+    lodEncoding: LOD_FROM_ONE,
+    dpiStages: { maxStages: 5, minDpi: 100, maxDpi: 32000, stepDpi: 50 },
+    // Reported on hardware: the Lightspeed link runs to 8 kHz, the USB cable
+    // is a 1 kHz charging connection rather than a full-rate wired mode.
+    reportRates: { wirelessMaxHz: 8000, wiredMaxHz: 1000 },
+    maxNameLength: PROFILE_NAME_MAX_CHARS,
+    bunnyHop: true,
+  },
+  // Format 8 carries the analog-button block, so it is the PRO X 2 Superstrike
+  // format. Its two levels predate the format table and were never rechecked
+  // against the encoding, and its sensor range was never captured, so slots
+  // stay unavailable rather than being assumed to match format 7.
+  8: {
+    supportedLods: ["Low", "High"],
+    lodEncoding: LOD_FROM_ZERO,
+    dpiStages: null,
+    reportRates: null,
+    // The name region is part of base v6, which format 8 shares.
+    maxNameLength: PROFILE_NAME_MAX_CHARS,
+    bunnyHop: true,
+  },
+};
+
+export function capabilitiesForFormat(profileFormatId: number | null | undefined): ProfileFormatCapabilities {
+  if (profileFormatId === null || profileFormatId === undefined) return DEFAULT_FORMAT_CAPABILITIES;
+  return FORMAT_CAPABILITIES[profileFormatId] ?? DEFAULT_FORMAT_CAPABILITIES;
+}
+
+/** Turns a raw 0x2202 lift-off byte back into a level for the given format. */
+export function decodeLiftOffLevel(
+  raw: number | null | undefined,
+  capabilities: ProfileFormatCapabilities,
+): LiftOffLevel | null {
+  if (raw === null || raw === undefined) return null;
+  const level = (Object.keys(capabilities.lodEncoding) as LiftOffLevel[])
+    .find((name) => capabilities.lodEncoding[name] === raw);
+  // An unmapped byte is reported as unknown rather than guessed at: on a
+  // count-from-one format 0 means the stage is unused.
+  return level ?? null;
+}
+
+export interface OnboardProfilesInfo {
+  memoryModelId: number;
+  profileFormatId: number;
+  profileCount: number;
+  sectorCount: number;
+  sectorSize: number;
+}
+
+export interface DirectoryEntry {
+  sector: number;
+  enabled: boolean;
+}
+
+export interface DpiStage {
+  x: number;
+  y: number;
+  /** 0 marks an unused stage; real levels are 1-3 (low/medium/high). */
+  lod: number;
+}
+
+export interface OnboardProfile {
+  sector: number;
+  enabled: boolean;
+  isCurrent: boolean;
+  name: string | null;
+  dpiStages: DpiStage[];
+  defaultDpiIndex: number | null;
+  reportRateWireless: number | null;
+  reportRateWired: number | null;
+  angleSnapping: boolean | null;
+  powerSaveTimeoutSeconds: number | null;
+  powerOffTimeoutSeconds: number | null;
+  /**
+   * Bunny-hop timeout in milliseconds, or 0 when the feature is off. Stored as
+   * ms / 10, so G HUB's 100-1000 ms range is 0x0a-0x64 and "off" is 0x00. All
+   * three confirmed on hardware; 0xff is unwritten flash and decodes as null.
+   */
+  bunnyHoppingMs: number | null;
+  crcValid: boolean;
+  /** Raw sector, kept so captures can diff before/after a vendor-app change. */
+  raw: Uint8Array;
+}
+
+/** Report-rate bytes index this table, matching 0x8061's ordering. */
+const REPORT_RATE_HZ = [125, 250, 500, 1000, 2000, 4000, 8000] as const;
+
+/**
+ * Field offsets per profile format. Formats 1-5 use the v1 base, 6-8 the v6
+ * base; only the fields the UI reads are listed here.
+ */
+interface ProfileLayout {
+  reportRateWireless: number | null;
+  reportRateWired: number | null;
+  /** Start of the DPI block: two index bytes, then five 5-byte stages. */
+  dpi: number | null;
+  angleSnapping: number;
+  powerSaveTimeout: number | null;
+  powerOffTimeout: number | null;
+  profileName: number;
+  /** Only formats 7+ register this component. */
+  bunnyHopping: number | null;
+}
+
+const LAYOUT_V1: ProfileLayout = {
+  reportRateWireless: null,
+  reportRateWired: null,
+  dpi: null,
+  angleSnapping: 0x11,
+  powerSaveTimeout: null,
+  powerOffTimeout: null,
+  profileName: 0xa0,
+  bunnyHopping: null,
+};
+
+const LAYOUT_V6: ProfileLayout = {
+  reportRateWireless: 0x00,
+  reportRateWired: 0x01,
+  dpi: 0x02,
+  angleSnapping: 0x22,
+  powerSaveTimeout: 0x2c,
+  powerOffTimeout: 0x2e,
+  profileName: 0xa0,
+  bunnyHopping: null,
+};
+
+export function layoutForFormat(profileFormatId: number): ProfileLayout {
+  const base = profileFormatId >= 6 ? LAYOUT_V6 : LAYOUT_V1;
+  return { ...base, bunnyHopping: profileFormatId >= 7 ? 0x25 : null };
+}
+
+export interface ComponentSpec {
+  offset: number;
+  size: number;
+  name: string;
+}
+
+const COMPONENTS_V1: ComponentSpec[] = [
+  { offset: 0x00, size: 1, name: "report_rate" },
+  { offset: 0x01, size: 0x0a, name: "dpi_v1" },
+  { offset: 0x0d, size: 3, name: "color" },
+  { offset: 0x10, size: 1, name: "power_mode" },
+  { offset: 0x11, size: 1, name: "angle_snapping" },
+  { offset: 0x20, size: 0x40, name: "button_functions" },
+  { offset: 0x60, size: 0x40, name: "g_shift_function" },
+  { offset: 0xa0, size: 0x30, name: "profile_name" },
+];
+
+const COMPONENTS_V6: ComponentSpec[] = [
+  { offset: 0x00, size: 1, name: "report_rate_wireless" },
+  { offset: 0x01, size: 1, name: "report_rate_wired" },
+  { offset: 0x02, size: 0x1b, name: "dpi_v6" },
+  { offset: 0x1d, size: 4, name: "dpi_delta" },
+  { offset: 0x21, size: 1, name: "power_mode" },
+  { offset: 0x22, size: 1, name: "angle_snapping" },
+  { offset: 0x23, size: 2, name: "write_counter" },
+  { offset: 0x2c, size: 2, name: "power_save_timeout" },
+  { offset: 0x2e, size: 2, name: "power_off_timeout" },
+  { offset: 0x30, size: 0x30, name: "button_functions" },
+  { offset: 0x70, size: 0x30, name: "g_shift_function" },
+  { offset: 0xa0, size: 0x30, name: "profile_name" },
+  { offset: 0xd0, size: 0x0b, name: "lighting cluster_0_active" },
+  { offset: 0xdb, size: 0x0b, name: "lighting cluster_1_active" },
+  { offset: 0xe6, size: 0x0b, name: "lighting cluster_0_passive" },
+  { offset: 0xf1, size: 0x0b, name: "lighting cluster_1_passive" },
+  { offset: 0xfc, size: 1, name: "lighting_flag" },
+];
+
+const BUNNY_HOPPING: ComponentSpec = { offset: 0x25, size: 1, name: "bunny_hopping" };
+const ANALOG_BUTTON: ComponentSpec = { offset: 0x26, size: 6, name: "analog_button" };
+
+export function componentsForFormat(profileFormatId: number): ComponentSpec[] {
+  const components = profileFormatId >= 6 ? [...COMPONENTS_V6] : [...COMPONENTS_V1];
+  if (profileFormatId >= 7) components.push(BUNNY_HOPPING);
+  if (profileFormatId >= 8) components.push(ANALOG_BUTTON);
+  return components.sort((left, right) => left.offset - right.offset);
+}
+
+/**
+ * Names the field a byte belongs to, so a diff reads as "dpi_v6 +2" rather
+ * than a bare offset. Returns null for bytes no component claims.
+ */
+export function describeOffset(profileFormatId: number, offset: number, sectorSize = 255): string | null {
+  if (offset >= sectorSize - 2) return "checksum";
+  const owner = componentsForFormat(profileFormatId)
+    .find((component) => offset >= component.offset && offset < component.offset + component.size);
+  return owner ? `${owner.name} +${offset - owner.offset}` : null;
+}
+
+export function parseProfilesInfo(reply: Uint8Array): OnboardProfilesInfo {
+  return {
+    memoryModelId: reply[3] ?? 0,
+    profileFormatId: reply[4] ?? 0,
+    profileCount: reply[6] ?? 0,
+    sectorCount: reply[9] ?? 0,
+    sectorSize: ((reply[10] ?? 0) << 8) | (reply[11] ?? 0),
+  };
+}
+
+/** Directory entries are 4 bytes: sector (big-endian), enabled, reserved. */
+export function parseDirectory(bytes: Uint8Array): DirectoryEntry[] {
+  const entries: DirectoryEntry[] = [];
+  for (let offset = 0; offset + 4 <= bytes.length; offset += 4) {
+    const sector = ((bytes[offset] ?? 0) << 8) | (bytes[offset + 1] ?? 0);
+    if (sector === 0xffff || sector === 0x0000) break;
+    entries.push({ sector, enabled: bytes[offset + 2] === 0x01 });
+  }
+  return entries;
+}
+
+/** CRC-16/CCITT-FALSE over everything but the trailing two checksum bytes. */
+export function profileCrc(bytes: Uint8Array): number {
+  let crc = 0xffff;
+  for (let index = 0; index < bytes.length - 2; index += 1) {
+    crc ^= (bytes[index] ?? 0) << 8;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc & 0x8000) ? ((crc << 1) ^ 0x1021) & 0xffff : (crc << 1) & 0xffff;
+    }
+  }
+  return crc;
+}
+
+export function storedCrc(bytes: Uint8Array): number {
+  return ((bytes[bytes.length - 2] ?? 0) << 8) | (bytes[bytes.length - 1] ?? 0);
+}
+
+/** Writes the checksum into the last two bytes, big-endian. */
+export function applyCrc(bytes: Uint8Array): Uint8Array {
+  const crc = profileCrc(bytes);
+  bytes[bytes.length - 2] = (crc >> 8) & 0xff;
+  bytes[bytes.length - 1] = crc & 0xff;
+  return bytes;
+}
+
+/**
+ * Returns a copy of the directory sector with one profile's enabled flag
+ * changed and the checksum recomputed. Every other byte is carried through
+ * untouched, so unknown directory fields survive.
+ */
+export function setDirectoryEnabled(sector: Uint8Array, profileSector: number, enabled: boolean): Uint8Array {
+  const updated = sector.slice();
+  for (let offset = 0; offset + 4 <= updated.length; offset += 4) {
+    const entry = ((updated[offset] ?? 0) << 8) | (updated[offset + 1] ?? 0);
+    if (entry === 0xffff || entry === 0x0000) break;
+    if (entry === profileSector) {
+      updated[offset + 2] = enabled ? 0x01 : 0x00;
+      return applyCrc(updated);
+    }
+  }
+  throw new Error(`Profile sector ${profileSector} is not listed in the directory.`);
+}
+
+function readUint16LE(bytes: Uint8Array, offset: number): number | null {
+  const low = bytes[offset];
+  const high = bytes[offset + 1];
+  if (low === undefined || high === undefined) return null;
+  const value = low | (high << 8);
+  // Unwritten flash reads as 0xffff.
+  return value === 0xffff ? null : value;
+}
+
+/** Profile names are UTF-16LE, despite the library calling them "utf8". */
+function decodeName(bytes: Uint8Array, offset: number): string | null {
+  const slice = bytes.slice(offset, offset + 0x30);
+  if (slice.length === 0 || slice.every((byte) => byte === 0xff)) return null;
+  const text = new TextDecoder("utf-16le").decode(slice).split("\0")[0].trim();
+  return text.length > 0 ? text : null;
+}
+
+function decodeDpi(bytes: Uint8Array, offset: number): { stages: DpiStage[]; defaultIndex: number | null } {
+  const defaultIndex = bytes[offset] ?? null;
+  const stages: DpiStage[] = [];
+  for (let stage = 0; stage < 5; stage += 1) {
+    const base = offset + 2 + stage * 5;
+    const x = readUint16LE(bytes, base);
+    const y = readUint16LE(bytes, base + 2);
+    const lod = bytes[base + 4];
+    if (x === null || y === null || lod === undefined || x === 0) continue;
+    stages.push({ x, y, lod });
+  }
+  return { stages, defaultIndex: defaultIndex === 0xff ? null : defaultIndex };
+}
+
+function decodeReportRate(bytes: Uint8Array, offset: number | null): number | null {
+  if (offset === null) return null;
+  const raw = bytes[offset];
+  return raw === undefined || raw === 0xff ? null : REPORT_RATE_HZ[raw] ?? null;
+}
+
+/** Rates the byte can index, filtered to the ceiling for that connection. */
+export function reportRatesFor(
+  capabilities: ReportRateCapabilities | null,
+  link: "wireless" | "wired",
+): number[] {
+  if (!capabilities) return [];
+  const ceiling = link === "wired" ? capabilities.wiredMaxHz : capabilities.wirelessMaxHz;
+  return REPORT_RATE_HZ.filter((rate) => rate <= ceiling);
+}
+
+export function validateReportRate(
+  hz: number,
+  capabilities: ReportRateCapabilities | null,
+  link: "wireless" | "wired",
+): string | null {
+  const allowed = reportRatesFor(capabilities, link);
+  if (allowed.length === 0) return "Report rates are not known for this profile format.";
+  if (!allowed.includes(hz)) {
+    return `${link === "wired" ? "Wired" : "Wireless"} report rate must be one of ${allowed.join(", ")} Hz.`;
+  }
+  return null;
+}
+
+/**
+ * Returns a copy of the sector with one connection's report rate replaced and
+ * the checksum reapplied. The two links are stored separately, so setting one
+ * leaves the other alone.
+ */
+export function encodeReportRate(
+  sector: Uint8Array,
+  profileFormatId: number,
+  link: "wireless" | "wired",
+  hz: number,
+): Uint8Array {
+  const capabilities = capabilitiesForFormat(profileFormatId).reportRates;
+  const invalid = validateReportRate(hz, capabilities, link);
+  if (invalid) throw new Error(invalid);
+  const layout = layoutForFormat(profileFormatId);
+  const offset = link === "wired" ? layout.reportRateWired : layout.reportRateWireless;
+  if (offset === null) throw new Error("This profile format has no report-rate setting.");
+
+  const result = sector.slice();
+  result[offset] = REPORT_RATE_HZ.indexOf(hz as (typeof REPORT_RATE_HZ)[number]);
+  return applyCrc(result);
+}
+
+/** Returns why a profile name cannot be stored, or null when it fits. */
+export function validateProfileName(name: string, maxLength: number | null): string | null {
+  if (maxLength === null) return "This profile format has no name field.";
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return "Enter a profile name.";
+  if (trimmed.length > maxLength) return `Profile names are at most ${maxLength} characters.`;
+  // The region is UTF-16 code units, so anything outside the BMP takes two of
+  // them and would be cut in half by the length check above.
+  if ([...trimmed].some((character) => (character.codePointAt(0) ?? 0) > 0xffff)) {
+    return "Profile names cannot contain emoji or other characters outside the basic range.";
+  }
+  return null;
+}
+
+/**
+ * Returns a copy of the sector with the profile name replaced and the checksum
+ * reapplied. The region is zero-filled first so a shorter name cannot leave the
+ * tail of the previous one behind it.
+ */
+export function encodeProfileName(
+  sector: Uint8Array,
+  profileFormatId: number,
+  name: string,
+): Uint8Array {
+  const invalid = validateProfileName(name, capabilitiesForFormat(profileFormatId).maxNameLength);
+  if (invalid) throw new Error(invalid);
+  const offset = layoutForFormat(profileFormatId).profileName;
+
+  const result = sector.slice();
+  result.fill(0, offset, offset + PROFILE_NAME_BYTES);
+  const trimmed = name.trim();
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const code = trimmed.charCodeAt(index);
+    result[offset + index * 2] = code & 0xff;
+    result[offset + index * 2 + 1] = (code >> 8) & 0xff;
+  }
+  return applyCrc(result);
+}
+
+export const BUNNY_HOP_LIMITS = { minMs: 100, maxMs: 1000, stepMs: 10 } as const;
+
+/**
+ * Returns why a bunny-hop time is invalid, or null when it is acceptable.
+ * The byte stores ms / 10, so anything off-step cannot be represented.
+ */
+export function validateBunnyHoppingMs(milliseconds: number): string | null {
+  if (!Number.isFinite(milliseconds) || !Number.isInteger(milliseconds)) {
+    return "Enter a whole number of milliseconds.";
+  }
+  if (milliseconds % BUNNY_HOP_LIMITS.stepMs !== 0) {
+    return `Bunny hop time must be a multiple of ${BUNNY_HOP_LIMITS.stepMs} ms.`;
+  }
+  if (milliseconds === 0) return null; // off
+  if (milliseconds < BUNNY_HOP_LIMITS.minMs || milliseconds > BUNNY_HOP_LIMITS.maxMs) {
+    return `Bunny hop time must be between ${BUNNY_HOP_LIMITS.minMs} and ${BUNNY_HOP_LIMITS.maxMs} ms, or off.`;
+  }
+  return null;
+}
+
+/** The stage table always has room for five records; how many a format allows
+ * is a per-format limit, so this is only the size of the region to clear. */
+const DPI_STAGE_SLOTS = 5;
+
+export interface DpiStagePlan {
+  /** One entry per slot the user wants, within the format's limit. */
+  stages: DpiStage[];
+  /** Which slot the mouse starts on, as an index into `stages`. */
+  defaultIndex: number;
+}
+
+/**
+ * Returns why a stage plan cannot be written to this format, or null when it
+ * is writable. Every limit comes from the format, so an older mouse holding
+ * fewer slots or a narrower DPI range is checked against its own numbers.
+ */
+export function validateDpiStagePlan(
+  plan: DpiStagePlan,
+  capabilities: DpiStageCapabilities | null,
+): string | null {
+  if (capabilities === null) {
+    return "DPI slots are not known for this profile format.";
+  }
+  const { maxStages, minDpi, maxDpi, stepDpi } = capabilities;
+  if (plan.stages.length < 1 || plan.stages.length > maxStages) {
+    return `This profile holds 1 to ${maxStages} DPI slots.`;
+  }
+  if (!Number.isInteger(plan.defaultIndex) || plan.defaultIndex < 0 || plan.defaultIndex >= plan.stages.length) {
+    return "The default slot must be one of the slots in use.";
+  }
+  for (const [index, stage] of plan.stages.entries()) {
+    for (const [axis, value] of [["X", stage.x], ["Y", stage.y]] as const) {
+      if (!Number.isInteger(value) || value < minDpi || value > maxDpi) {
+        return `Slot ${index + 1} ${axis} DPI must be between ${minDpi} and ${maxDpi}.`;
+      }
+      if (value % stepDpi !== 0) {
+        return `Slot ${index + 1} ${axis} DPI must be a multiple of ${stepDpi}.`;
+      }
+    }
+    // 0 is the "unused stage" marker, so an in-use slot cannot carry it.
+    if (!Number.isInteger(stage.lod) || stage.lod < 1 || stage.lod > 3) {
+      return `Slot ${index + 1} has an invalid lift-off level.`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Levels as stored inside a stage record, where 0 means the stage is unused.
+ * This is a property of the record itself, so it does not vary with whatever
+ * encoding feature 0x2202 happens to use on a given format.
+ */
+export const PROFILE_STAGE_LOD: Record<LiftOffLevel, number> = { Low: 1, Medium: 2, High: 3 };
+
+export function stageLodLevel(lod: number): LiftOffLevel | null {
+  return (Object.keys(PROFILE_STAGE_LOD) as LiftOffLevel[])
+    .find((level) => PROFILE_STAGE_LOD[level] === lod) ?? null;
+}
+
+/** Snaps a typed DPI onto the step and into the range the format allows. */
+export function clampDpi(value: number, capabilities: DpiStageCapabilities): number {
+  const { minDpi, maxDpi, stepDpi } = capabilities;
+  if (!Number.isFinite(value)) return minDpi;
+  const stepped = Math.round(value / stepDpi) * stepDpi;
+  return Math.min(maxDpi, Math.max(minDpi, stepped));
+}
+
+/**
+ * Returns a copy of the sector with the DPI stage table replaced and the
+ * checksum reapplied. Slots past the plan are zeroed, which is how the vendor
+ * marks a stage unused, so the slot count is simply how many stages are set.
+ */
+export function encodeDpiStages(
+  sector: Uint8Array,
+  profileFormatId: number,
+  plan: DpiStagePlan,
+): Uint8Array {
+  const invalid = validateDpiStagePlan(plan, capabilitiesForFormat(profileFormatId).dpiStages);
+  if (invalid) throw new Error(invalid);
+  const layout = layoutForFormat(profileFormatId);
+  if (layout.dpi === null) throw new Error("This profile format has no DPI stages.");
+
+  const result = sector.slice();
+  result[layout.dpi] = plan.defaultIndex;
+  // 0x03 is the g-shift index. It is left alone unless it now points past the
+  // slots in use, in which case it would select a zeroed stage.
+  const gShift = result[layout.dpi + 1] ?? 0;
+  if (gShift >= plan.stages.length) result[layout.dpi + 1] = plan.defaultIndex;
+
+  for (let stage = 0; stage < DPI_STAGE_SLOTS; stage += 1) {
+    const base = layout.dpi + 2 + stage * 5;
+    const entry = plan.stages[stage];
+    if (!entry) {
+      result[base] = 0; result[base + 1] = 0;
+      result[base + 2] = 0; result[base + 3] = 0;
+      result[base + 4] = 0;
+      continue;
+    }
+    writeUint16LE(result, base, entry.x);
+    writeUint16LE(result, base + 2, entry.y);
+    result[base + 4] = entry.lod;
+  }
+  return applyCrc(result);
+}
+
+/**
+ * Snaps a typed bunny-hop time into the range and step the byte can hold.
+ * A number field only enforces min/max/step for its spinner, so a typed value
+ * has to be corrected here instead of being rejected.
+ */
+export function clampBunnyHopMs(milliseconds: number): number {
+  const { minMs, maxMs, stepMs } = BUNNY_HOP_LIMITS;
+  if (!Number.isFinite(milliseconds)) return minMs;
+  const stepped = Math.round(milliseconds / stepMs) * stepMs;
+  return Math.min(maxMs, Math.max(minMs, stepped));
+}
+
+/** Stored as ms / 10: G HUB's 100-1000 ms range is 0x0a-0x64. */
+function decodeBunnyHoppingMs(bytes: Uint8Array, offset: number | null): number | null {
+  if (offset === null) return null;
+  const raw = bytes[offset];
+  return raw === undefined || raw === 0xff ? null : raw * 10;
+}
+
+function writeUint16LE(bytes: Uint8Array, offset: number, value: number): void {
+  bytes[offset] = value & 0xff;
+  bytes[offset + 1] = (value >> 8) & 0xff;
+}
+
+/**
+ * Rebuilds `before` with every field we can encode set to the value found in
+ * `after`, then fixes the checksum.
+ *
+ * This is how a write path is proven without writing: if the result is
+ * byte-identical to what the vendor software actually produced, our encoding,
+ * offsets and CRC are all correct. Any byte that differs is something we either
+ * model wrongly or cannot write yet.
+ */
+export function reproduceProfile(before: Uint8Array, after: Uint8Array, profileFormatId: number): Uint8Array {
+  const layout = layoutForFormat(profileFormatId);
+  const result = before.slice();
+
+  const copyRate = (offset: number | null): void => {
+    if (offset === null) return;
+    const hz = decodeReportRate(after, offset);
+    const index = hz === null ? null : REPORT_RATE_HZ.indexOf(hz as (typeof REPORT_RATE_HZ)[number]);
+    if (index !== null && index >= 0) result[offset] = index;
+  };
+  copyRate(layout.reportRateWireless);
+  copyRate(layout.reportRateWired);
+
+  if (layout.dpi !== null) {
+    const dpi = decodeDpi(after, layout.dpi);
+    if (dpi.defaultIndex !== null) result[layout.dpi] = dpi.defaultIndex;
+    result[layout.dpi + 1] = after[layout.dpi + 1];
+    // Stages are re-encoded from decoded values, not copied, so the little
+    // endian x/y/lod encoding is what is actually under test.
+    let stage = 0;
+    for (const { x, y, lod } of dpi.stages) {
+      const base = layout.dpi + 2 + stage * 5;
+      writeUint16LE(result, base, x);
+      writeUint16LE(result, base + 2, y);
+      result[base + 4] = lod;
+      stage += 1;
+    }
+  }
+
+  const angleSnapping = after[layout.angleSnapping];
+  if (angleSnapping !== undefined) result[layout.angleSnapping] = angleSnapping;
+
+  if (layout.bunnyHopping !== null) {
+    const milliseconds = decodeBunnyHoppingMs(after, layout.bunnyHopping);
+    if (milliseconds !== null) result[layout.bunnyHopping] = Math.round(milliseconds / 10);
+  }
+
+  for (const offset of [layout.powerSaveTimeout, layout.powerOffTimeout]) {
+    if (offset === null) continue;
+    const seconds = readUint16LE(after, offset);
+    if (seconds !== null) writeUint16LE(result, offset, seconds);
+  }
+
+  const name = decodeName(after, layout.profileName);
+  if (name !== null) {
+    const encoded = new Uint8Array(0x30);
+    encoded.set(after.slice(layout.profileName, layout.profileName + 0x30).map(() => 0));
+    for (let index = 0; index < name.length && index * 2 + 1 < 0x30; index += 1) {
+      const code = name.charCodeAt(index);
+      encoded[index * 2] = code & 0xff;
+      encoded[index * 2 + 1] = (code >> 8) & 0xff;
+    }
+    result.set(encoded, layout.profileName);
+  }
+
+  return applyCrc(result);
+}
+
+export function decodeOnboardProfile(
+  bytes: Uint8Array,
+  profileFormatId: number,
+  entry: DirectoryEntry,
+  isCurrent: boolean,
+): OnboardProfile {
+  const layout = layoutForFormat(profileFormatId);
+  const dpi = layout.dpi === null
+    ? { stages: [], defaultIndex: null }
+    : decodeDpi(bytes, layout.dpi);
+  const angleSnappingByte = bytes[layout.angleSnapping];
+
+  return {
+    sector: entry.sector,
+    enabled: entry.enabled,
+    isCurrent,
+    name: decodeName(bytes, layout.profileName),
+    dpiStages: dpi.stages,
+    defaultDpiIndex: dpi.defaultIndex,
+    reportRateWireless: decodeReportRate(bytes, layout.reportRateWireless),
+    reportRateWired: decodeReportRate(bytes, layout.reportRateWired),
+    angleSnapping: angleSnappingByte === undefined || angleSnappingByte === 0xff
+      ? null
+      : angleSnappingByte !== 0,
+    powerSaveTimeoutSeconds: layout.powerSaveTimeout === null
+      ? null
+      : readUint16LE(bytes, layout.powerSaveTimeout),
+    powerOffTimeoutSeconds: layout.powerOffTimeout === null
+      ? null
+      : readUint16LE(bytes, layout.powerOffTimeout),
+    bunnyHoppingMs: decodeBunnyHoppingMs(bytes, layout.bunnyHopping),
+    crcValid: bytes.length > 2 && profileCrc(bytes) === storedCrc(bytes),
+    raw: bytes,
+  };
+}

--- a/src/devices/logitech/protocol.ts
+++ b/src/devices/logitech/protocol.ts
@@ -28,6 +28,16 @@ export function isDirectConnectProduct(productId: number): boolean {
   return DIRECT_PRODUCT_ID_SET.has(productId);
 }
 
+/**
+ * Whether this HID++ endpoint is the mouse itself rather than a receiver.
+ * Runtime probing is authoritative for unknown Logitech product IDs; the PID
+ * list is only the pre-probe fast path.
+ */
+export function isDirectConnection(productId: number, resolvedDeviceIndex: number | null): boolean {
+  return resolvedDeviceIndex === DEVICE_INDEX_DIRECT
+    || (resolvedDeviceIndex === null && isDirectConnectProduct(productId));
+}
+
 export function hidppDeviceIndex(productId: number): number {
   return isDirectConnectProduct(productId) ? DEVICE_INDEX_DIRECT : DEVICE_INDEX_RECEIVER;
 }
@@ -43,6 +53,10 @@ const HIDPP_ERRORS: Readonly<Record<number, string>> = {
   0x07: "invalid function",
   0x08: "device busy",
   0x09: "unsupported",
+  // Not in the HID++ 2.0 enum, which stops at 0x09. Older firmware answers a
+  // 2.0-shaped error with the 1.0 code REQUEST_UNAVAILABLE, which a G102
+  // returns when asked for something its current mode does not allow.
+  0x0a: "the mouse will not accept that request in its current mode",
 };
 
 export function hidppErrorMessage(code: number): string {
@@ -108,5 +122,28 @@ export function decodeBatteryLevelState(batteryStatus: number): BatteryChargeSta
     case 0x04: return "Charging slowly";
     // 5 invalid battery, 6 thermal error, 7 other charging error.
     default: return "Unknown";
+  }
+}
+
+/**
+ * The mouse keeps its settings in onboard memory and will not hand control to
+ * software, so the only way to change anything is to write its profile — which
+ * needs a decoded layout for that profile format.
+ *
+ * Its own type because it is not a fault: it is a mouse that cannot be
+ * supported yet, and the way forward is a capture from whoever owns one.
+ */
+export class OnboardOnlyError extends Error {
+  readonly profileFormatId: number | null;
+
+  constructor(profileFormatId: number | null) {
+    super(
+      "This mouse keeps its settings in onboard memory and will not hand control to software. "
+      + `Writing ${profileFormatId === null ? "its profile format" : `profile format ${profileFormatId}`} `
+      + 'is not supported yet. Open Diagnostics, then HID++ capture, and use "Copy verification data" — '
+      + "sending that is what lets the layout be added.",
+    );
+    this.name = "OnboardOnlyError";
+    this.profileFormatId = profileFormatId;
   }
 }

--- a/src/devices/logitech/protocol.ts
+++ b/src/devices/logitech/protocol.ts
@@ -75,3 +75,38 @@ export function decodeReportRateBitmap(bitflags: number): number[] {
 export function legacyDpiFallback(): number[] {
   return Array.from({ length: 46 }, (_, step) => 252 + step * 84);
 }
+
+export type BatteryChargeState =
+  | "Charging" | "Charging slowly" | "Almost full" | "Full" | "Discharging" | "Unknown";
+
+/**
+ * 0x1004 UNIFIED_BATTERY chargingStatus.
+ *
+ * Deliberately separate from the 0x1000 mapping below: the two features number
+ * their states differently, and decoding one with the other's table reports a
+ * slow charge as "almost full".
+ */
+export function decodeUnifiedBatteryState(chargingStatus: number): BatteryChargeState {
+  switch (chargingStatus) {
+    case 0x00: return "Discharging";
+    case 0x01: return "Charging";
+    case 0x02: return "Charging slowly";
+    case 0x03: return "Full";
+    // 4 is a charging fault. There is no state for it, and calling it charging
+    // would be worse than admitting we do not know.
+    default: return "Unknown";
+  }
+}
+
+/** 0x1000 BATTERY_LEVEL_STATUS batteryStatus. */
+export function decodeBatteryLevelState(batteryStatus: number): BatteryChargeState {
+  switch (batteryStatus) {
+    case 0x00: return "Discharging";
+    case 0x01: return "Charging";
+    case 0x02: return "Almost full";
+    case 0x03: return "Full";
+    case 0x04: return "Charging slowly";
+    // 5 invalid battery, 6 thermal error, 7 other charging error.
+    default: return "Unknown";
+  }
+}

--- a/src/devices/logitech/protocol.ts
+++ b/src/devices/logitech/protocol.ts
@@ -43,7 +43,7 @@ export function hidppDeviceIndex(productId: number): number {
 }
 
 /** HID++ 2.0 error codes, reported in byte 4 of a 0xFF error response. */
-const HIDPP_ERRORS: Readonly<Record<number, string>> = {
+const HIDPP20_ERRORS: Readonly<Record<number, string>> = {
   0x01: "unknown request",
   0x02: "invalid argument",
   0x03: "value out of range",
@@ -53,17 +53,53 @@ const HIDPP_ERRORS: Readonly<Record<number, string>> = {
   0x07: "invalid function",
   0x08: "device busy",
   0x09: "unsupported",
-  // Not in the HID++ 2.0 enum, which stops at 0x09. Older firmware answers a
-  // 2.0-shaped error with the 1.0 code REQUEST_UNAVAILABLE, which a G102
-  // returns when asked for something its current mode does not allow.
-  0x0a: "the mouse will not accept that request in its current mode",
+};
+
+/** HID++ 1.0 error codes, reported in byte 4 of a 0x8F error response. */
+const HIDPP10_ERRORS: Readonly<Record<number, string>> = {
+  0x01: "invalid command",
+  0x02: "invalid address",
+  0x03: "invalid value",
+  0x04: "connection request failed",
+  0x05: "too many devices",
+  0x06: "already exists",
+  0x07: "device busy",
+  0x08: "unknown device",
+  0x09: "resource error",
+  0x0a: "request unavailable",
+  0x0b: "unsupported parameter value",
+  0x0c: "wrong PIN code",
 };
 
 export function hidppErrorMessage(code: number): string {
-  const reason = HIDPP_ERRORS[code];
+  const reason = HIDPP20_ERRORS[code];
   return reason
     ? `The mouse rejected that setting (${reason}).`
-    : `The mouse rejected that setting (HID++ error 0x${code.toString(16).padStart(2, "0")}).`;
+    : `The mouse rejected that setting (HID++ 2.0 error 0x${code.toString(16).padStart(2, "0")}).`;
+}
+
+export function hidpp10ErrorMessage(code: number): string {
+  const reason = HIDPP10_ERRORS[code];
+  return reason
+    ? `The mouse rejected that setting (HID++ 1.0: ${reason}).`
+    : `The mouse rejected that setting (HID++ 1.0 error 0x${code.toString(16).padStart(2, "0")}).`;
+}
+
+/**
+ * Decodes an error only when it echoes the request being awaited.
+ *
+ * HID++ 1.0: [device, 0x8f, sub-id, address, error]
+ * HID++ 2.0: [device, 0xff, feature-index, function+software-id, error]
+ */
+export function hidppErrorForRequest(
+  report: Uint8Array,
+  requestFirstByte: number,
+  requestSecondByte: number,
+): string | null {
+  if (report[2] !== requestFirstByte || report[3] !== withSoftwareId(requestSecondByte)) return null;
+  if (report[1] === 0x8f) return hidpp10ErrorMessage(report[4] ?? 0);
+  if (report[1] === 0xff) return hidppErrorMessage(report[4] ?? 0);
+  return null;
 }
 
 /**

--- a/src/devices/mouse-types.ts
+++ b/src/devices/mouse-types.ts
@@ -13,7 +13,7 @@ export interface MouseUiHints {
    * in, so they are worth reporting even while `settingsReady` hides the grid.
    */
   valuesVerified?: boolean;
-  /** Hide 0.7 mm LOD option. */
+  /** Hide the Low LOD option. */
   hideLodLow?: boolean;
   /** Disable LOD controls while gamingSurfaceMode is "Off". */
   lodRequiresSurface?: boolean;
@@ -89,6 +89,15 @@ export interface MouseStatus {
   liftOffDistance: "Low" | "Medium" | "High" | null;
   /** Explicit LOD choices when a mouse does not support all three common levels. */
   supportedLiftOffDistances?: Array<NonNullable<MouseStatus["liftOffDistance"]>>;
+  /** Logitech onboard profile format (HID++ 0x8100), which selects the layout. */
+  onboardProfileFormat?: {
+    id: number;
+    name: string;
+    base: string;
+    supported: boolean;
+    /** False when the layout comes from vendor code but was never confirmed on hardware. */
+    verified: boolean;
+  } | null;
   gamingSurfaceMode?: "On" | "Off" | "Auto" | null;
   lightforceSwitchMode?: "Hybrid" | "Optical" | null;
   firmware: string[];

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -46,9 +46,16 @@ export const LOGITECH_PRODUCT_IDS = [
   ...LOGITECH_DIRECT_PRODUCT_IDS,
 ] as const;
 
-export const LOGITECH_RECEIVER_FILTERS: HIDDeviceFilter[] = LOGITECH_PRODUCT_IDS.map(
-  (productId) => ({ vendorId: VENDOR_ID.logitech, productId, usagePage: 0xff00, usage: 0x0001 }),
-);
+/**
+ * Every Logitech HID++ control interface, not only the product ids listed
+ * above: a mouse we have never seen should still be offered. The usage page
+ * keeps this to HID++ endpoints, but it cannot tell a mouse from a keyboard or
+ * a headset — the driver decides that after connecting, by looking for a sensor
+ * feature, and reports a clear message when there is none.
+ */
+export const LOGITECH_RECEIVER_FILTERS: HIDDeviceFilter[] = [
+  { vendorId: VENDOR_ID.logitech, usagePage: 0xff00, usage: 0x0001 },
+];
 
 // Retained for existing imports; points at the first supported receiver.
 export const LOGITECH_RECEIVER_FILTER: HIDDeviceFilter = LOGITECH_RECEIVER_FILTERS[0];

--- a/src/pending-changes.test.ts
+++ b/src/pending-changes.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   clearPendingChanges,
   hasPendingChanges,
+  pendingChangeBatches,
   pendingChanges,
   stagePendingChange,
   withPendingChanges,
@@ -32,6 +33,62 @@ test("staged changes replace earlier values for the same setting", () => {
 
   assert.equal(pendingChanges().length, 1);
   assert.equal(pendingChanges()[0]?.label, "DPI 1600");
+  clearPendingChanges();
+});
+
+test("a change with no preview still stages", () => {
+  // Settings that live outside MouseStatus (Logitech onboard profile values)
+  // omit preview and render themselves, so previewing must be a no-op rather
+  // than a reason to skip the change.
+  clearPendingChanges();
+  const deviceStatus = status();
+  stagePendingChange({ key: "bunny-hop", label: "Bunny hop 200 ms", command: "", progress: "", apply: async () => {} });
+
+  assert.equal(hasPendingChanges(), true);
+  assert.equal(pendingChanges()[0]?.label, "Bunny hop 200 ms");
+  assert.deepEqual(withPendingChanges(deviceStatus), deviceStatus);
+  clearPendingChanges();
+});
+
+test("changes sharing a group collapse into one write", () => {
+  clearPendingChanges();
+  const written: string[] = [];
+  const stage = (key: string, group?: string) => stagePendingChange({
+    key, group, label: key, command: "", progress: "",
+    apply: async () => { written.push(key); },
+  });
+
+  stage("gaming-surface", "mode-status");
+  stage("dpi");
+  stage("lightforce", "mode-status");
+
+  const batches = pendingChangeBatches();
+  assert.equal(batches.length, 2, "the two mode-status changes share a batch");
+  // The group keeps the position of its first member, so the flash order
+  // follows the order settings were touched.
+  assert.deepEqual(batches[0]?.map((change) => change.key), ["gaming-surface", "lightforce"]);
+  assert.deepEqual(batches[1]?.map((change) => change.key), ["dpi"]);
+
+  // A batch is written by its last member, which carries the combined value.
+  assert.equal(batches[0]?.at(-1)?.key, "lightforce");
+  clearPendingChanges();
+});
+
+test("restaging a grouped change does not split its group", () => {
+  clearPendingChanges();
+  const stage = (key: string, group: string) => stagePendingChange({
+    key, group, label: key, command: "", progress: "", apply: async () => {},
+  });
+
+  stage("gaming-surface", "mode-status");
+  stage("lightforce", "mode-status");
+  // Re-selecting a value re-inserts the key, which must not leave the group
+  // behind as a second batch and write the byte twice.
+  stage("gaming-surface", "mode-status");
+
+  const batches = pendingChangeBatches();
+  assert.equal(batches.length, 1);
+  assert.equal(batches[0]?.length, 2);
   clearPendingChanges();
 });
 

--- a/src/pending-changes.ts
+++ b/src/pending-changes.ts
@@ -3,6 +3,12 @@ import type { MouseStatus } from "./devices/mouse-types";
 export interface PendingChange {
   // Dedupe key. Staging the same key again replaces the earlier entry.
   key: string;
+  // Settings that land in the same byte, sector or transaction share a group.
+  // A group is written once, by the last change staged into it, so its apply
+  // has to write every staged value in the group rather than only its own.
+  // Without this, two changes to one byte cost two writes and the second is
+  // built from a device read the first has already invalidated.
+  group?: string;
   // Short summary shown in the unsaved-changes bar, e.g. "DPI 1,600".
   label: string;
   // Diagnostics command text recorded when the change is flashed.
@@ -10,7 +16,10 @@ export interface PendingChange {
   // Live-status copy shown while this change is being written.
   progress: string;
   // Mirrors the staged value onto a status snapshot so the UI can render it.
-  preview(status: MouseStatus): void;
+  // Omitted when the setting is not part of MouseStatus (a Logitech onboard
+  // profile value, say); such a change renders itself and cannot be compared
+  // against the device status.
+  preview?(status: MouseStatus): void;
   // Writes the staged value to the device.
   apply(): Promise<void>;
 }
@@ -35,6 +44,34 @@ export function stagePendingChange(change: PendingChange): void {
 
 export function pendingChanges(): PendingChange[] {
   return [...changes.values()];
+}
+
+/**
+ * Staged changes split into the batches a flash should write, in staging order.
+ * Changes sharing a group collapse into one batch; an ungrouped change is a
+ * batch of its own. The last entry of a batch is the one that performs the
+ * write, so a batch is applied by calling `apply` on `batch.at(-1)`.
+ */
+export function pendingChangeBatches(): PendingChange[][] {
+  const batches: PendingChange[][] = [];
+  const byGroup = new Map<string, PendingChange[]>();
+  for (const change of changes.values()) {
+    if (change.group === undefined) {
+      batches.push([change]);
+      continue;
+    }
+    const existing = byGroup.get(change.group);
+    if (existing) {
+      existing.push(change);
+      continue;
+    }
+    // The batch keeps the position of its first member, so the bar and the
+    // flash order follow the order settings were touched.
+    const batch = [change];
+    byGroup.set(change.group, batch);
+    batches.push(batch);
+  }
+  return batches;
 }
 
 export function pendingChangeCount(): number {
@@ -66,6 +103,6 @@ export function clearPendingChanges(): void {
 export function withPendingChanges(status: MouseStatus): MouseStatus {
   if (changes.size === 0) return status;
   const preview = structuredClone(status);
-  for (const change of changes.values()) change.preview(preview);
+  for (const change of changes.values()) change.preview?.(preview);
   return preview;
 }

--- a/src/preview-fixtures.ts
+++ b/src/preview-fixtures.ts
@@ -1,4 +1,7 @@
 import type { MouseStatus } from "./devices/mouse-types";
+import { PREVIEW_KEYS, type FixturePreviewMode } from "./preview-modes";
+
+export { PREVIEW_KEYS };
 
 /**
  * Dev-only stand-in statuses, one per supported driver.
@@ -299,7 +302,7 @@ const LOGITECH_LEGACY: MouseStatus = {
  * Keyed by the `?preview=` value. `superstrike` and `slots` are handled
  * separately because they drive panels beyond a plain status.
  */
-export const PREVIEW_FIXTURES: Record<string, PreviewFixture> = {
+export const PREVIEW_FIXTURES: Record<FixturePreviewMode, PreviewFixture> = {
   pulsar: { label: "Pulsar X2H Mini", status: PULSAR },
   "pulsar-pro": { label: "Pulsar X2H Mini Pro", status: PULSAR_PRO },
   "egg-op1": { label: "Endgame Gear OP1 8K", status: EGG_OP1 },
@@ -315,6 +318,3 @@ export const PREVIEW_FIXTURES: Record<string, PreviewFixture> = {
   finalmouse: { label: "Finalmouse UltralightX", status: FINALMOUSE },
   "logitech-legacy": { label: "Logitech G402 (legacy DPI)", status: LOGITECH_LEGACY },
 };
-
-/** Every `?preview=` value, including the two with their own setup. */
-export const PREVIEW_KEYS = ["slots", "superstrike", ...Object.keys(PREVIEW_FIXTURES)];

--- a/src/preview-fixtures.ts
+++ b/src/preview-fixtures.ts
@@ -1,0 +1,320 @@
+import type { MouseStatus } from "./devices/mouse-types";
+
+/**
+ * Dev-only stand-in statuses, one per supported driver.
+ *
+ * The control shell decides which cards and panels to show entirely from
+ * `MouseStatus`, so a fixture that matches what a driver really reports
+ * exercises the same rendering path the device would. That makes it possible to
+ * check a shell change against every brand without owning every mouse.
+ *
+ * Each fixture is modelled on the corresponding driver's readStatus return, so
+ * when a driver changes what it reports its fixture should change with it.
+ */
+export interface PreviewFixture {
+  /** Shown in the picker and the live-status line. */
+  label: string;
+  status: MouseStatus;
+}
+
+const PULSAR: MouseStatus = {
+  brand: "Pulsar",
+  name: "X2H Mini",
+  ui: { family: "pulsar", hideUnsupportedPollingRates: true },
+  batteryPercent: 64,
+  batteryState: "Discharging",
+  dpi: 1600,
+  pollingRateHz: 1000,
+  supportedPollingRates: [125, 250, 500, 1000],
+  activeProfile: 1,
+  liftOffDistance: "Medium",
+  connectionType: "Wireless",
+  connectionDetail: "2.4 GHz receiver",
+  dongleLedEnabled: true,
+  signalStrength: 82,
+  motionSync: true,
+  debounceMs: 4,
+  sleepTimeout: 30,
+  angleSnapping: false,
+  rippleControl: false,
+  firmware: ["1.04.11"],
+};
+
+const PULSAR_PRO: MouseStatus = {
+  ...PULSAR,
+  name: "X2H Mini Pro",
+  performanceMode: true,
+  angleTuning: 0,
+  wheelAcceleration: false,
+  pollingRateHz: 4000,
+  supportedPollingRates: [125, 250, 500, 1000, 2000, 4000, 8000],
+  firmware: ["2.01.03"],
+};
+
+const EGG_OP1: MouseStatus = {
+  brand: "Endgame Gear",
+  name: "OP1 8K",
+  ui: { family: "egg-op1", hideLodLow: true, hideUnsupportedPollingRates: true },
+  batteryPercent: null,
+  batteryState: "Unknown",
+  dpi: 3200,
+  pollingRateHz: 8000,
+  supportedPollingRates: [1000, 2000, 4000, 8000],
+  activeProfile: 2,
+  liftOffDistance: "Medium",
+  connectionType: "Wired",
+  motionSync: false,
+  angleSnapping: false,
+  rippleControl: false,
+  leftSpdtMode: "GX Speed",
+  rightSpdtMode: "GX Safe",
+  eggCpiLevels: 4,
+  eggCpiStages: [{ x: 800, y: 800 }, { x: 1600, y: 1600 }, { x: 3200, y: 3200 }, { x: 6400, y: 6400 }],
+  eggPollingDivider: 1,
+  eggMulticlickFilters: [0, 0],
+  eggButtonMappings: ["Left", "Right", "Middle", "Back", "Forward"],
+  firmware: ["1.02.00"],
+};
+
+const EGG_WE: MouseStatus = {
+  brand: "Endgame Gear",
+  name: "OP1we",
+  ui: {
+    family: "egg-we",
+    settingsReady: true,
+    hideLodLow: true,
+    hideUnsupportedPollingRates: true,
+    hideProcessingCard: true,
+    forceShowBattery: true,
+    pollingNote: "OP1we supports up to 1,000 Hz (125 / 250 / 500 / 1000).",
+    defaultDisplayName: "Endgame Gear OP1we",
+  },
+  batteryPercent: 58,
+  batteryState: "Discharging",
+  dpi: 1600,
+  pollingRateHz: 1000,
+  supportedPollingRates: [125, 250, 500, 1000],
+  activeProfile: 1,
+  liftOffDistance: "Medium",
+  connectionType: "Wireless",
+  slamclickFilter: true,
+  motionJitterFilter: false,
+  firmware: ["1.00.07"],
+};
+
+const WLMOUSE: MouseStatus = {
+  brand: "WLMouse",
+  name: "BEAST X",
+  ui: { family: "wlmouse", hideUnsupportedPollingRates: true, forceShowBattery: true },
+  batteryPercent: 91,
+  batteryState: "Charging",
+  dpi: 800,
+  dpiY: 800,
+  supportsSeparateDpiAxes: true,
+  pollingRateHz: 8000,
+  supportedPollingRates: [125, 250, 500, 1000, 2000, 4000, 8000],
+  activeProfile: 1,
+  liftOffDistance: "Low",
+  connectionType: "Wireless",
+  motionSync: true,
+  debounceMs: 2,
+  sleepTimeout: 60,
+  firmware: ["0.9.2"],
+};
+
+const LAMZU: MouseStatus = {
+  brand: "Lamzu",
+  name: "Atlantis OG V2",
+  ui: { family: "lamzu", hideUnsupportedPollingRates: true, forceShowBattery: true },
+  batteryPercent: 47,
+  batteryState: "Discharging",
+  dpi: 1600,
+  dpiY: 1600,
+  supportsSeparateDpiAxes: true,
+  pollingRateHz: 4000,
+  supportedPollingRates: [125, 250, 500, 1000, 2000, 4000],
+  activeProfile: 3,
+  liftOffDistance: "Medium",
+  connectionType: "Wireless",
+  motionSync: false,
+  debounceMs: 3,
+  sleepTimeout: 30,
+  firmware: ["1.1.4"],
+};
+
+const ATK: MouseStatus = {
+  brand: "ATK",
+  name: "A9 Ultra",
+  ui: { family: "atk", hideUnsupportedPollingRates: true, forceShowBattery: true },
+  batteryPercent: 73,
+  batteryState: "Unknown",
+  dpi: 1600,
+  dpiY: 1600,
+  supportsSeparateDpiAxes: false,
+  pollingRateHz: 8000,
+  supportedPollingRates: [125, 250, 500, 1000, 2000, 4000, 8000],
+  activeProfile: null,
+  liftOffDistance: "Medium",
+  connectionType: "Wireless",
+  firmware: ["1.0.0"],
+};
+
+const ORBITAL: MouseStatus = {
+  brand: "Orbital",
+  name: "Orbital One",
+  ui: { defaultDisplayName: "Orbital One", hideLodLow: false, hideUnsupportedPollingRates: true },
+  batteryPercent: 88,
+  batteryState: "Discharging",
+  dpi: 1600,
+  dpiY: 1600,
+  supportsSeparateDpiAxes: true,
+  pollingRateHz: 2000,
+  supportedPollingRates: [125, 250, 500, 1000, 2000, 4000],
+  activeProfile: 1,
+  liftOffDistance: "Low",
+  connectionType: "Wireless",
+  motionSync: true,
+  debounceMs: 5,
+  sleepTimeout: 180,
+  firmware: ["1.3.0"],
+};
+
+const RAZER: MouseStatus = {
+  brand: "Razer",
+  name: "Viper V3 Pro",
+  ui: {
+    family: "razer",
+    settingsReady: true,
+    valuesVerified: true,
+    hideUnsupportedPollingRates: true,
+    hideProcessingCard: true,
+    forceShowBattery: true,
+    defaultDisplayName: "Viper V3 Pro",
+  },
+  batteryPercent: 66,
+  batteryState: "Discharging",
+  dpi: 1600,
+  dpiY: 1600,
+  supportsSeparateDpiAxes: true,
+  pollingRateHz: 1000,
+  supportedPollingRates: [125, 250, 500, 1000, 2000, 4000, 8000],
+  activeProfile: 1,
+  liftOffDistance: null,
+  supportedLiftOffDistances: [],
+  connectionType: "Wireless",
+  connectionDetail: "HyperSpeed receiver",
+  firmware: ["1.01.00"],
+};
+
+const RAZER_VIPER_V4: MouseStatus = {
+  ...RAZER,
+  name: "Viper V4 Pro",
+  ui: { family: "razer-viper-v4-pro", hideUnsupportedPollingRates: true, hideProcessingCard: true, forceShowBattery: true },
+  pollingRateHz: 8000,
+  sleepTimeout: 300,
+  lowBatteryWarning: 15,
+  firmware: ["1.00.04"],
+};
+
+const TEEVOLUTION: MouseStatus = {
+  brand: "Teevolution",
+  name: "Terra Pro",
+  ui: { defaultDisplayName: "Terra Pro", hideUnsupportedPollingRates: true },
+  batteryPercent: 52,
+  batteryState: "Discharging",
+  dpi: 1600,
+  pollingRateHz: 1000,
+  supportedPollingRates: [125, 250, 500, 1000],
+  activeProfile: 1,
+  liftOffDistance: "Medium",
+  connectionType: "Wireless",
+  connectionDetail: "CID 1 · MID 2 · Type 3",
+  firmware: ["1.0.2"],
+};
+
+const VGN: MouseStatus = {
+  brand: "VGN",
+  name: "F2 Master Plus",
+  ui: { family: "vgn", hideUnsupportedPollingRates: true, forceShowBattery: true },
+  batteryPercent: 79,
+  batteryState: "Discharging",
+  dpi: 1600,
+  pollingRateHz: 4000,
+  supportedPollingRates: [125, 250, 500, 1000, 2000, 4000],
+  activeProfile: 1,
+  liftOffDistance: "Medium",
+  connectionType: "Wireless",
+  motionSync: true,
+  debounceMs: 4,
+  sleepTimeout: 60,
+  firmware: ["1.2.0"],
+};
+
+const FINALMOUSE: MouseStatus = {
+  brand: "Finalmouse",
+  name: "Finalmouse UltralightX",
+  ui: {
+    family: "finalmouse-ulx",
+    defaultDisplayName: "Finalmouse UltralightX",
+    hideUnsupportedPollingRates: true,
+    forceShowBattery: true,
+  },
+  batteryPercent: 76,
+  batteryVoltageMv: 3890,
+  batteryState: "Discharging",
+  dpi: 1600,
+  pollingRateHz: 8000,
+  supportedPollingRates: [500, 1000, 2000, 4000, 8000],
+  activeProfile: null,
+  connectionType: "Wireless",
+  connectionDetail: "2.4 GHz receiver · -48 dBm",
+  motionSync: true,
+  liftOffDistance: "Medium",
+  supportedLiftOffDistances: ["Medium", "High"],
+  finalmouseDongleLedMode: 1,
+  finalmouseTournamentScrollMode: 3,
+  finalmouseTournamentScrollTimeoutMs: 500,
+  firmware: ["Mouse 1.0.7", "Dongle RF 1.0.4", "Dongle USB 1.0.3"],
+};
+
+const LOGITECH_LEGACY: MouseStatus = {
+  brand: "Logitech",
+  name: "G402 Hyperion Fury",
+  ui: { family: "logitech-hidpp", lodRequiresSurface: true },
+  batteryPercent: null,
+  batteryState: "Unknown",
+  dpi: 1200,
+  pollingRateHz: 1000,
+  supportedPollingRates: [125, 250, 500, 1000],
+  activeProfile: 1,
+  // Legacy 0x2201 exposes no lift-off, which must hide the sensor card.
+  liftOffDistance: null,
+  supportedLiftOffDistances: [],
+  connectionType: "Wired",
+  connectionDetail: "Wired USB",
+  firmware: ["MPM 12.01"],
+};
+
+/**
+ * Keyed by the `?preview=` value. `superstrike` and `slots` are handled
+ * separately because they drive panels beyond a plain status.
+ */
+export const PREVIEW_FIXTURES: Record<string, PreviewFixture> = {
+  pulsar: { label: "Pulsar X2H Mini", status: PULSAR },
+  "pulsar-pro": { label: "Pulsar X2H Mini Pro", status: PULSAR_PRO },
+  "egg-op1": { label: "Endgame Gear OP1 8K", status: EGG_OP1 },
+  "egg-we": { label: "Endgame Gear OP1we", status: EGG_WE },
+  wlmouse: { label: "WLMouse BEAST X", status: WLMOUSE },
+  lamzu: { label: "Lamzu Atlantis OG V2", status: LAMZU },
+  atk: { label: "ATK A9 Ultra", status: ATK },
+  orbital: { label: "Orbital One", status: ORBITAL },
+  razer: { label: "Razer Viper V3 Pro", status: RAZER },
+  "razer-viper-v4": { label: "Razer Viper V4 Pro", status: RAZER_VIPER_V4 },
+  teevolution: { label: "Teevolution Terra Pro", status: TEEVOLUTION },
+  vgn: { label: "VGN F2 Master Plus", status: VGN },
+  finalmouse: { label: "Finalmouse UltralightX", status: FINALMOUSE },
+  "logitech-legacy": { label: "Logitech G402 (legacy DPI)", status: LOGITECH_LEGACY },
+};
+
+/** Every `?preview=` value, including the two with their own setup. */
+export const PREVIEW_KEYS = ["slots", "superstrike", ...Object.keys(PREVIEW_FIXTURES)];

--- a/src/preview-modes.test.ts
+++ b/src/preview-modes.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PREVIEW_KEYS, parsePreviewMode } from "./preview-modes.ts";
+
+test("preview mode accepts every explicitly supported route", () => {
+  for (const key of PREVIEW_KEYS) assert.equal(parsePreviewMode(key), key);
+});
+
+test("arbitrary URL values cannot disable HID startup", () => {
+  assert.equal(parsePreviewMode(null), null);
+  assert.equal(parsePreviewMode(""), null);
+  assert.equal(parsePreviewMode("unknown-driver"), null);
+  assert.equal(parsePreviewMode("SUPERSTRIKE"), null);
+});

--- a/src/preview-modes.ts
+++ b/src/preview-modes.ts
@@ -1,0 +1,52 @@
+/**
+ * Development preview routes accepted by the control app.
+ *
+ * Keep this as an explicit allowlist: arbitrary query-string values must not
+ * be able to disable the real HID startup path.
+ */
+export const PREVIEW_KEYS = [
+  "list",
+  "slots",
+  "superstrike",
+  "pulsar",
+  "pulsar-pro",
+  "egg-op1",
+  "egg-we",
+  "wlmouse",
+  "lamzu",
+  "atk",
+  "orbital",
+  "razer",
+  "razer-viper-v4",
+  "teevolution",
+  "vgn",
+  "finalmouse",
+  "logitech-legacy",
+] as const;
+
+export type PreviewMode = typeof PREVIEW_KEYS[number];
+export type FixturePreviewMode = Exclude<PreviewMode, "list" | "slots" | "superstrike">;
+
+/** Returns only trusted literals, breaking the data flow from the URL value. */
+export function parsePreviewMode(value: string | null): PreviewMode | null {
+  switch (value) {
+    case "list": return "list";
+    case "slots": return "slots";
+    case "superstrike": return "superstrike";
+    case "pulsar": return "pulsar";
+    case "pulsar-pro": return "pulsar-pro";
+    case "egg-op1": return "egg-op1";
+    case "egg-we": return "egg-we";
+    case "wlmouse": return "wlmouse";
+    case "lamzu": return "lamzu";
+    case "atk": return "atk";
+    case "orbital": return "orbital";
+    case "razer": return "razer";
+    case "razer-viper-v4": return "razer-viper-v4";
+    case "teevolution": return "teevolution";
+    case "vgn": return "vgn";
+    case "finalmouse": return "finalmouse";
+    case "logitech-legacy": return "logitech-legacy";
+    default: return null;
+  }
+}


### PR DESCRIPTION
## Logitech support

- Discover Logitech HID++ control interfaces without relying on a fixed product-ID list.
- Dynamically distinguish mice from other Logitech HID++ devices using their reported sensor features.
- Support receiver-connected and directly connected Logitech mice, including legacy devices such as the G402.
- Add support for:
  - DPI and independent X/Y sensitivity
  - Polling-rate discovery and control
  - Battery and firmware information
  - Host and onboard operating modes
  - Gaming-surface and LightForce modes
  - SuperStrike HITS actuation, rapid-trigger, and haptic tuning
  
  ## Onboard profiles

- Read and decode Logitech onboard-profile memory.
- Display, select, rename, enable, and disable profiles.
- Edit per-profile DPI stages and lift-off distance.
- Edit wired and wireless polling rates.
- Support bunny-hop filtering and profile names.
- Validate profile checksums before writing.
- Combine staged profile changes into a single flash write.
- Read back written sectors to confirm that the device stored them correctly.
- Restrict writes to hardware-verified profile formats. Format 7 is currently verified.

## Profile verification

- Add a profile-verification tool under Diagnostics.
- Export:
  - Device-reported memory geometry
  - Raw protocol replies
  - Complete profile directory
  - Every listed profile sector
  - Decoded profile values
  - CRC validation results
- Add Snapshot/Compare tooling for mapping vendor-app setting changes to profile bytes.
- Keep verification collection read-only and available for profile formats 1–8.

# Development previews

- Add development fixtures for every supported mouse brand.
- Add previews for Logitech profiles, the SuperStrike, legacy Logitech devices, Pulsar, Endgame Gear, WLMouse, Lamzu, ATK, Orbital, Razer, Teevolution, and VGN.
- Add a preview launcher to Interface Settings.
- Keep preview fixtures out of production bundles through development-only dynamic imports.

## Safety

Profile writes preserve unknown bytes, recompute checksums, avoid unnecessary no-op writes, and verify the resulting sector through a read-back. Unverified profile formats remain read-only until confirmed using real hardware data.

## Preview


https://github.com/user-attachments/assets/a3aac1e9-ac32-425f-93f1-fb0672ebf77b

## Tested on:
- Superlight 2

