### PR TITLE
hotfix(razer): retry corrupt replies after an 8K polling switch

### DIFF
--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -141,6 +141,16 @@ and a 500 Hz write measured 499 Hz through `pointerrawupdate`.
 The cable is limited to 1000 Hz on this model, which is also the ceiling the
 legacy encoding can express, so no HyperPolling command is missing there.
 
+## Changing the polling rate reconfigures the link
+
+Switching the receiver to 8,000 Hz briefly reconfigures the wireless link, and
+feature-report exchanges sent into that window come back with a bad checksum or
+not at all. `setPollingRate` pauses 150 ms for the link to settle, and `exchange`
+re-sends a request whose reply was corrupt instead of surfacing the checksum
+error — so a single garbage reply no longer fails the whole status read or hides
+the lift-off card. The read-back budget is unchanged in the healthy case; only a
+lost exchange takes the retry path.
+
 ## Idle sleep range
 
 Synapse slides from **1 to 15 minutes** in whole minutes, so the dropdown offers

--- a/src/devices/razer/hid.test.ts
+++ b/src/devices/razer/hid.test.ts
@@ -26,6 +26,8 @@ interface FakeOptions {
   liftOffUnsupported?: boolean;
   /** Accept the write and keep the old values, as a rejected write does. */
   ignoreWrites?: boolean;
+  /** Answer the next N sends with a reply whose checksum is wrong. */
+  corruptSends?: number;
 }
 
 function replyPacket(commandClass: number, commandId: number, dataSize: number, args: number[], status: number): Uint8Array {
@@ -48,6 +50,7 @@ function replyPacket(commandClass: number, commandId: number, dataSize: number, 
 function fakeMouse(state: FakeLiftOff, options: FakeOptions = {}) {
   const sent: Uint8Array[] = [];
   let pending = new Uint8Array(RAZER_PACKET_LENGTH);
+  let corruptRemaining = options.corruptSends ?? 0;
   const device = {
     vendorId: 0x1532,
     productId: 0x00c1,
@@ -86,6 +89,13 @@ function fakeMouse(state: FakeLiftOff, options: FakeOptions = {}) {
       pending = liftOffRead
         ? replyPacket(commandClass, commandId, 0x05, [0, 0, state.tracking, state.liftOff - 1, state.landing - 1], RAZER_STATUS.ok)
         : replyPacket(commandClass, commandId, data[5], [...data.slice(8, 8 + data[5])], RAZER_STATUS.ok);
+      if (corruptRemaining > 0) {
+        // The receiver returns garbage while it reconfigures after a rate
+        // change; break the checksum so the exchange has to be re-sent.
+        pending = replyPacket(commandClass, commandId, data[5], [], RAZER_STATUS.ok);
+        pending[88] ^= 0xff;
+        corruptRemaining -= 1;
+      }
     },
     receiveFeatureReport: async () => new DataView(pending.buffer.slice(0)),
   } as unknown as HIDDevice;
@@ -101,6 +111,39 @@ test("lift-off reads the tracking level and the asymmetric pair together", async
 
   // Assert
   assert.deepEqual(liftOff, { tracking: "Medium", liftOff: 16, landing: 11 });
+});
+
+test("a corrupt reply is retried instead of surfacing a checksum error", async () => {
+  // The receiver returns garbage while it reconfigures the wireless link after
+  // a polling-rate change, which is what produced the "bad checksum" errors
+  // right after an 8,000 Hz switch. A bad checksum means the exchange was lost,
+  // so the driver re-sends the request until a valid reply arrives — otherwise
+  // a single corrupt reply would hide the lift-off card entirely.
+  // Arrange
+  const { client, sent } = fakeMouse({ tracking: 1, liftOff: 16, landing: 11, asymmetric: true }, { corruptSends: 2 });
+
+  // Act
+  const liftOff = await client.readLiftOff();
+
+  // Assert
+  assert.deepEqual(liftOff, { tracking: "Medium", liftOff: 16, landing: 11 });
+  assert.equal(sent.length, 3);
+});
+
+test("retrying a corrupt reply does not break the command/response pairing", async () => {
+  // Re-sending on a corrupt reply must never let one command swallow another's
+  // reply. A multi-command sequence — unlock, pair write, read-back — still has
+  // to land in order even when one of its exchanges comes back corrupt.
+  // Arrange
+  const { client, sent } = fakeMouse({ tracking: 2, liftOff: 26, landing: 25, asymmetric: true }, { corruptSends: 1 });
+
+  // Act
+  const confirmed = await client.setLiftOff(16, 11);
+
+  // Assert
+  assert.deepEqual(confirmed, { tracking: "High", liftOff: 16, landing: 11 });
+  // The unlock, the pair write, the corrupt pair read, and its re-sent read.
+  assert.equal(sent.length, 4);
 });
 
 test("a transport that rejects class 0x0b degrades to null instead of throwing", async () => {

--- a/src/devices/razer/hid.ts
+++ b/src/devices/razer/hid.ts
@@ -89,6 +89,9 @@ const PRODUCTS: ReadonlyMap<number, RazerProduct> = new Map([
 const DPI_MIN = 100;
 const RESPONSE_DELAY_MS = 100;
 const RESPONSE_ATTEMPTS = 6;
+// How long a polling-rate change takes to re-establish the wireless link. The
+// Viper V4 Pro driver pauses 150 ms for the same reason.
+const POLLING_LINK_SETTLE_MS = 150;
 
 // The vendor software slides from 1 to 15 minutes, so those are the bounds this
 // model is meant to hold. The firmware itself accepts less — 30 s round-tripped
@@ -341,6 +344,11 @@ export class RazerHidClient {
     await this.request(this.isWireless()
       ? razerSetExtendedPollingCommand(pollingRateHz)
       : razerSetLegacyPollingCommand(pollingRateHz));
+    // Changing the rate briefly reconfigures the wireless link, and exchanges
+    // sent into that window come back corrupt or unanswered — the Viper V4 Pro
+    // driver documents the same pause. Let it settle before the read-back; any
+    // stragglers are then caught by `exchange`'s own retry.
+    if (this.isWireless()) await this.delay(POLLING_LINK_SETTLE_MS);
     const confirmed = await this.readPollingRateHz();
     if (confirmed !== pollingRateHz) {
       throw new Error(`The mouse kept ${confirmed.toLocaleString()} Hz instead of ${pollingRateHz.toLocaleString()} Hz.`);
@@ -494,18 +502,43 @@ export class RazerHidClient {
   private async exchange(command: RazerCommand): Promise<Uint8Array> {
     await this.open();
     const transactionId = this.profile()?.transactionId ?? RAZER_TRANSACTION_ID;
-    await this.device.sendFeatureReport(RAZER_REPORT_ID, encodeRazerRequest(command, transactionId));
+    const request = encodeRazerRequest(command, transactionId);
+    // A busy status means the mouse will answer this same request later, so the
+    // reads keep going without a re-send. A corrupt reply means the exchange
+    // itself was lost — the receiver can return garbage while it reconfigures
+    // the wireless link after a polling-rate change — so the send is retried
+    // from scratch. Retrying keeps one corrupt reply from failing the whole
+    // status read, which is what took the lift-off panel down after an 8,000 Hz
+    // switch.
     for (let attempt = 0; attempt < RESPONSE_ATTEMPTS; attempt += 1) {
+      await this.device.sendFeatureReport(RAZER_REPORT_ID, request);
+      const reply = await this.awaitReply(command);
+      if (reply) return reply;
+    }
+    throw new Error("The mouse stayed busy — it may be asleep or out of range.");
+  }
+
+  /**
+   * Reads up to the response budget for one send. Returns the decoded reply, or
+   * null when the reply was corrupt or the budget ran out on busy replies — the
+   * caller re-sends on null, since a corrupt reply is a lost exchange rather
+   * than a status the mouse owns.
+   */
+  private async awaitReply(command: RazerCommand): Promise<Uint8Array | null> {
+    for (let read = 0; read < RESPONSE_ATTEMPTS; read += 1) {
       await this.delay(RESPONSE_DELAY_MS);
       const reply = this.copyDataView(await this.device.receiveFeatureReport(RAZER_REPORT_ID));
       try {
         return decodeRazerResponse(reply, command);
       } catch (error) {
         if (error instanceof RazerProtocolError && error.status === RAZER_STATUS.busy) continue;
+        // A bad checksum or wrong length carries no status, so it is transport
+        // corruption rather than an answer the mouse decided on.
+        if (error instanceof RazerProtocolError && error.status === null) return null;
         throw error;
       }
     }
-    throw new Error("The mouse stayed busy — it may be asleep or out of range.");
+    return null;
   }
 
   private copyDataView(view: DataView): Uint8Array {


### PR DESCRIPTION
## Summary

Hotfix for the Razer Viper V3 Pro (firmware 1.12): setting the polling rate to 8,000 Hz on the HyperSpeed receiver briefly reconfigures the wireless link, and feature-report exchanges sent into that window come back with a bad checksum.

## Problem

- After an 8K polling switch, the DPI read (`0x04/0x85`) and charging read (`0x07/0x84`) threw `Class 0x04 command 0x85 returned a reply with a bad checksum.` (and the equivalent for charging).
- The lift-off (LOD) card silently disappeared, because `readLiftOff` degrades to `null` on a failed exchange.
- The 8K apply sometimes failed outright.

## Fix

- `exchange` now re-sends a request whose reply came back corrupt (bad checksum / wrong length) instead of treating it as fatal, retrying within the existing response budget. Busy (`0x01`) replies still keep reading without a re-send.
- `setPollingRate` pauses 150 ms after a wireless rate write so the read-back happens after the link settles (the Viper V4 Pro driver documents the same pause).

## Testing

- Added `hid.test.ts` cases: a corrupt reply is retried instead of surfacing a checksum error, and retrying does not break the command/response pairing of the multi-step lift-off write.
- `npm test` (200 tests) and `npm run build` pass.