### PR TITLE
MX Master 3S

### DIFF
--- a/build/check-bundle-size.ts
+++ b/build/check-bundle-size.ts
@@ -7,9 +7,10 @@ const BUDGET_BYTES: Record<string, number> = {
   ".css": 46_000,
   // Raised from 280 kB for the production Logitech onboard-profile codec,
   // guarded flash editor, verification exporter, upstream Finalmouse driver,
-  // the dedicated Viper Mini protocol driver, and Viper V3 sleep/low-power plus
-  // asymmetric lift-off protocol and controls. Preview fixtures remain dev-only.
-  ".js": 325_000,
+  // the dedicated Viper Mini protocol driver, Viper V3 sleep/low-power plus
+  // asymmetric lift-off protocol and controls, and Logi Bolt / MX Master 3S
+  // transport. Preview fixtures remain dev-only.
+  ".js": 330_000,
 };
 
 const ASSETS = join("dist", "assets");

--- a/src/device-clients.ts
+++ b/src/device-clients.ts
@@ -1,6 +1,7 @@
 import {
   eggWeMergeLogicalDevices,
 } from "./devices/endgame/egg-we-control";
+import { collapseBoltPeers } from "./devices/logitech/bolt";
 import {
   clientSupportScore,
   createSupportedClient,
@@ -13,5 +14,6 @@ export { clientSupportScore, createSupportedClient, deviceBrand, type PulsarClie
 
 /** Supported devices for the sidebar; multi-path drivers collapse via their module. */
 export function listLogicalDevices(devices: HIDDevice[] = []): HIDDevice[] {
-  return eggWeMergeLogicalDevices(devices, (device) => createSupportedClient(device) !== null);
+  const afterEgg = eggWeMergeLogicalDevices(devices, (device) => createSupportedClient(device) !== null);
+  return collapseBoltPeers(afterEgg);
 }

--- a/src/devices/logitech/TESTING.md
+++ b/src/devices/logitech/TESTING.md
@@ -9,9 +9,15 @@ Supported identifiers:
 
 - `046d:c54d`, `046d:c547` — Lightspeed receivers
 - `046d:c539` — HERO-era Lightspeed receiver
+- `046d:c548` — Logi Bolt receiver (MX Master 3S and other Bolt mice)
 - `046d:c0a8` — PRO X 2 Superstrike (USB)
 - `046d:c07e` — G402 / G402 Hyperion Fury (wired)
 - `046d:c08f` — G403 HERO (wired)
+
+For Logi Bolt, authorize **both** HID++ collections when the picker offers them
+(`usagePage 0xff00`, `usage 0x0001` and `usage 0x0002`). Device feature traffic
+uses the long-report collection (`usage 0x0002`). Close Logi Options+ first —
+it holds the same vendor interface.
 
 ## Receiver-attached and Superstrike devices
 
@@ -90,3 +96,20 @@ hidden.
    the LightForce switch are all hidden.
 3. Change the DPI and polling rate and confirm each write persists after a
    reload.
+
+## MX Master 3S (Logi Bolt `046d:c548`, WPID `B034`)
+
+The MX Master 3S pairs to a Logi Bolt receiver. HID++ 2.0 feature calls use
+**long** reports on pairing slot 1–6 (often slot 2), not device index `0xFF`.
+It exposes Adjustable DPI `0x2201` and Unified Battery `0x1004`, and has no
+`0x8060`/`0x8061` report-rate feature and no lift-off / onboard-profile path.
+
+1. Close Logi Options+. Authorize both Bolt HID++ collections if offered.
+2. Confirm the sidebar shows the Bolt receiver / MX Master 3S, connection
+   **Wireless**, battery percentage, and DPI.
+3. Confirm the sensor (lift-off) card and polling-rate buttons stay inactive /
+   noted as unavailable — this mouse has no HID++ polling control.
+4. Stage a DPI change and flash it. Confirm read-back matches and the value
+   persists after a reload.
+5. If connect fails with "invalid command", the short collection alone was
+   selected — reconnect and include usage `0x0002`.

--- a/src/devices/logitech/bolt.test.ts
+++ b/src/devices/logitech/bolt.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  boltSupportScore,
+  classifyHidpp20Probe,
+  collapseBoltPeers,
+  hasHidppLongCollection,
+  hasHidppShortCollection,
+  hidppIndexCandidates,
+  resolveBoltReportDevice,
+} from "./bolt.ts";
+import {
+  BOLT_PAIRING_SLOTS,
+  DEVICE_INDEX_DIRECT,
+  DEVICE_INDEX_RECEIVER,
+  isBoltReceiverProduct,
+  isDirectConnectProduct,
+} from "./protocol.ts";
+
+const LIGHTSPEED_RECEIVER = 0xc54d;
+const BOLT_RECEIVER = 0xc548;
+const KNOWN_RECEIVERS = new Set([LIGHTSPEED_RECEIVER, BOLT_RECEIVER, 0xc539, 0xc547, 0xc0a8]);
+
+function fakeHidDevice(productId: number, collections: HIDCollectionInfo[]): HIDDevice {
+  return {
+    vendorId: 0x046d,
+    productId,
+    productName: "test",
+    collections,
+  } as unknown as HIDDevice;
+}
+
+function hidppCollection(usage: number): HIDCollectionInfo {
+  return {
+    usagePage: 0xff00,
+    usage,
+    type: 1,
+    children: [],
+    featureReports: [],
+    inputReports: [],
+    outputReports: [],
+  } as unknown as HIDCollectionInfo;
+}
+
+test("Logi Bolt receivers are distinct from Lightspeed and direct-connect mice", () => {
+  assert.equal(isBoltReceiverProduct(BOLT_RECEIVER), true);
+  assert.equal(isBoltReceiverProduct(LIGHTSPEED_RECEIVER), false);
+  assert.equal(isDirectConnectProduct(BOLT_RECEIVER), false);
+  assert.deepEqual([...BOLT_PAIRING_SLOTS], [0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+});
+
+test("Bolt index candidates cover all pairing slots; Lightspeed stays 0x01 then 0xFF", () => {
+  assert.deepEqual(hidppIndexCandidates(BOLT_RECEIVER, KNOWN_RECEIVERS), [...BOLT_PAIRING_SLOTS]);
+  assert.deepEqual(
+    hidppIndexCandidates(LIGHTSPEED_RECEIVER, KNOWN_RECEIVERS),
+    [DEVICE_INDEX_RECEIVER, DEVICE_INDEX_DIRECT],
+  );
+  assert.deepEqual(
+    hidppIndexCandidates(0xc084, KNOWN_RECEIVERS),
+    [DEVICE_INDEX_DIRECT, DEVICE_INDEX_RECEIVER],
+  );
+});
+
+test("Bolt HID++ support accepts short and long collections and prefers long", () => {
+  const shortOnly = fakeHidDevice(BOLT_RECEIVER, [hidppCollection(0x0001)]);
+  const longOnly = fakeHidDevice(BOLT_RECEIVER, [hidppCollection(0x0002)]);
+  const lightspeed = fakeHidDevice(LIGHTSPEED_RECEIVER, [hidppCollection(0x0001)]);
+
+  assert.equal(hasHidppShortCollection(shortOnly), true);
+  assert.equal(hasHidppLongCollection(shortOnly), false);
+  assert.equal(hasHidppLongCollection(longOnly), true);
+  assert.equal(boltSupportScore(longOnly, true), 8);
+  assert.equal(boltSupportScore(shortOnly, true), 6);
+  assert.equal(boltSupportScore(lightspeed, true), 6);
+  assert.equal(boltSupportScore(longOnly, false), 0);
+});
+
+test("Bolt short and long peers collapse to one logical device", () => {
+  const shortOnly = fakeHidDevice(BOLT_RECEIVER, [hidppCollection(0x0001)]);
+  const longOnly = fakeHidDevice(BOLT_RECEIVER, [hidppCollection(0x0002)]);
+  const lightspeed = fakeHidDevice(LIGHTSPEED_RECEIVER, [hidppCollection(0x0001)]);
+
+  assert.deepEqual(
+    collapseBoltPeers([shortOnly, longOnly, lightspeed]),
+    [longOnly, lightspeed],
+  );
+  assert.deepEqual(
+    collapseBoltPeers([shortOnly, lightspeed]),
+    [shortOnly, lightspeed],
+    "short collection is kept when no long peer is authorized yet",
+  );
+});
+
+test("Bolt report device resolves to the long-report peer when needed", () => {
+  const shortOnly = fakeHidDevice(BOLT_RECEIVER, [hidppCollection(0x0001)]);
+  const longOnly = fakeHidDevice(BOLT_RECEIVER, [hidppCollection(0x0002)]);
+  assert.equal(resolveBoltReportDevice(longOnly, []), longOnly);
+  assert.equal(resolveBoltReportDevice(shortOnly, [longOnly]), longOnly);
+  assert.throws(() => resolveBoltReportDevice(shortOnly, []), /usage 2/);
+});
+
+test("HID++ 1.0 probe errors are treated as absent indices", () => {
+  assert.equal(classifyHidpp20Probe(new Error("timeout"), true), "absent");
+  assert.equal(
+    classifyHidpp20Probe(new Error("The mouse rejected that setting (HID++ 1.0: invalid command)."), false),
+    "absent",
+  );
+  assert.equal(
+    classifyHidpp20Probe(new Error("The mouse rejected that setting (unsupported)."), false),
+    "hidpp20",
+  );
+});

--- a/src/devices/logitech/bolt.ts
+++ b/src/devices/logitech/bolt.ts
@@ -1,0 +1,112 @@
+/**
+ * Logi Bolt transport helpers.
+ *
+ * Kept out of hidpp.ts so Bolt/MX work can land without rewriting the shared
+ * Lightspeed / direct-connect driver paths that other PRs touch often.
+ */
+import {
+  BOLT_PAIRING_SLOTS,
+  DEVICE_INDEX_DIRECT,
+  DEVICE_INDEX_RECEIVER,
+  isBoltReceiverProduct,
+} from "./protocol.ts";
+
+/** Index probe on empty Bolt slots should fail fast; feature I/O keeps longer. */
+export const BOLT_INDEX_PROBE_TIMEOUT_MS = 800;
+
+/** True when a collection (or nested child) is an HID++ short- or long-report endpoint. */
+function collectionHasHidppUsage(
+  collections: readonly HIDCollectionInfo[],
+  usage: number,
+): boolean {
+  return collections.some((collection) =>
+    (collection.usagePage === 0xff00 && collection.usage === usage)
+    || collectionHasHidppUsage(collection.children, usage));
+}
+
+/** Short-report HID++ collection (Lightspeed, Bolt receiver registers). */
+export function hasHidppShortCollection(device: HIDDevice): boolean {
+  return collectionHasHidppUsage(device.collections, 0x0001);
+}
+
+/** Long-report HID++ collection (required for Bolt device feature traffic). */
+export function hasHidppLongCollection(device: HIDDevice): boolean {
+  return collectionHasHidppUsage(device.collections, 0x0002);
+}
+
+/**
+ * Prefer Bolt's long-report collection when both HID++ endpoints are present
+ * so feature traffic lands on the interface that can carry it.
+ */
+export function boltSupportScore(device: HIDDevice, supported: boolean): number {
+  if (!supported) return 0;
+  if (isBoltReceiverProduct(device.productId) && hasHidppLongCollection(device)) return 8;
+  return 6;
+}
+
+/**
+ * Collapse Bolt short+long peers to one sidebar entry (the long collection
+ * when both are authorized).
+ */
+export function collapseBoltPeers(devices: readonly HIDDevice[]): HIDDevice[] {
+  const boltLongPresent = new Set<number>();
+  for (const device of devices) {
+    if (isBoltReceiverProduct(device.productId) && hasHidppLongCollection(device)) {
+      boltLongPresent.add(device.productId);
+    }
+  }
+  return devices.filter((device) => {
+    if (!isBoltReceiverProduct(device.productId) || !hasHidppShortCollection(device)) return true;
+    if (hasHidppLongCollection(device)) return true;
+    return !boltLongPresent.has(device.productId);
+  });
+}
+
+/**
+ * HID++ device-index probe order. Bolt may place the mouse on any of six
+ * pairing slots; Lightspeed stays 0x01 then 0xFF; unknown endpoints try self
+ * first so wired mice are not addressed as receivers.
+ */
+export function hidppIndexCandidates(
+  productId: number,
+  knownReceiverIds: ReadonlySet<number>,
+): number[] {
+  if (isBoltReceiverProduct(productId)) return [...BOLT_PAIRING_SLOTS];
+  if (knownReceiverIds.has(productId)) return [DEVICE_INDEX_RECEIVER, DEVICE_INDEX_DIRECT];
+  return [DEVICE_INDEX_DIRECT, DEVICE_INDEX_RECEIVER];
+}
+
+/**
+ * Classify a root getFeature probe: only HID++ 2.0 replies mean a mouse is on
+ * that index. Bolt receivers answer HID++ 1.0 errors on empty slots / 0xFF.
+ */
+export function classifyHidpp20Probe(error: unknown, isTimeout: boolean): "hidpp20" | "absent" {
+  if (isTimeout) return "absent";
+  if (error instanceof Error && /HID\+\+ 1\.0/.test(error.message)) return "absent";
+  return "hidpp20";
+}
+
+/**
+ * Bolt device features answer on the long-report collection (usage 2). The
+ * picker may hand us the short collection; use an already-authorized peer.
+ */
+export function resolveBoltReportDevice(
+  device: HIDDevice,
+  peers: readonly HIDDevice[],
+): HIDDevice {
+  if (!isBoltReceiverProduct(device.productId)) return device;
+  if (hasHidppLongCollection(device)) return device;
+  const longPeer = peers.find((candidate) =>
+    candidate !== device
+    && candidate.vendorId === device.vendorId
+    && candidate.productId === device.productId
+    && hasHidppLongCollection(candidate));
+  if (!longPeer) {
+    throw new Error(
+      "Logi Bolt needs the HID++ long-report interface (usage 2). "
+      + "Reconnect and authorize both Bolt HID++ collections, or pick the usage-2 interface. "
+      + "Close Logi Options+ if the browser cannot open the device.",
+    );
+  }
+  return longPeer;
+}

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -1,18 +1,34 @@
 import type { MouseStatus } from "../mouse-types.ts";
+import { LOGITECH_RECEIVER_PRODUCT_IDS } from "../vendors.ts";
 import {
-  DEVICE_INDEX_DIRECT,
-  DEVICE_INDEX_RECEIVER,
+  BOLT_INDEX_PROBE_TIMEOUT_MS,
+  boltSupportScore,
+  classifyHidpp20Probe,
+  collapseBoltPeers,
+  hasHidppLongCollection,
+  hasHidppShortCollection,
+  hidppIndexCandidates,
+  resolveBoltReportDevice,
+} from "./bolt.ts";
+import {
   decodeBatteryLevelState,
   decodeReportRateBitmap,
   decodeUnifiedBatteryState,
   hidppDeviceIndex,
   hidppErrorForRequest,
+  isBoltReceiverProduct,
   isDirectConnection,
   isDirectConnectProduct,
   OnboardOnlyError,
   legacyDpiFallback,
   withSoftwareId,
 } from "./protocol.ts";
+
+export {
+  collapseBoltPeers,
+  hasHidppLongCollection,
+  hasHidppShortCollection,
+} from "./bolt.ts";
 import {
   MODE_STATUS,
   buildModeStatusWriteMany,
@@ -118,8 +134,7 @@ export class NotAMouseError extends Error {
 }
 
 const LOGITECH_VENDOR_ID = 0x046d;
-// HID++ control interfaces, including the PRO X 2 Superstrike USB interface.
-const LOGITECH_RECEIVER_PRODUCT_IDS = new Set([0xc54d, 0xc539, 0xc0a8, 0xc547]);
+const KNOWN_RECEIVER_PRODUCT_IDS: ReadonlySet<number> = new Set(LOGITECH_RECEIVER_PRODUCT_IDS);
 
 /**
  * Models whose 0x8090 mode-status feature drives the power-mode switch only.
@@ -148,6 +163,7 @@ export function hasLiftOffControl(legacyDpi: boolean, lodByte: number | null): b
 
 const SHORT_REPORT_ID = 0x10;
 const LONG_REPORT_ID = 0x11;
+const REQUEST_TIMEOUT_MS = 6000;
 const FEATURE = {
   deviceName: 0x0005,
   firmware: 0x0003,
@@ -227,6 +243,12 @@ export class LogitechHidppClient {
   private lodCapabilities: ProfileFormatCapabilities = capabilitiesForFormat(null);
   private supportedLods: Array<NonNullable<LogitechMouseStatus["liftOffDistance"]>> = ["Medium", "High"];
   private readonly rateChangeWaiters: Array<{ rate: number; resolve: () => void; reject: (reason: Error) => void }> = [];
+  /**
+   * Device used for HID++ feature sendReport. On Bolt this is the long-report
+   * collection (usage 2); elsewhere it is `device` itself.
+   */
+  private ioDevice: HIDDevice | null = null;
+  private listeningDevices = new Set<HIDDevice>();
   private readonly onInputReport = (event: HIDInputReportEvent): void => {
     if (event.reportId !== SHORT_REPORT_ID && event.reportId !== LONG_REPORT_ID) {
       return;
@@ -290,45 +312,61 @@ export class LogitechHidppClient {
     return isDirectConnection(this.device.productId, this.resolvedDeviceIndex);
   }
 
-  /** HID++ device index: the receiver's first slot, or the mouse itself. */
+  private get isBoltReceiver(): boolean {
+    return isBoltReceiverProduct(this.device.productId);
+  }
+
+  /** HID++ device index: a receiver pairing slot, or the mouse itself. */
   private get deviceIndex(): number {
     return this.resolvedDeviceIndex ?? hidppDeviceIndex(this.device.productId);
+  }
+
+  private get reportDevice(): HIDDevice {
+    return this.ioDevice ?? this.device;
   }
 
   /**
    * Finds which HID++ device index this connection answers on.
    *
-   * A mouse reached through its receiver answers on the receiver's pairing slot
-   * (0x01); the same mouse plugged in by cable answers as itself (0xFF). That
-   * cannot be read from the descriptors, and deriving it from a list of product
-   * ids only works for the handful of ids on the list — every other mouse
-   * plugged in directly was addressed as a receiver and never replied.
+   * A mouse reached through its receiver answers on a pairing slot (usually
+   * 0x01 on Lightspeed; any of 1..6 on Bolt). The same mouse plugged in by
+   * cable answers as itself (0xFF). That cannot be read from the descriptors.
    *
-   * So ask. The root feature query is the cheapest request there is, and the
-   * wrong index simply times out.
+   * Only a HID++ 2.0 reply (success or 2.0 error) counts. Bolt receivers answer
+   * HID++ 1.0 errors on empty slots and on 0xFF; treating those as "answered"
+   * made OpenMouse lock onto the receiver and report "invalid command".
    */
   private async resolveDeviceIndex(): Promise<void> {
     if (this.resolvedDeviceIndex !== null) return;
-    // Only a receiver forwards to a pairing slot; anything else is the mouse's
-    // own endpoint and answers as itself. Ordering by "is this a known
-    // receiver" rather than by the direct-connect id list matters for mice that
-    // are on neither list — a wired G102 is its own endpoint, and asking it as
-    // though it were behind a receiver is what made it look mode-locked.
-    const candidates = LOGITECH_RECEIVER_PRODUCT_IDS.has(this.device.productId)
-      ? [DEVICE_INDEX_RECEIVER, DEVICE_INDEX_DIRECT]
-      : [DEVICE_INDEX_DIRECT, DEVICE_INDEX_RECEIVER];
+    const candidates = hidppIndexCandidates(this.device.productId, KNOWN_RECEIVER_PRODUCT_IDS);
 
     for (const candidate of candidates) {
       this.resolvedDeviceIndex = candidate;
-      // Any reply at all proves something is listening, including a HID++
-      // error reply. Only silence rules the index out.
-      const answered = await this.request(0x00, 0x00, FEATURE.firmware >> 8, FEATURE.firmware & 0xff)
-        .then(() => true)
-        .catch((error: unknown) => !(error instanceof HidppTimeoutError));
-      if (answered) return;
+      const outcome = await this.probeHidpp20Root();
+      if (outcome === "hidpp20") return;
     }
     this.resolvedDeviceIndex = null;
-    throw new Error("The mouse did not answer on any HID++ device index.");
+    throw new Error(this.isBoltReceiver
+      ? "No mouse answered on this Logi Bolt receiver. Move the mouse, then try again. Close Logi Options+ if it is open."
+      : "The mouse did not answer on any HID++ device index.");
+  }
+
+  /**
+   * Root getFeature(firmware): distinguishes a HID++ 2.0 device from receiver
+   * HID++ 1.0 noise and from empty pairing slots.
+   */
+  private async probeHidpp20Root(): Promise<"hidpp20" | "absent"> {
+    try {
+      await this.requestWithOptions(
+        0x00,
+        0x00,
+        [FEATURE.firmware >> 8, FEATURE.firmware & 0xff],
+        { timeoutMs: this.isBoltReceiver ? BOLT_INDEX_PROBE_TIMEOUT_MS : REQUEST_TIMEOUT_MS },
+      );
+      return "hidpp20";
+    } catch (error: unknown) {
+      return classifyHidpp20Probe(error, error instanceof HidppTimeoutError);
+    }
   }
 
   /**
@@ -339,17 +377,26 @@ export class LogitechHidppClient {
    */
   static isSupported(device: HIDDevice): boolean {
     if (device.vendorId !== LOGITECH_VENDOR_ID) return false;
-    const hasHidppCollection = (collections: readonly HIDCollectionInfo[]): boolean =>
-      collections.some((collection) =>
-        (collection.usagePage === 0xff00 && collection.usage === 0x0001)
-        || hasHidppCollection(collection.children));
-    return hasHidppCollection(device.collections);
+    return hasHidppShortCollection(device) || hasHidppLongCollection(device);
+  }
+
+  /**
+   * Prefer Bolt's long-report collection when both HID++ endpoints are present
+   * so feature traffic lands on the interface that can carry it.
+   */
+  static supportScore(device: HIDDevice): number {
+    return boltSupportScore(device, this.isSupported(device));
+  }
+
+  /** @see collapseBoltPeers */
+  static collapseBoltPeers(devices: readonly HIDDevice[]): HIDDevice[] {
+    return collapseBoltPeers(devices);
   }
 
   /** Known receivers, kept as the fast path for the WebHID picker's filters. */
   static isKnownReceiver(device: HIDDevice): boolean {
     return device.vendorId === LOGITECH_VENDOR_ID
-      && (LOGITECH_RECEIVER_PRODUCT_IDS.has(device.productId) || isDirectConnectProduct(device.productId));
+      && (KNOWN_RECEIVER_PRODUCT_IDS.has(device.productId) || isDirectConnectProduct(device.productId));
   }
 
   static async requestReceiver(): Promise<LogitechHidppClient | null> {
@@ -358,14 +405,15 @@ export class LogitechHidppClient {
     }
 
     const devices = await navigator.hid.requestDevice({
-      filters: [...LOGITECH_RECEIVER_PRODUCT_IDS].map((productId) => ({
-        vendorId: LOGITECH_VENDOR_ID,
-        productId,
-        usagePage: 0xff00,
-        usage: 0x0001,
-      })),
+      filters: [...LOGITECH_RECEIVER_PRODUCT_IDS].flatMap((productId) => [
+        { vendorId: LOGITECH_VENDOR_ID, productId, usagePage: 0xff00, usage: 0x0001 },
+        { vendorId: LOGITECH_VENDOR_ID, productId, usagePage: 0xff00, usage: 0x0002 },
+      ]),
     });
-    const device = devices[0];
+    const ranked = [...devices]
+      .filter((device) => this.isSupported(device))
+      .sort((left, right) => this.supportScore(right) - this.supportScore(left));
+    const device = ranked[0];
     return device ? new LogitechHidppClient(device) : null;
   }
 
@@ -374,8 +422,11 @@ export class LogitechHidppClient {
       return null;
     }
 
-    const devices = await navigator.hid.getDevices();
-    const device = devices.find((candidate) => this.isSupported(candidate));
+    const devices = this.collapseBoltPeers(
+      (await navigator.hid.getDevices()).filter((candidate) => this.isSupported(candidate)),
+    );
+    const ranked = [...devices].sort((left, right) => this.supportScore(right) - this.supportScore(left));
+    const device = ranked[0];
     return device ? new LogitechHidppClient(device) : null;
   }
 
@@ -428,12 +479,18 @@ export class LogitechHidppClient {
     const supportsSeparateDpiAxes = dpiFeature.legacy
       ? false
       : await this.readDpiCapabilities(dpiFeature.index);
-    const supportedPollingRates = reportRateFeature.legacy
-      ? await this.readLegacyReportRates(reportRateFeature.index)
-      : await this.readSupportedPollingRates(reportRateFeature.index);
-    const pollingRateHz = reportRateFeature.legacy
-      ? await this.readLegacyReportRate(reportRateFeature.index)
-      : await this.readPollingRate(reportRateFeature.index);
+    // Productivity Bolt mice (MX Master 3S) expose DPI and battery but no
+    // 0x8060/0x8061 report-rate feature. Skip rather than throwing.
+    const supportedPollingRates = reportRateFeature.index
+      ? reportRateFeature.legacy
+        ? await this.readLegacyReportRates(reportRateFeature.index)
+        : await this.readSupportedPollingRates(reportRateFeature.index)
+      : [];
+    const pollingRateHz = reportRateFeature.index
+      ? reportRateFeature.legacy
+        ? await this.readLegacyReportRate(reportRateFeature.index)
+        : await this.readPollingRate(reportRateFeature.index)
+      : 0;
     const profileState = await this.readProfileState(profilesFeature.index);
     const firmware = await this.readFirmware(firmwareFeature.index);
     const analogButtonTuning = analogButtonsFeature.index
@@ -466,10 +523,14 @@ export class LogitechHidppClient {
         lodRequiresSurface: true,
         // Direct-connect mice report their rate but keep the writable copy in
         // the onboard profile, so show it without offering to change it.
-        pollingReadOnly: this.isDirectConnect ? true : undefined,
+        // Bolt productivity mice often expose no report-rate feature at all.
+        pollingReadOnly: this.isDirectConnect || !reportRateFeature.index ? true : undefined,
         pollingNote: this.isDirectConnect
           ? "This mouse stores its polling rate in the onboard profile, so OpenMouse reads it without changing it."
-          : undefined,
+          : !reportRateFeature.index
+            ? "This mouse does not expose a HID++ polling-rate control."
+            : undefined,
+        hideUnsupportedPollingRates: !reportRateFeature.index ? true : undefined,
       },
       batteryPercent: battery.percent,
       batteryVoltageMv: battery.voltageMv ?? null,
@@ -503,8 +564,13 @@ export class LogitechHidppClient {
       supportedLiftOffDistances: hasLiftOffControl(dpiFeature.legacy, dpiState.lod) ? this.supportedLods : [],
       connectionType: wired ? "Wired" : "Wireless",
       // Without this the shell falls back to its "2.4 GHz receiver" wording,
-      // which is wrong for a mouse plugged straight into USB.
-      connectionDetail: this.isDirectConnect ? "Wired USB" : undefined,
+      // which is wrong for a mouse plugged straight into USB, and imprecise
+      // for Logi Bolt (BLE-based) versus Lightspeed.
+      connectionDetail: this.isDirectConnect
+        ? "Wired USB"
+        : this.isBoltReceiver
+          ? "Logi Bolt"
+          : undefined,
       activeProfile: profileState.activeProfile,
       deviceMode: profileState.deviceMode,
       unitId: identity.unitId,
@@ -515,10 +581,14 @@ export class LogitechHidppClient {
   }
 
   async close(): Promise<void> {
-    this.device.removeEventListener("inputreport", this.onInputReport);
-    if (this.device.opened) {
-      await this.device.close();
+    for (const device of this.listeningDevices) {
+      device.removeEventListener("inputreport", this.onInputReport);
+      if (device.opened) {
+        await device.close().catch(() => undefined);
+      }
     }
+    this.listeningDevices.clear();
+    this.ioDevice = null;
   }
 
   async setPollingRate(pollingRateHz: number): Promise<number> {
@@ -1231,10 +1301,24 @@ export class LogitechHidppClient {
   }
 
   private async open(): Promise<void> {
-    if (!this.device.opened) {
-      await this.device.open();
+    await this.bindBoltIoDevice();
+    const devices = new Set<HIDDevice>([this.device, this.reportDevice]);
+    for (const device of devices) {
+      if (!device.opened) {
+        await device.open();
+      }
+      if (!this.listeningDevices.has(device)) {
+        device.addEventListener("inputreport", this.onInputReport);
+        this.listeningDevices.add(device);
+      }
     }
-    this.device.addEventListener("inputreport", this.onInputReport);
+  }
+
+  private async bindBoltIoDevice(): Promise<void> {
+    const peers = typeof navigator !== "undefined" && navigator.hid
+      ? await navigator.hid.getDevices()
+      : [];
+    this.ioDevice = resolveBoltReportDevice(this.device, peers);
   }
 
   /** Prefer extended DPI (0x2202); fall back to legacy Adjustable DPI (0x2201). */
@@ -1631,6 +1715,21 @@ export class LogitechHidppClient {
   }
 
   private async request(featureIndex: number, functionId: number, ...parameters: number[]): Promise<Uint8Array> {
+    return this.requestWithOptions(featureIndex, functionId, parameters);
+  }
+
+  private async requestWithOptions(
+    featureIndex: number,
+    functionId: number,
+    parameters: number[],
+    options: { timeoutMs?: number } = {},
+  ): Promise<Uint8Array> {
+    // Bolt feature traffic only answers on long reports. Lightspeed and wired
+    // mice keep the short form for the three-parameter path they were verified
+    // with; longer payloads still go through requestLong.
+    if (this.isBoltReceiver) {
+      return this.requestLong(featureIndex, functionId, parameters, options.timeoutMs);
+    }
     if (parameters.length > 3) {
       throw new Error("This WebHID client only sends short, read-only HID++ requests.");
     }
@@ -1643,16 +1742,21 @@ export class LogitechHidppClient {
       parameters[1] ?? 0,
       parameters[2] ?? 0,
     ]);
-    const response = this.waitForResponse(featureIndex, functionId);
+    const response = this.waitForResponse(featureIndex, functionId, options.timeoutMs);
     // Keep the timeout rejection observed even when sendReport itself fails
     // (for example, when a browser selected a protected mouse collection).
     // The original sendReport error is then shown by the control panel.
     void response.catch(() => undefined);
-    await this.device.sendReport(SHORT_REPORT_ID, report);
+    await this.reportDevice.sendReport(SHORT_REPORT_ID, report);
     return await response;
   }
 
-  private async requestLong(featureIndex: number, functionId: number, parameters: number[]): Promise<Uint8Array> {
+  private async requestLong(
+    featureIndex: number,
+    functionId: number,
+    parameters: number[],
+    timeoutMs = REQUEST_TIMEOUT_MS,
+  ): Promise<Uint8Array> {
     if (parameters.length > 16) {
       throw new Error("HID++ long requests support at most 16 parameter bytes.");
     }
@@ -1661,13 +1765,17 @@ export class LogitechHidppClient {
     report[1] = featureIndex;
     report[2] = withSoftwareId(functionId);
     report.set(parameters, 3);
-    const response = this.waitForResponse(featureIndex, functionId);
+    const response = this.waitForResponse(featureIndex, functionId, timeoutMs);
     void response.catch(() => undefined);
-    await this.device.sendReport(LONG_REPORT_ID, report);
+    await this.reportDevice.sendReport(LONG_REPORT_ID, report);
     return await response;
   }
 
-  private waitForResponse(featureIndex: number, functionId: number): Promise<Uint8Array> {
+  private waitForResponse(
+    featureIndex: number,
+    functionId: number,
+    timeoutMs = REQUEST_TIMEOUT_MS,
+  ): Promise<Uint8Array> {
     return new Promise<Uint8Array>((resolve, reject) => {
       const timeout = window.setTimeout(() => {
         const index = this.waiters.findIndex((waiter) => waiter.reject === reject);
@@ -1676,8 +1784,10 @@ export class LogitechHidppClient {
         }
         reject(new HidppTimeoutError(this.isDirectConnect
           ? "The mouse did not answer. Close Logitech G HUB or Logitech Gaming Software, then try again."
-          : "The mouse did not answer. Move it or click a button, then try again."));
-      }, 6000);
+          : this.isBoltReceiver
+            ? "The mouse did not answer. Move it, close Logi Options+, then try again."
+            : "The mouse did not answer. Move it or click a button, then try again."));
+      }, timeoutMs);
 
       this.waiters.push({
         featureIndex,

--- a/src/devices/logitech/protocol.ts
+++ b/src/devices/logitech/protocol.ts
@@ -11,6 +11,8 @@ export function withSoftwareId(functionId: number): number {
 export const DEVICE_INDEX_RECEIVER = 0x01;
 /** A mouse addressed over its own USB interface answers on 0xFF. */
 export const DEVICE_INDEX_DIRECT = 0xff;
+/** Bolt receivers expose up to six pairing slots (HID++ device indices 1..6). */
+export const BOLT_PAIRING_SLOTS = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06] as const;
 
 /**
  * Logitech mice whose vendor interface is the mouse itself rather than a
@@ -25,10 +27,24 @@ export const DEVICE_INDEX_DIRECT = 0xff;
  */
 export const LOGITECH_DIRECT_PRODUCT_IDS = [0xc07e, 0xc08f] as const;
 
+/**
+ * Logi Bolt receivers. Unlike Lightspeed, device HID++ 2.0 rides long reports
+ * (report id 0x11) on usage `ff00:2`, and the mouse may sit on any pairing
+ * slot — not only 0x01.
+ *
+ * - 0xc548 — Logi Bolt USB receiver (MX Master 3S and other Bolt mice)
+ */
+export const LOGITECH_BOLT_PRODUCT_IDS = [0xc548] as const;
+
 const DIRECT_PRODUCT_ID_SET: ReadonlySet<number> = new Set(LOGITECH_DIRECT_PRODUCT_IDS);
+const BOLT_PRODUCT_ID_SET: ReadonlySet<number> = new Set(LOGITECH_BOLT_PRODUCT_IDS);
 
 export function isDirectConnectProduct(productId: number): boolean {
   return DIRECT_PRODUCT_ID_SET.has(productId);
+}
+
+export function isBoltReceiverProduct(productId: number): boolean {
+  return BOLT_PRODUCT_ID_SET.has(productId);
 }
 
 /**

--- a/src/devices/registry.ts
+++ b/src/devices/registry.ts
@@ -32,7 +32,7 @@ export const DEVICE_DRIVERS: readonly DeviceDriver[] = [
   { brand: "Pulsar", supports: (device) => PulsarHidClient.isSupported(device), create: (device) => new PulsarHidClient(device), score: () => 7 },
   { brand: "Teevolution", supports: (device) => TeevolutionHidClient.isSupported(device), create: (device) => new TeevolutionHidClient(device), score: () => 7 },
   { brand: "VGN", supports: (device) => VgnF2HidClient.isSupported(device), create: (device) => new VgnF2HidClient(device), score: () => 7 },
-  { brand: "Logitech", supports: (device) => LogitechHidppClient.isSupported(device), create: (device) => new LogitechHidppClient(device), score: () => 6 },
+  { brand: "Logitech", supports: (device) => LogitechHidppClient.isSupported(device), create: (device) => new LogitechHidppClient(device), score: (device) => LogitechHidppClient.supportScore(device) },
   { brand: "WLMouse", supports: (device) => WLMouseHidClient.isSupported(device), create: (device) => new WLMouseHidClient(device), score: () => 5 },
   { brand: "Lamzu", supports: (device) => LamzuHidClient.isSupported(device), create: (device) => new LamzuHidClient(device), score: () => 5 },
   { brand: "Orbital", supports: (device) => OrbitalHidClient.isSupported(device), create: (device) => new OrbitalHidClient(device), score: () => 6 },

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -1,5 +1,8 @@
 import { EGG_WE_HID_FILTERS } from "./endgame/egg-we-control.ts";
-import { LOGITECH_DIRECT_PRODUCT_IDS } from "./logitech/protocol.ts";
+import {
+  LOGITECH_BOLT_PRODUCT_IDS,
+  LOGITECH_DIRECT_PRODUCT_IDS,
+} from "./logitech/protocol.ts";
 
 export const VENDOR_ID = {
   pulsar: 0x3710,
@@ -53,14 +56,21 @@ export const RAZER_DEATHADDER_ESSENTIAL_FILTERS: HIDDeviceFilter[] = [0x006e, 0x
 
 export const TEEVOLUTION_PRODUCT_IDS = [0xf520, 0xf523, 0xf5bb, 0xf522] as const;
 
-// Logitech HID++ control interfaces addressed through a receiver slot (HID++
-// device index 0x01). 0xc54d and 0xc547 are newer Lightspeed receivers, 0xc539
-// is HERO-era Lightspeed, and 0xc0a8 is the PRO X 2 Superstrike USB interface.
-export const LOGITECH_RECEIVER_PRODUCT_IDS = [0xc54d, 0xc539, 0xc0a8, 0xc547] as const;
+// Logitech HID++ control interfaces addressed through a receiver slot.
+// 0xc54d and 0xc547 are newer Lightspeed receivers, 0xc539 is HERO-era
+// Lightspeed, 0xc0a8 is the PRO X 2 Superstrike USB interface, and Bolt
+// product ids live in ./logitech/protocol with the direct-connect list.
+export const LOGITECH_RECEIVER_PRODUCT_IDS = [
+  0xc54d,
+  0xc539,
+  0xc0a8,
+  0xc547,
+  ...LOGITECH_BOLT_PRODUCT_IDS,
+] as const;
 
 // Every Logitech product with an HID++ control interface, receiver-addressed or
-// not. Direct-connect product IDs live in ./logitech/protocol so the driver and
-// these filters cannot disagree about which index a mouse answers on.
+// not. Direct-connect and Bolt product IDs live in ./logitech/protocol so the
+// driver and these filters cannot disagree about which index a mouse answers on.
 export const LOGITECH_PRODUCT_IDS = [
   ...LOGITECH_RECEIVER_PRODUCT_IDS,
   ...LOGITECH_DIRECT_PRODUCT_IDS,
@@ -68,13 +78,14 @@ export const LOGITECH_PRODUCT_IDS = [
 
 /**
  * Every Logitech HID++ control interface, not only the product ids listed
- * above: a mouse we have never seen should still be offered. The usage page
- * keeps this to HID++ endpoints, but it cannot tell a mouse from a keyboard or
- * a headset — the driver decides that after connecting, by looking for a sensor
- * feature, and reports a clear message when there is none.
+ * above: a mouse we have never seen should still be offered. Usage 1 is the
+ * short-report HID++ collection used by Lightspeed and for Bolt receiver
+ * registers; usage 2 is the long-report collection Bolt mice need for HID++
+ * 2.0 feature traffic. The driver decides mouse-vs-keyboard after connecting.
  */
 export const LOGITECH_RECEIVER_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.logitech, usagePage: 0xff00, usage: 0x0001 },
+  { vendorId: VENDOR_ID.logitech, usagePage: 0xff00, usage: 0x0002 },
 ];
 
 // Retained for existing imports; points at the first supported receiver.


### PR DESCRIPTION
## Summary
- Add Logi Bolt receiver support (`046d:c548`) so MX Master 3S (and other Bolt mice) can connect through OpenMouse.
- Isolate Bolt transport in `src/devices/logitech/bolt.ts` (pairing slots 1–6, long-report / usage `ff00:2` peer bind, sidebar collapse) so Lightspeed and wired Logitech paths stay shared.
- Reuse existing HID++ feature readers for DPI (`0x2201`), battery (`0x1004`), name, and firmware; mice without a report-rate feature no longer fail `readStatus`.
## Why
Bolt is not Lightspeed: device HID++ 2.0 rides **long** reports on usage `2`, and the mouse may sit on any pairing slot. Treating `C548` like a direct `0xFF` endpoint produced `HID++ 1.0: invalid command`.
## Test plan
- [ ] Close Logi Options+ / G HUB
- [ ] Connect Bolt dongle; authorize both HID++ collections if offered (usage `1` and `2`)
- [ ] Confirm MX Master 3S shows Wireless / Logi Bolt, battery %, and DPI
- [ ] Change DPI and confirm live read-back matches (persistence is not expected yet — see Notes)
- [ ] Confirm polling/LOD cards stay inactive or noted unavailable (no `0x8060`/`0x2202` on this mouse)
- [ ] Smoke a Lightspeed or wired Logitech mouse if available (short-report path unchanged)
## Notes
- Verified against Bolt `046d:c548`, WPID `B034` (MX Master 3S), HID++ 4.5.
- DPI writes today are **live only** via `0x2201` `setSensorDpi`. After disconnect/reconnect the mouse falls back to firmware default (~1000 DPI) until (if installed) Logi Options+ starts and restores its saved profile which is seperate from openmouse.
- Not implemented yet: SmartShift, HiRes/thumb wheel, host switching, button remaps, persistent DPI.