### PR TITLE
added Razer Viper Mini support

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -83,6 +83,7 @@ import type { MouseStatus } from "./devices/mouse-types";
 import { PulsarProHidClient } from "./devices/pulsar/pulsar-pro-hid";
 import { OrbitalHidClient } from "./devices/orbital/hid";
 import { RazerHidClient } from "./devices/razer/hid";
+import { RazerViperMiniHidClient } from "./devices/razer/viper-mini-hid";
 import { RazerViperV4ProHidClient } from "./devices/razer/viper-v4-pro-hid";
 import { FinalmouseHidClient } from "./devices/finalmouse/hid";
 import { TeevolutionHidClient } from "./devices/teevolution/hid";
@@ -114,7 +115,7 @@ let activeEggClient: EggOp1HidClient | null = null;
 let activeEggWeClient: EggWeHidClient | null = null;
 let activeDmClient: WLMouseHidClient | LamzuHidClient | AtkHidClient | null = null;
 let activeOrbitalClient: OrbitalHidClient | null = null;
-let activeRazerClient: RazerHidClient | null = null;
+let activeRazerClient: RazerHidClient | RazerViperMiniHidClient | null = null;
 let activeTeevolutionClient: TeevolutionHidClient | null = null;
 let activeVgnClient: VgnF2HidClient | null = null;
 let activeViperClient: RazerViperV4ProHidClient | null = null;
