### PR TITLE
fix(logitech): hide surface and LightForce controls the G305 does not have

### DIFF
--- a/src/devices/logitech/TESTING.md
+++ b/src/devices/logitech/TESTING.md
@@ -90,3 +90,17 @@ hidden.
    the LightForce switch are all hidden.
 3. Change the DPI and polling rate and confirm each write persists after a
    reload.
+
+## G305 LIGHTSPEED (receiver-attached, Model ID `407400000000`)
+
+Like the G309, the G305 exposes Mode Status `0x8090` but only the power-mode
+half is meaningful: the status1 byte that would carry the gaming-surface and
+LightForce fields is reserved and reads 0. The G305 also has no lift-off
+control. OpenMouse treats all three as absent, so those cards stay hidden.
+
+1. Confirm the model, battery, connection type, DPI, and polling rate are read
+   correctly.
+2. Confirm the sensor card (lift-off distance), the gaming-surface card, and
+   the LightForce switch are all hidden.
+3. Change the DPI and polling rate and confirm each write persists after a
+   reload.

--- a/src/devices/logitech/hidpp.test.ts
+++ b/src/devices/logitech/hidpp.test.ts
@@ -162,6 +162,8 @@ test("an onboard-only mouse is told how to get itself supported", () => {
 test("the G309's mode status is power-only and exposes no surface or LightForce controls", () => {
   // Model id captured from hardware: 0x8090 V2 with only the power-mode half.
   assert.equal(isPowerOnlyModeStatus("B03C40B10000"), true);
+  // The G305 reports the same reserved status1 byte.
+  assert.equal(isPowerOnlyModeStatus("407400000000"), true);
   // Every other model keeps the status1 fields, and unknown/absent ids must
   // not be silently downgraded.
   assert.equal(isPowerOnlyModeStatus("B03C40B10001"), false);

--- a/src/devices/logitech/hidpp.ts
+++ b/src/devices/logitech/hidpp.ts
@@ -130,6 +130,7 @@ const LOGITECH_RECEIVER_PRODUCT_IDS = new Set([0xc54d, 0xc539, 0xc0a8, 0xc547]);
  */
 const MODE_STATUS_POWER_ONLY_MODEL_IDS: ReadonlySet<string> = new Set([
   "B03C40B10000", // G309 LIGHTSPEED
+  "407400000000", // G305 LIGHTSPEED
 ]);
 
 /** Whether 0x8090 on this model is the power-mode-only variant. */


### PR DESCRIPTION
## Summary

The G305 LIGHTSPEED exposes Mode Status `0x8090`, but on this model only the power-mode half is meaningful: the status1 byte that would carry the gaming-surface and LightForce fields is reserved and reads `0`. OpenMouse decoded that as Gaming surface "Auto" and LightForce "Optical" and offered both controls (plus the sensor card), which the G305 does not have.

### Fix

Keyed on the firmware model id, the same way the G309 was handled in `ff6e1cd`:

- `src/devices/logitech/hidpp.ts`: added model id `407400000000` to `MODE_STATUS_POWER_ONLY_MODEL_IDS`, so `gamingSurfaceMode` and `lightforceSwitchMode` are reported `null` and both cards stay hidden.
- `src/devices/logitech/hidpp.test.ts`: asserts the G305 model id is power-only.
- `src/devices/logitech/TESTING.md`: added a G305 checklist section.

Model id `407400000000` was captured from the device's connection diagnostics.

### Verification

- Confirmed on hardware with a G305 LIGHTSPEED: the gaming-surface and LightForce cards (and lift-off, already absent) are now hidden, while DPI, polling rate, and battery read and write correctly.
- `npm run check` (build + 197 tests) passes.
