### PR TITLE
fix(logitech): G305 LIGHTSPEED — connect via Nano receiver and hide unsupported controls

### DIFF
--- a/src/devices/logitech/TESTING.md
+++ b/src/devices/logitech/TESTING.md
@@ -91,3 +91,17 @@ hidden.
    the LightForce switch are all hidden.
 3. Change the DPI and polling rate and confirm each write persists after a
    reload.
+
+## G305 LIGHTSPEED (receiver-attached, Model ID `407400000000`)
+
+Like the G309, the G305 exposes Mode Status `0x8090` but only the power-mode
+half is meaningful: the status1 byte that would carry the gaming-surface and
+LightForce fields is reserved and reads 0. The G305 also has no lift-off
+control. OpenMouse treats all three as absent, so those cards stay hidden.
+
+1. Confirm the model, battery, connection type, DPI, and polling rate are read
+   correctly.
+2. Confirm the sensor card (lift-off distance), the gaming-surface card, and
+   the LightForce switch are all hidden.
+3. Change the DPI and polling rate and confirm each write persists after a
+   reload.

--- a/src/devices/logitech/TESTING.md
+++ b/src/devices/logitech/TESTING.md
@@ -9,6 +9,7 @@ Supported identifiers:
 
 - `046d:c54d`, `046d:c547` — Lightspeed receivers
 - `046d:c539` — HERO-era Lightspeed receiver
+- `046d:c53f`, `046d:c543` — Nano Lightspeed 1.1 / 1.2 receivers (G305)
 - `046d:c0a8` — PRO X 2 Superstrike (USB)
 - `046d:c07e` — G402 / G402 Hyperion Fury (wired)
 - `046d:c08f` — G403 HERO (wired)