@@ -1441,7 +1442,7 @@ async function activateClient(client: SupportedClient): Promise<void> {
     dpiOptions = client.getDpiOptions();
     configureDpiControl(status.dpi);
     showStatus(status);
-  } else if (client instanceof RazerHidClient) {
+  } else if (client instanceof RazerHidClient || client instanceof RazerViperMiniHidClient) {
     activeRazerClient = client;
     const status = await client.readStatus();
     deviceStatuses.set(client.device, status);

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -7,6 +7,7 @@ Supported identifiers:
 
 - `1532:00c0` — Viper V3 Pro, wired
 - `1532:00c1` — Viper V3 Pro, HyperSpeed receiver
+- `1532:008a` — Viper Mini, wired
 
 Razer does not declare its control channel in the HID descriptor, so no
 interface advertises a feature report. The exchange still works because WebHID
@@ -117,3 +118,39 @@ needs a richer type before it can be exposed even once the command is found.
   the control offers the wrong choices.
 - The DPI stage table (`0x04`/`0x06`) is decoded and tested but never written.
   A wrong length there is the one realistic way to corrupt stored settings.
+
+## Viper Mini (not yet verified on hardware)
+
+The Viper Mini shares the 90-byte report and command ids above, but belongs to
+openrazer's legacy transaction group: every command is sent with transaction id
+`0xff` rather than `0x1f`, and the DPI read uses the no-store byte (`0x00`)
+where the V3 Pro reads with the storage byte. Commands and the transaction id
+below come from openrazer's kernel driver and daemon, not from this app's own
+hardware captures. Confirm each on the device before trusting it:
+
+1. Connect the mouse over USB and confirm the model and wired state appear, with
+   no battery column (the Viper Mini is wired-only and answers no battery query).
+2. Confirm DPI reads correctly and that the control offers 100–8500 DPI.
+3. Change the DPI and confirm the pointer speed changes, then reload and confirm
+   persistence. This also confirms the write-then-read-back pairing of storage
+   (`0x01`) and no-store (`0x00`) works on this model.
+4. Confirm the polling rate reads 125/500/1000 Hz and tracks a Synapse change,
+   then change it and confirm it persists.
+5. Confirm no lift-off distance buttons and no sensor processing card appear.
+6. Record the device identifier, firmware version, and any failing setting in
+   the issue or pull request.
+
+| Read | Class / ID | Notes |
+| --- | --- | --- |
+| Firmware | `0x00` / `0x81` | transaction id `0xff` |
+| Serial | `0x00` / `0x82` | ASCII, null terminated; transaction id `0xff` |
+| DPI | `0x04` / `0x85` | no-store byte, then big-endian X and Y |
+| Polling | `0x00` / `0x85` | divisor of 1000; wired only |
+
+| Write | Class / ID | Notes |
+| --- | --- | --- |
+| DPI | `0x04` / `0x05` | storage byte, then big-endian X and Y |
+| Polling | `0x00` / `0x05` | divisor of 1000 |
+
+The Viper Mini's 8500 DPI ceiling comes from the openrazer daemon class. The
+DPI step granularity is assumed to be whole values, matching the V3 Pro driver.

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -119,38 +119,34 @@ needs a richer type before it can be exposed even once the command is found.
 - The DPI stage table (`0x04`/`0x06`) is decoded and tested but never written.
   A wrong length there is the one realistic way to corrupt stored settings.
 
-## Viper Mini (not yet verified on hardware)
+## Viper Mini (verified on hardware)
 
 The Viper Mini shares the 90-byte report and command ids above, but belongs to
-openrazer's legacy transaction group: every command is sent with transaction id
-`0xff` rather than `0x1f`, and the DPI read uses the no-store byte (`0x00`)
-where the V3 Pro reads with the storage byte. Commands and the transaction id
-below come from openrazer's kernel driver and daemon, not from this app's own
-hardware captures. Confirm each on the device before trusting it:
+openrazer's legacy transaction group: every command is answered with transaction
+id `0xff` rather than `0x1f`, and the DPI read uses the no-store byte (`0x00`)
+where the V3 Pro reads with the storage byte. The transaction id and the command
+table below were confirmed on hardware (`1532:008a`):
 
-1. Connect the mouse over USB and confirm the model and wired state appear, with
-   no battery column (the Viper Mini is wired-only and answers no battery query).
-2. Confirm DPI reads correctly and that the control offers 100–8500 DPI.
-3. Change the DPI and confirm the pointer speed changes, then reload and confirm
-   persistence. This also confirms the write-then-read-back pairing of storage
-   (`0x01`) and no-store (`0x00`) works on this model.
-4. Confirm the polling rate reads 125/500/1000 Hz and tracks a Synapse change,
-   then change it and confirm it persists.
-5. Confirm no lift-off distance buttons and no sensor processing card appear.
-6. Record the device identifier, firmware version, and any failing setting in
-   the issue or pull request.
+1. The model and wired state appear, with no battery column (wired-only; the
+   mouse answers no battery query).
+2. DPI reads back correctly and the control offers 100–8500 DPI.
+3. A DPI change alters pointer speed and persists after reload, confirming the
+   write-with-storage (`0x01`) / read-with-no-store (`0x00`) pairing.
+4. Polling rate reads 125/500/1000 Hz, a 1000 Hz write round-trips with status
+   `0x02`, and the rate persists.
+5. No lift-off distance buttons and no sensor processing card appear.
 
 | Read | Class / ID | Notes |
 | --- | --- | --- |
 | Firmware | `0x00` / `0x81` | transaction id `0xff` |
 | Serial | `0x00` / `0x82` | ASCII, null terminated; transaction id `0xff` |
-| DPI | `0x04` / `0x85` | no-store byte, then big-endian X and Y |
+| DPI | `0x04` / `0x85` | no-store byte `0x00`, then big-endian X and Y |
 | Polling | `0x00` / `0x85` | divisor of 1000; wired only |
 
 | Write | Class / ID | Notes |
 | --- | --- | --- |
-| DPI | `0x04` / `0x05` | storage byte, then big-endian X and Y |
+| DPI | `0x04` / `0x05` | storage byte `0x01`, then big-endian X and Y |
 | Polling | `0x00` / `0x05` | divisor of 1000 |
 
-The Viper Mini's 8500 DPI ceiling comes from the openrazer daemon class. The
-DPI step granularity is assumed to be whole values, matching the V3 Pro driver.
+The 8500 DPI ceiling comes from the openrazer daemon class. The DPI step
+granularity is assumed to be whole values, matching the V3 Pro driver.

--- a/src/devices/razer/viper-mini-hid.test.ts
+++ b/src/devices/razer/viper-mini-hid.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { RAZER_READ, encodeRazerRequest, razerSetDpiCommand, razerSetLegacyPollingCommand } from "./protocol.ts";
+import {
+  VIPER_MINI_DPI_READ,
+  VIPER_MINI_PRODUCT_ID,
+  VIPER_MINI_TRANSACTION_ID,
+  RazerViperMiniHidClient,
+} from "./viper-mini-hid.ts";
+
+test("Viper Mini requests use the legacy 0xFF transaction id", () => {
+  const packet = encodeRazerRequest(RAZER_READ.firmware, VIPER_MINI_TRANSACTION_ID);
+
+  assert.equal(packet[1], 0xff);
+  assert.equal(packet[6], 0x00);
+  assert.equal(packet[7], 0x81);
+});
+
+test("Viper Mini DPI read uses the no-store byte openrazer pairs with writes", () => {
+  const packet = encodeRazerRequest(VIPER_MINI_DPI_READ, VIPER_MINI_TRANSACTION_ID);
+
+  assert.equal(packet[6], 0x04);
+  assert.equal(packet[7], 0x85);
+  assert.equal(packet[8], 0x00);
+});
+
+test("Viper Mini DPI write carries the storage byte and reads back through no-store", () => {
+  const write = encodeRazerRequest(razerSetDpiCommand(1600, 800), VIPER_MINI_TRANSACTION_ID);
+  const read = encodeRazerRequest(VIPER_MINI_DPI_READ, VIPER_MINI_TRANSACTION_ID);
+
+  assert.deepEqual([...write.slice(8, 15)], [0x01, 0x06, 0x40, 0x03, 0x20, 0x00, 0x00]);
+  assert.equal(read[8], 0x00);
+});
+
+test("Viper Mini polling writes the legacy divisor of 1000", () => {
+  const packet = encodeRazerRequest(razerSetLegacyPollingCommand(500), VIPER_MINI_TRANSACTION_ID);
+
+  assert.equal(packet[1], 0xff);
+  assert.deepEqual([packet[6], packet[7], packet[8]], [0x00, 0x05, 2]);
+});
+
+test("Viper Mini accepts only its own PID on a single Generic Desktop Mouse collection", () => {
+  const control = {
+    vendorId: 0x1532,
+    productId: VIPER_MINI_PRODUCT_ID,
+    collections: [{ usagePage: 0x01, usage: 0x02, featureReports: [], children: [] }],
+  } as unknown as HIDDevice;
+  const wrongPid = { ...control, productId: 0x00c0 } as unknown as HIDDevice;
+  const extraCollection = {
+    ...control,
+    collections: [
+      { usagePage: 0x01, usage: 0x02, featureReports: [], children: [] },
+      { usagePage: 0x01, usage: 0x06, featureReports: [], children: [] },
+    ],
+  } as unknown as HIDDevice;
+
+  assert.equal(RazerViperMiniHidClient.isSupported(control), true);
+  assert.equal(RazerViperMiniHidClient.isSupported(wrongPid), false);
+  assert.equal(RazerViperMiniHidClient.isSupported(extraCollection), false);
+});

--- a/src/devices/razer/viper-mini-hid.ts
+++ b/src/devices/razer/viper-mini-hid.ts
@@ -1,0 +1,208 @@
+import type { MouseStatus } from "../mouse-types.ts";
+import { VENDOR_ID } from "../vendors.ts";
+import {
+  RAZER_READ,
+  RAZER_REPORT_ID,
+  RAZER_STATUS,
+  RazerProtocolError,
+  decodeDpi,
+  decodeFirmwareVersion,
+  decodeLegacyPollingRate,
+  decodeRazerResponse,
+  decodeSerial,
+  encodeRazerRequest,
+  razerSetDpiCommand,
+  razerSetLegacyPollingCommand,
+  type RazerCommand,
+} from "./protocol.ts";
+
+export const VIPER_MINI_PRODUCT_ID = 0x008a;
+
+/**
+ * Transaction id used by openrazer's legacy group (Viper / Viper Ultimate);
+ * kept separate from `0x1f`, verified on the newer Viper V3 Pro firmware.
+ */
+export const VIPER_MINI_TRANSACTION_ID = 0xff;
+
+// Openrazer reads DPI with the no-store byte and writes with the storage byte.
+export const VIPER_MINI_DPI_READ: RazerCommand = {
+  commandClass: 0x04,
+  commandId: 0x85,
+  dataSize: 0x07,
+  args: [0x00],
+};
+
+// Wired-only, so the legacy polling command (a divisor of 1000) covers every rate.
+const RATES_WIRED: readonly number[] = [125, 500, 1000];
+const DPI_MIN = 100;
+const DPI_MAX = 8500;
+const RESPONSE_DELAY_MS = 100;
+const RESPONSE_ATTEMPTS = 6;
+
+/**
+ * Razer exposes its control channel on the interface whose only collection is
+ * Generic Desktop Mouse. Every other interface either belongs to a different
+ * function or is a protected collection the browser will not talk to.
+ */
+function isControlInterface(device: HIDDevice): boolean {
+  const [collection, ...rest] = device.collections;
+  return rest.length === 0 && collection?.usagePage === 0x01 && collection?.usage === 0x02;
+}
+
+export class RazerViperMiniHidClient {
+  private queue: Promise<unknown> = Promise.resolve();
+  private readonly staticReads = new Map<string, Promise<Uint8Array | null>>();
+
+  readonly device: HIDDevice;
+
+  constructor(device: HIDDevice) {
+    this.device = device;
+  }
+
+  static isSupported(device: HIDDevice): boolean {
+    return device.vendorId === VENDOR_ID.razer
+      && device.productId === VIPER_MINI_PRODUCT_ID
+      && isControlInterface(device);
+  }
+
+  async open(): Promise<void> {
+    // On Linux "Failed to open the device" means the hidraw node for 1532:008a
+    // is root-owned or the razermouse kernel driver claimed the interface.
+    // Fix: udev rule granting plugdev access to that vendor/product, then
+    // `sudo rmmod razermouse`.
+    if (!this.device.opened) await this.device.open();
+  }
+
+  async close(): Promise<void> {
+    this.staticReads.clear();
+    if (this.device.opened) await this.device.close();
+  }
+
+  displayName(): string {
+    return this.device.productName || "Razer Viper Mini";
+  }
+
+  isWireless(): boolean {
+    return false;
+  }
+
+  maxDpi(): number {
+    return DPI_MAX;
+  }
+
+  getSupportedPollingRates(): number[] {
+    return [...RATES_WIRED];
+  }
+
+  /** Every whole value, because the control validates entries against this list. */
+  getDpiOptions(): number[] {
+    const options: number[] = [];
+    for (let dpi = DPI_MIN; dpi <= this.maxDpi(); dpi += 1) options.push(dpi);
+    return options;
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    await this.open();
+    const firmware = await this.once("firmware", () => this.request(RAZER_READ.firmware));
+    if (!firmware) throw new Error("The mouse did not report a firmware version.");
+    const serial = await this.once("serial", () => this.request(RAZER_READ.serial).catch(() => null));
+    const dpi = decodeDpi(await this.request(VIPER_MINI_DPI_READ));
+    const pollingRateHz = decodeLegacyPollingRate(await this.request(RAZER_READ.pollingRate));
+    return {
+      brand: "Razer",
+      name: this.displayName(),
+      ui: {
+        family: "razer",
+        settingsReady: true,
+        valuesVerified: true,
+        hideUnsupportedPollingRates: true,
+        // No lift-off or sensor-processing command is confirmed, so neither
+        // control is offered rather than offered and left inert.
+        hideProcessingCard: true,
+        defaultDisplayName: "Viper Mini",
+      },
+      // Wired-only model: openrazer exposes no battery attribute, so neither
+      // the level nor the charging query is sent.
+      batteryPercent: null,
+      batteryState: "Unknown",
+      dpi: dpi.x,
+      dpiY: dpi.y,
+      supportsSeparateDpiAxes: true,
+      pollingRateHz,
+      supportedPollingRates: this.getSupportedPollingRates(),
+      activeProfile: null,
+      connectionType: "Wired",
+      connectionDetail: "Wired USB",
+      unitId: serial ? decodeSerial(serial) : null,
+      liftOffDistance: null,
+      supportedLiftOffDistances: [],
+      firmware: [`Mouse ${decodeFirmwareVersion(firmware)}`],
+    };
+  }
+
+  async setDpi(dpi: number, dpiY: number = dpi): Promise<number> {
+    const ceiling = this.maxDpi();
+    for (const value of [dpi, dpiY]) {
+      if (!Number.isInteger(value) || value < DPI_MIN || value > ceiling) {
+        throw new Error(`DPI must be a whole number between ${DPI_MIN} and ${ceiling.toLocaleString()}.`);
+      }
+    }
+    await this.request(razerSetDpiCommand(dpi, dpiY));
+    const confirmed = decodeDpi(await this.request(VIPER_MINI_DPI_READ));
+    if (confirmed.x !== dpi || confirmed.y !== dpiY) {
+      throw new Error(`The mouse kept ${confirmed.x.toLocaleString()} DPI instead of ${dpi.toLocaleString()}.`);
+    }
+    return confirmed.x;
+  }
+
+  async setPollingRate(pollingRateHz: number): Promise<number> {
+    if (!this.getSupportedPollingRates().includes(pollingRateHz)) {
+      throw new Error(`This mouse does not support ${pollingRateHz.toLocaleString()} Hz on this connection.`);
+    }
+    await this.request(razerSetLegacyPollingCommand(pollingRateHz));
+    const confirmed = decodeLegacyPollingRate(await this.request(RAZER_READ.pollingRate));
+    if (confirmed !== pollingRateHz) {
+      throw new Error(`The mouse kept ${confirmed.toLocaleString()} Hz instead of ${pollingRateHz.toLocaleString()} Hz.`);
+    }
+    return confirmed;
+  }
+
+  private once(key: string, read: () => Promise<Uint8Array | null>): Promise<Uint8Array | null> {
+    const pending = this.staticReads.get(key);
+    if (pending) return pending;
+    const started = read();
+    this.staticReads.set(key, started);
+    started.catch(() => this.staticReads.delete(key));
+    return started;
+  }
+
+  private async request(command: RazerCommand): Promise<Uint8Array> {
+    const run = this.queue.then(() => this.exchange(command), () => this.exchange(command));
+    this.queue = run.catch(() => undefined);
+    return await run;
+  }
+
+  private async exchange(command: RazerCommand): Promise<Uint8Array> {
+    await this.open();
+    await this.device.sendFeatureReport(RAZER_REPORT_ID, encodeRazerRequest(command, VIPER_MINI_TRANSACTION_ID));
+    for (let attempt = 0; attempt < RESPONSE_ATTEMPTS; attempt += 1) {
+      await this.delay(RESPONSE_DELAY_MS);
+      const reply = this.copyDataView(await this.device.receiveFeatureReport(RAZER_REPORT_ID));
+      try {
+        return decodeRazerResponse(reply, command);
+      } catch (error) {
+        if (error instanceof RazerProtocolError && error.status === RAZER_STATUS.busy) continue;
+        throw error;
+      }
+    }
+    throw new Error("The mouse stayed busy — it may be asleep or out of range.");
+  }
+
+  private copyDataView(view: DataView): Uint8Array {
+    return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+  }
+
+  private delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+  }
+}

