### PR TITLE
fix(logitech): stop offering surface and lift-off controls the G309 does not have

### DIFF
--- a/src/devices/logitech/TESTING.md
+++ b/src/devices/logitech/TESTING.md
@@ -47,3 +47,19 @@ Persistent polling-rate and DPI-stage changes need a CRC-checked rewrite of the
 1024-byte profile sector and are intentionally not implemented. Record the
 device identifier, protocol version, and any failing setting in the issue or
 pull request. Do not use factory reset during initial testing.
+
+## G309 LIGHTSPEED (receiver-attached, Model ID `B03C40B10000`)
+
+The G309 exposes Extended Adjustable DPI `0x2202` and Mode Status `0x8090`, but
+only the power-mode half of Mode Status is meaningful: the status1 byte that
+would carry the gaming-surface and LightForce fields is reserved and reads 0.
+The `0x2202` sensor likewise reports lift-off level 0, the feature's "no
+lift-off control" value. OpenMouse treats both as absent, so those cards stay
+hidden.
+
+1. Confirm the model, battery, connection type, DPI, and polling rate are read
+   correctly.
+2. Confirm the sensor card (lift-off distance), the gaming-surface card, and
+   the LightForce switch are all hidden.
+3. Change the DPI and polling rate and confirm each write persists after a
+   reload.

--- a/src/devices/logitech/hidpp.test.ts
+++ b/src/devices/logitech/hidpp.test.ts
@@ -18,6 +18,8 @@ import {
   withSoftwareId,
 } from "./protocol.ts";
 
+import { hasLiftOffControl, isPowerOnlyModeStatus } from "./hidpp.ts";
+
 const G402 = 0xc07e;
 const LIGHTSPEED_RECEIVER = 0xc54d;
 const SUPERSTRIKE_USB = 0xc0a8;