--- a/src/devices/logitech/hidpp.test.ts
+++ b/src/devices/logitech/hidpp.test.ts
@@ -162,6 +162,8 @@ test("an onboard-only mouse is told how to get itself supported", () => {
 test("the G309's mode status is power-only and exposes no surface or LightForce controls", () => {
   // Model id captured from hardware: 0x8090 V2 with only the power-mode half.
   assert.equal(isPowerOnlyModeStatus("B03C40B10000"), true);
+  // The G305 reports the same reserved status1 byte.
+  assert.equal(isPowerOnlyModeStatus("407400000000"), true);
   // Every other model keeps the status1 fields, and unknown/absent ids must
   // not be silently downgraded.
   assert.equal(isPowerOnlyModeStatus("B03C40B10001"), false);

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -119,7 +119,7 @@ export class NotAMouseError extends Error {
 
 const LOGITECH_VENDOR_ID = 0x046d;
 // HID++ control interfaces, including the PRO X 2 Superstrike USB interface.
-const LOGITECH_RECEIVER_PRODUCT_IDS = new Set([0xc54d, 0xc539, 0xc0a8, 0xc547]);
+const LOGITECH_RECEIVER_PRODUCT_IDS = new Set([0xc54d, 0xc539, 0xc0a8, 0xc547, 0xc53f, 0xc543]);
 
 /**
  * Models whose 0x8090 mode-status feature drives the power-mode switch only.
@@ -320,11 +320,13 @@ export class LogitechHidppClient {
 
     for (const candidate of candidates) {
       this.resolvedDeviceIndex = candidate;
-      // Any reply at all proves something is listening, including a HID++
-      // error reply. Only silence rules the index out.
+      // Only a successful reply proves a HID++ 2.0 mouse is on this index. A
+      // receiver answers the direct index with a HID++ 1.0 error reply, which
+      // is not a mouse and must not count — else we latch onto it and every
+      // later request fails with "invalid command".
       const answered = await this.request(0x00, 0x00, FEATURE.firmware >> 8, FEATURE.firmware & 0xff)
         .then(() => true)
-        .catch((error: unknown) => !(error instanceof HidppTimeoutError));
+        .catch(() => false);
       if (answered) return;
     }
     this.resolvedDeviceIndex = null;

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -130,6 +130,7 @@ const LOGITECH_RECEIVER_PRODUCT_IDS = new Set([0xc54d, 0xc539, 0xc0a8, 0xc547, 0
  */
 const MODE_STATUS_POWER_ONLY_MODEL_IDS: ReadonlySet<string> = new Set([
   "B03C40B10000", // G309 LIGHTSPEED
+  "407400000000", // G305 LIGHTSPEED
 ]);
 
 /** Whether 0x8090 on this model is the power-mode-only variant. */

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -55,8 +55,9 @@ export const TEEVOLUTION_PRODUCT_IDS = [0xf520, 0xf523, 0xf5bb, 0xf522] as const
 
 // Logitech HID++ control interfaces addressed through a receiver slot (HID++
 // device index 0x01). 0xc54d and 0xc547 are newer Lightspeed receivers, 0xc539
-// is HERO-era Lightspeed, and 0xc0a8 is the PRO X 2 Superstrike USB interface.
-export const LOGITECH_RECEIVER_PRODUCT_IDS = [0xc54d, 0xc539, 0xc0a8, 0xc547] as const;
+// is HERO-era Lightspeed, 0xc53f and 0xc543 are Nano Lightspeed 1.1/1.2
+// receivers (G305), and 0xc0a8 is the PRO X 2 Superstrike USB interface.
+export const LOGITECH_RECEIVER_PRODUCT_IDS = [0xc54d, 0xc539, 0xc0a8, 0xc547, 0xc53f, 0xc543] as const;
 
 // Every Logitech product with an HID++ control interface, receiver-addressed or
 // not. Direct-connect product IDs live in ./logitech/protocol so the driver and


### PR DESCRIPTION
## Summary

Two fixes make the G305 LIGHTSPEED usable: it never connected before (probing latched onto its receiver's HID++ 1.0 error reply), and once connected it showed gaming-surface / LightForce controls the mouse does not have. Both are verified on hardware.

## Fix 1 — device connect

The G305 connects through a Nano Lightspeed receiver (`046d:c53f`) that was missing from `LOGITECH_RECEIVER_PRODUCT_IDS`, so device-index probing ran the wrong way around.

- **Root cause**: `resolveDeviceIndex()` probes two HID++ device indexes to learn whether a mouse answers on its own endpoint (`0xFF`) or through a receiver pairing slot (`0x01`). For product IDs not on the receiver list it tried `0xFF` first. The G305's receiver is a HID++ 1.0 device and **answers that probe with a HID++ 1.0 error reply** (`0x8F`, "invalid command") rather than silence. The old probe counted *any* reply — including an error reply — as "a mouse is here", so OpenMouse locked onto device index `0xFF` and every later request failed with "The mouse rejected that setting (HID++ 1.0: invalid command)."
- **Fix**: `resolveDeviceIndex()` now only treats a *successful* root feature query as proof of a HID++ 2.0 mouse; a receiver's HID++ 1.0 error reply no longer counts as "answered", so probing falls through to the pairing slot and finds the mouse. Only genuine HID++ 2.0 mice answer the root probe successfully, so direct-connect mice (G402, G403 HERO, etc.) are unaffected. Also added `0xc53f` (Nano Lightspeed 1.1, G305) and `0xc543` (Lightspeed 1.2) to `LOGITECH_RECEIVER_PRODUCT_IDS` so the receiver slot is probed first.

## Fix 2 — hide surface / LightForce controls the G305 does not have

The G305 exposes Mode Status `0x8090`, but only the power-mode half is meaningful: the status1 byte that would carry the gaming-surface and LightForce fields is reserved and reads `0`. That decoded as Gaming surface "Auto" and LightForce "Optical" and offered both controls (plus the sensor card).

- **Fix**: keyed on the firmware model id `407400000000` (captured from the device's connection diagnostics), added to `MODE_STATUS_POWER_ONLY_MODEL_IDS` the same way the G309 was handled in `ff6e1cd`. `gamingSurfaceMode` and `lightforceSwitchMode` are now reported `null` and both cards stay hidden.

## Files changed

- `src/devices/logitech/hidpp.ts` — strict index probe; receiver PIDs; G305 model id.
- `src/devices/vendors.ts` — receiver PIDs for the picker.
- `src/devices/logitech/hidpp.test.ts` — G305 mode-status assertion.
- `src/devices/logitech/TESTING.md` — receiver identifiers and G305 checklist.

## Verification

- Confirmed on hardware with a G305 LIGHTSPEED (receiver `046d:c53f`): connects and reads DPI, polling rate, and battery correctly; gaming-surface, LightForce, and lift-off cards stay hidden.
- `npm run check` (build + 197 tests) passes.