--- a/src/devices/registry.ts
+++ b/src/devices/registry.ts
@@ -8,13 +8,14 @@ import { OrbitalHidClient } from "./orbital/hid.ts";
 import { PulsarHidClient } from "./pulsar/pulsar-hid.ts";
 import { PulsarProHidClient } from "./pulsar/pulsar-pro-hid.ts";
 import { RazerHidClient } from "./razer/hid.ts";
+import { RazerViperMiniHidClient } from "./razer/viper-mini-hid.ts";
 import { RazerViperV4ProHidClient } from "./razer/viper-v4-pro-hid.ts";
 import { TeevolutionHidClient } from "./teevolution/hid.ts";
 import { VgnF2HidClient } from "./vgn/hid.ts";
 import { WLMouseHidClient } from "./wlmouse/hid.ts";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperV4ProHidClient | TeevolutionHidClient | AtkHidClient | VgnF2HidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | TeevolutionHidClient | AtkHidClient | VgnF2HidClient;
 
 export interface DeviceDriver {
   brand: string;
@@ -36,6 +37,7 @@ export const DEVICE_DRIVERS: readonly DeviceDriver[] = [
   { brand: "Lamzu", supports: (device) => LamzuHidClient.isSupported(device), create: (device) => new LamzuHidClient(device), score: () => 5 },
   { brand: "Orbital", supports: (device) => OrbitalHidClient.isSupported(device), create: (device) => new OrbitalHidClient(device), score: () => 6 },
   { brand: "Razer", supports: (device) => RazerHidClient.isSupported(device), create: (device) => new RazerHidClient(device), score: () => 6 },
+  { brand: "Razer", supports: (device) => RazerViperMiniHidClient.isSupported(device), create: (device) => new RazerViperMiniHidClient(device), score: () => 6 },
   { brand: "ATK", supports: (device) => AtkHidClient.isSupported(device), create: (device) => new AtkHidClient(device), score: () => 5 },
   { brand: "Razer", supports: (device) => RazerViperV4ProHidClient.isSupported(device), create: (device) => new RazerViperV4ProHidClient(device), score: () => 7 },
 ];

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -23,6 +23,12 @@ export const RAZER_VIPER_V3_CONTROL_FILTERS: HIDDeviceFilter[] = [0x00c0, 0x00c1
   (productId) => ({ vendorId: VENDOR_ID.razer, productId, usagePage: 0x01, usage: 0x02 }),
 );
 
+// The Viper Mini answers on the same kind of single Generic Desktop Mouse
+// control interface as the V3 Pro, so it gets the same narrow collection filter.
+export const RAZER_VIPER_MINI_CONTROL_FILTERS: HIDDeviceFilter[] = [0x008a].map(
+  (productId) => ({ vendorId: VENDOR_ID.razer, productId, usagePage: 0x01, usage: 0x02 }),
+);
+
 // Synapse Web exposes the V4 control interface through a single top-level
 // Generic Desktop or Consumer collection with Feature reports. Request both
 // pages so the browser offers that interface, then the driver rejects ordinary
@@ -99,6 +105,7 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.orbital, usagePage: 0xff0a, usage: 1 },
   ...TEEVOLUTION_PRODUCT_IDS.map((productId) => ({ vendorId: VENDOR_ID.teevolution, productId })),
   ...RAZER_VIPER_V3_CONTROL_FILTERS,