@@ -133,4 +135,26 @@ test("an onboard-only mouse is told how to get itself supported", () => {
   const unknown = new OnboardOnlyError(null);
   assert.doesNotMatch(unknown.message, /format (\d|null)/);
   assert.match(unknown.message, /Copy verification data/);
+});
+
+test("the G309's mode status is power-only and exposes no surface or LightForce controls", () => {
+  // Model id captured from hardware: 0x8090 V2 with only the power-mode half.
+  assert.equal(isPowerOnlyModeStatus("B03C40B10000"), true);
+  // Every other model keeps the status1 fields, and unknown/absent ids must
+  // not be silently downgraded.
+  assert.equal(isPowerOnlyModeStatus("B03C40B10001"), false);
+  assert.equal(isPowerOnlyModeStatus(""), false);
+  assert.equal(isPowerOnlyModeStatus(null), false);
+  assert.equal(isPowerOnlyModeStatus(undefined), false);
+});
+
+test("a sensor without lift-off control advertises no lift-off levels", () => {
+  // 0x2201 legacy DPI carries no lod byte at all.
+  assert.equal(hasLiftOffControl(true, null), false);
+  // 0x2202 byte 0 is the "no lift-off control" value, as on the G309.
+  assert.equal(hasLiftOffControl(false, 0), false);
+  assert.equal(hasLiftOffControl(false, null), false);
+  // The levels 1-4 (Low/Medium/High/Extra high) are driveable.
+  assert.equal(hasLiftOffControl(false, 1), true);
+  assert.equal(hasLiftOffControl(false, 2), true);
 });

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -120,6 +120,32 @@ export class NotAMouseError extends Error {
 const LOGITECH_VENDOR_ID = 0x046d;
 // HID++ control interfaces, including the PRO X 2 Superstrike USB interface.
 const LOGITECH_RECEIVER_PRODUCT_IDS = new Set([0xc54d, 0xc539, 0xc0a8, 0xc547]);
+
+/**
+ * Models whose 0x8090 mode-status feature drives the power-mode switch only.
+ * The status1 byte that carries the gaming-surface and LightForce fields is
+ * reserved on them and reads 0, which would otherwise decode as "Auto" and
+ * "Optical" and offer controls the mouse does not have. Keyed on the firmware
+ * model id, like the Superstrike detection.
+ */
+const MODE_STATUS_POWER_ONLY_MODEL_IDS: ReadonlySet<string> = new Set([
+  "B03C40B10000", // G309 LIGHTSPEED
+]);
+
+/** Whether 0x8090 on this model is the power-mode-only variant. */
+export function isPowerOnlyModeStatus(modelId: string | null | undefined): boolean {
+  return MODE_STATUS_POWER_ONLY_MODEL_IDS.has(modelId ?? "");
+}
+
+/**
+ * Whether the mouse exposes lift-off levels it can drive: only extended DPI
+ * (0x2202) carries one, and its byte 0 is the "no lift-off control" value, so
+ * a legacy-DPI mouse or a sensor reporting 0 advertises no levels.
+ */
+export function hasLiftOffControl(legacyDpi: boolean, lodByte: number | null): boolean {
+  return !legacyDpi && lodByte !== null && lodByte !== 0;
+}
+
 const SHORT_REPORT_ID = 0x10;
 const LONG_REPORT_ID = 0x11;
 const FEATURE = {
@@ -414,6 +440,7 @@ export class LogitechHidppClient {
       : undefined;
     const modeStatusFeature = await this.getFeature(FEATURE.modeStatus);
     const modeStatus = modeStatusFeature.index ? await this.readModeStatus(modeStatusFeature.index) : null;
+    const modeStatusCarriesControls = !isPowerOnlyModeStatus(identity.modelId);
     // One extra request; the layout it selects is worth surfacing in diagnostics.
     const onboardProfileFormat = profilesFeature.index
       ? await this.request(profilesFeature.index, PROFILE_FN.getInfo)
@@ -452,8 +479,12 @@ export class LogitechHidppClient {
       analogButtonTuning,
       liftOffDistance: decodeLiftOffLevel(dpiState.lod, this.lodCapabilities),
       onboardProfileFormat,
-      gamingSurfaceMode: modeStatus === null ? null : decodeModeStatus(modeStatus, MODE_STATUS.gamingSurface),
-      lightforceSwitchMode: modeStatus === null ? null : decodeModeStatus(modeStatus, MODE_STATUS.lightforce),
+      gamingSurfaceMode: modeStatus === null || !modeStatusCarriesControls
+        ? null
+        : decodeModeStatus(modeStatus, MODE_STATUS.gamingSurface),
+      lightforceSwitchMode: modeStatus === null || !modeStatusCarriesControls
+        ? null
+        : decodeModeStatus(modeStatus, MODE_STATUS.lightforce),
       // The USB connection exposes the Superstrike as a 1 kHz device. Its
       // Lightspeed receiver can use the higher rates advertised by HID++.
       pollingRateHz: isSuperstrike && wired ? Math.min(pollingRateHz, 1000) : pollingRateHz,
@@ -463,9 +494,12 @@ export class LogitechHidppClient {
       // Lift-off distance is only reachable through extended DPI (0x2202). On a
       // mouse that exposes just legacy 0x2201 there is nothing to drive, so
       // report an empty set rather than offering buttons that can only fail.
-      // Otherwise the levels come from the profile format, which is where the
-      // count and the byte encoding are both established.
-      supportedLiftOffDistances: dpiFeature.legacy ? [] : this.supportedLods,
+      // The same applies when the sensor reports no lift-off level (byte 0 is
+      // the feature's "no lift-off control" value), which is how a 0x2202 mouse
+      // without LOD, like the G309, advertises its lack of one. Otherwise the
+      // levels come from the profile format, which is where the count and the
+      // byte encoding are both established.
+      supportedLiftOffDistances: hasLiftOffControl(dpiFeature.legacy, dpiState.lod) ? this.supportedLods : [],
       connectionType: wired ? "Wired" : "Wireless",
       // Without this the shell falls back to its "2.4 GHz receiver" wording,
       // which is wrong for a mouse plugged straight into USB.


### PR DESCRIPTION
The G309 LIGHTSPEED (Model ID `B03C40B10000`) exposes Mode Status `0x8090` and Extended Adjustable DPI `0x2202`, but only the power-mode half of `0x8090` is meaningful — the status1 byte that would carry the gaming-surface and LightForce fields is reserved and reads 0, which decoded as "Auto" and "Optical" and surfaced cards the mouse does not have. Its `0x2202` sensor likewise reports lift-off level 0, the feature's "no lift-off control" value, yet the app still advertised the Medium/High levels.

This gates those controls so the sensor card, gaming-surface card, and LightForce switch stay hidden, and adds tests plus a hardware checklist section.