+  ...RAZER_VIPER_MINI_CONTROL_FILTERS,
   { vendorId: VENDOR_ID.vgn, productId: 0xfb56 },
   { vendorId: VENDOR_ID.vgn, productId: 0xfb57 },
   { vendorId: VENDOR_ID.atk, usagePage: 0xff02, usage: 2 },


### PR DESCRIPTION
## Summary
Adds WebHID control for the Razer Viper Mini (1532:008a), wired-only: DPI (100–8500), polling rate (125/500/1000 Hz), serial, and firmware.

## Details
- New driver \`src/devices/razer/viper-mini-hid.ts\` using openrazer's legacy transaction id \`0xff\` (Viper / Viper Ultimate group, not the V3 Pro's \`0x1f\`).
- DPI read uses the no-store byte; writes carry the storage byte, matching openrazer's \`set_dpi_xy\`.
- No battery/charging queries (wired-only; openrazer exposes none) — status returns \`batteryPercent: null\`.
- Registered in \`registry.ts\`, \`vendors.ts\`, \`control.ts\`; 5 unit tests added.

## Testing
- [x] 97 tests pass (\`npm test\`)
- [x] \`npm run build\` clean
- [x] Verified on hardware
<img width="1920" height="1080" alt="Screenshot From 2026-08-06 21-54-05" src="https://github.com/user-attachments/assets/03ea874e-40a3-44da-ba43-87b85a1ceb51" />

> Linux note: if the browser shows \`Failed to open the device\`, the hidraw node is root-owned or the \`razermouse\` kernel driver has claimed the interface. Fix: udev rule granting \`plugdev\` access to \`1532:008a\`, then \`sudo rmmod razermouse\`. See comment in \`viper-mini-hid.ts\`.