### PR TITLE
feat(razer): Add support for the base Razer Viper

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -85,6 +85,7 @@ import { PulsarProHidClient } from "./devices/pulsar/pulsar-pro-hid";
 import { OrbitalHidClient } from "./devices/orbital/hid";
 import { RazerHidClient } from "./devices/razer/hid";
 import { RazerViperMiniHidClient } from "./devices/razer/viper-mini-hid";
+import { RazerViperHidClient } from "./devices/razer/viper-hid"
 import { RazerViperV4ProHidClient } from "./devices/razer/viper-v4-pro-hid";
 import { FinalmouseHidClient } from "./devices/finalmouse/hid";
 import { TeevolutionHidClient } from "./devices/teevolution/hid";
@@ -116,7 +117,7 @@ let activeEggClient: EggOp1HidClient | null = null;
 let activeEggWeClient: EggWeHidClient | null = null;
 let activeDmClient: WLMouseHidClient | LamzuHidClient | AtkHidClient | null = null;
 let activeOrbitalClient: OrbitalHidClient | null = null;
-let activeRazerClient: RazerHidClient | RazerViperMiniHidClient | null = null;
+let activeRazerClient: RazerHidClient | RazerViperMiniHidClient | RazerViperHidClient | null = null;
 let activeTeevolutionClient: TeevolutionHidClient | null = null;
 let activeVgnClient: VgnF2HidClient | null = null;
 let activeViperClient: RazerViperV4ProHidClient | null = null;
@@ -1527,7 +1528,7 @@ async function activateClient(client: SupportedClient): Promise<void> {
     dpiOptions = client.getDpiOptions();
     configureDpiControl(status.dpi);
     showStatus(status);
-  } else if (client instanceof RazerHidClient || client instanceof RazerViperMiniHidClient) {
+  } else if (client instanceof RazerHidClient || client instanceof RazerViperMiniHidClient || client instanceof RazerViperHidClient) {
     activeRazerClient = client;
     const status = await client.readStatus();
     deviceStatuses.set(client.device, status);

--- a/src/devices/razer/viper-hid.test.ts
+++ b/src/devices/razer/viper-hid.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { RAZER_READ, encodeRazerRequest, razerSetDpiCommand, razerSetLegacyPollingCommand } from "./protocol.ts";
+import {
+  VIPER_DPI_READ,
+  VIPER_PRODUCT_ID,
+  VIPER_TRANSACTION_ID,
+  RazerViperHidClient,
+} from "./viper-hid.ts";
+
+test("Viper requests use the legacy 0xFF transaction id", () => {
+  const packet = encodeRazerRequest(RAZER_READ.firmware, VIPER_TRANSACTION_ID);
+
+  assert.equal(packet[1], 0xff);
+  assert.equal(packet[6], 0x00);
+  assert.equal(packet[7], 0x81);
+});
+
+test("Viper DPI read uses the no-store byte openrazer pairs with writes", () => {
+  const packet = encodeRazerRequest(VIPER_DPI_READ, VIPER_TRANSACTION_ID);
+
+  assert.equal(packet[6], 0x04);
+  assert.equal(packet[7], 0x85);
+  assert.equal(packet[8], 0x00);
+});
+
+test("Viper DPI write carries the storage byte and reads back through no-store", () => {
+  const write = encodeRazerRequest(razerSetDpiCommand(1600, 800), VIPER_TRANSACTION_ID);
+  const read = encodeRazerRequest(VIPER_DPI_READ, VIPER_TRANSACTION_ID);
+
+  assert.deepEqual([...write.slice(8, 15)], [0x01, 0x06, 0x40, 0x03, 0x20, 0x00, 0x00]);
+  assert.equal(read[8], 0x00);
+});
+
+test("Viper polling writes the legacy divisor of 1000", () => {
+  const packet = encodeRazerRequest(razerSetLegacyPollingCommand(500), VIPER_TRANSACTION_ID);
+
+  assert.equal(packet[1], 0xff);
+  assert.deepEqual([packet[6], packet[7], packet[8]], [0x00, 0x05, 2]);
+});
+
+test("Viper accepts only its own PID on a single Generic Desktop Mouse collection", () => {
+  const control = {
+    vendorId: 0x1532,
+    productId: VIPER_PRODUCT_ID,
+    collections: [{ usagePage: 0x01, usage: 0x02, featureReports: [], children: [] }],
+  } as unknown as HIDDevice;
+  const wrongPid = { ...control, productId: 0x00c0 } as unknown as HIDDevice;
+  const extraCollection = {
+    ...control,
+    collections: [
+      { usagePage: 0x01, usage: 0x02, featureReports: [], children: [] },
+      { usagePage: 0x01, usage: 0x06, featureReports: [], children: [] },
+    ],
+  } as unknown as HIDDevice;
+
+  assert.equal(RazerViperHidClient.isSupported(control), true);
+  assert.equal(RazerViperHidClient.isSupported(wrongPid), false);
+  assert.equal(RazerViperHidClient.isSupported(extraCollection), false);
+});

--- a/src/devices/razer/viper-hid.ts
+++ b/src/devices/razer/viper-hid.ts
@@ -1,0 +1,208 @@
+import type { MouseStatus } from "../mouse-types.ts";
+import { VENDOR_ID } from "../vendors.ts";
+import {
+  RAZER_READ,
+  RAZER_REPORT_ID,
+  RAZER_STATUS,
+  RazerProtocolError,
+  decodeDpi,
+  decodeFirmwareVersion,
+  decodeLegacyPollingRate,
+  decodeRazerResponse,
+  decodeSerial,
+  encodeRazerRequest,
+  razerSetDpiCommand,
+  razerSetLegacyPollingCommand,
+  type RazerCommand,
+} from "./protocol.ts";
+
+export const VIPER_PRODUCT_ID = 0x0078;
+
+/**
+ * Transaction id used by openrazer's legacy group (Viper / Viper Ultimate);
+ * kept separate from `0x1f`, verified on the newer Viper V3 Pro firmware.
+ */
+export const VIPER_TRANSACTION_ID = 0xff;
+
+// Openrazer reads DPI with the no-store byte and writes with the storage byte.
+export const VIPER_DPI_READ: RazerCommand = {
+  commandClass: 0x04,
+  commandId: 0x85,
+  dataSize: 0x07,
+  args: [0x00],
+};
+
+// Wired-only, so the legacy polling command (a divisor of 1000) covers every rate.
+const RATES_WIRED: readonly number[] = [125, 500, 1000];
+const DPI_MIN = 100;
+const DPI_MAX = 8500;
+const RESPONSE_DELAY_MS = 100;
+const RESPONSE_ATTEMPTS = 6;
+
+/**
+ * Razer exposes its control channel on the interface whose only collection is
+ * Generic Desktop Mouse. Every other interface either belongs to a different
+ * function or is a protected collection the browser will not talk to.
+ */
+function isControlInterface(device: HIDDevice): boolean {
+  const [collection, ...rest] = device.collections;
+  return rest.length === 0 && collection?.usagePage === 0x01 && collection?.usage === 0x02;
+}
+
+export class RazerViperHidClient {
+  private queue: Promise<unknown> = Promise.resolve();
+  private readonly staticReads = new Map<string, Promise<Uint8Array | null>>();
+
+  readonly device: HIDDevice;
+
+  constructor(device: HIDDevice) {
+    this.device = device;
+  }
+
+  static isSupported(device: HIDDevice): boolean {
+    return device.vendorId === VENDOR_ID.razer
+      && device.productId === VIPER_PRODUCT_ID
+      && isControlInterface(device);
+  }
+
+  async open(): Promise<void> {
+    // On Linux "Failed to open the device" means the hidraw node for 1532:0078
+    // is root-owned or the razermouse kernel driver claimed the interface.
+    // Fix: udev rule granting plugdev access to that vendor/product, then
+    // `sudo rmmod razermouse`.
+    if (!this.device.opened) await this.device.open();
+  }
+
+  async close(): Promise<void> {
+    this.staticReads.clear();
+    if (this.device.opened) await this.device.close();
+  }
+
+  displayName(): string {
+    return this.device.productName || "Razer Viper";
+  }
+
+  isWireless(): boolean {
+    return false;
+  }
+
+  maxDpi(): number {
+    return DPI_MAX;
+  }
+
+  getSupportedPollingRates(): number[] {
+    return [...RATES_WIRED];
+  }
+
+  /** Every whole value, because the control validates entries against this list. */
+  getDpiOptions(): number[] {
+    const options: number[] = [];
+    for (let dpi = DPI_MIN; dpi <= this.maxDpi(); dpi += 1) options.push(dpi);
+    return options;
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    await this.open();
+    const firmware = await this.once("firmware", () => this.request(RAZER_READ.firmware));
+    if (!firmware) throw new Error("The mouse did not report a firmware version.");
+    const serial = await this.once("serial", () => this.request(RAZER_READ.serial).catch(() => null));
+    const dpi = decodeDpi(await this.request(VIPER_DPI_READ));
+    const pollingRateHz = decodeLegacyPollingRate(await this.request(RAZER_READ.pollingRate));
+    return {
+      brand: "Razer",
+      name: this.displayName(),
+      ui: {
+        family: "razer",
+        settingsReady: true,
+        valuesVerified: true,
+        hideUnsupportedPollingRates: true,
+        // No lift-off or sensor-processing command is confirmed, so neither
+        // control is offered rather than offered and left inert.
+        hideProcessingCard: true,
+        defaultDisplayName: "Viper",
+      },
+      // Wired-only model: openrazer exposes no battery attribute, so neither
+      // the level nor the charging query is sent.
+      batteryPercent: null,
+      batteryState: "Unknown",
+      dpi: dpi.x,
+      dpiY: dpi.y,
+      supportsSeparateDpiAxes: true,
+      pollingRateHz,
+      supportedPollingRates: this.getSupportedPollingRates(),
+      activeProfile: null,
+      connectionType: "Wired",
+      connectionDetail: "Wired USB",
+      unitId: serial ? decodeSerial(serial) : null,
+      liftOffDistance: null,
+      supportedLiftOffDistances: [],
+      firmware: [`Mouse ${decodeFirmwareVersion(firmware)}`],
+    };
+  }
+
+  async setDpi(dpi: number, dpiY: number = dpi): Promise<number> {
+    const ceiling = this.maxDpi();
+    for (const value of [dpi, dpiY]) {
+      if (!Number.isInteger(value) || value < DPI_MIN || value > ceiling) {
+        throw new Error(`DPI must be a whole number between ${DPI_MIN} and ${ceiling.toLocaleString()}.`);
+      }
+    }
+    await this.request(razerSetDpiCommand(dpi, dpiY));
+    const confirmed = decodeDpi(await this.request(VIPER_DPI_READ));
+    if (confirmed.x !== dpi || confirmed.y !== dpiY) {
+      throw new Error(`The mouse kept ${confirmed.x.toLocaleString()} DPI instead of ${dpi.toLocaleString()}.`);
+    }
+    return confirmed.x;
+  }
+
+  async setPollingRate(pollingRateHz: number): Promise<number> {
+    if (!this.getSupportedPollingRates().includes(pollingRateHz)) {
+      throw new Error(`This mouse does not support ${pollingRateHz.toLocaleString()} Hz on this connection.`);
+    }
+    await this.request(razerSetLegacyPollingCommand(pollingRateHz));
+    const confirmed = decodeLegacyPollingRate(await this.request(RAZER_READ.pollingRate));
+    if (confirmed !== pollingRateHz) {
+      throw new Error(`The mouse kept ${confirmed.toLocaleString()} Hz instead of ${pollingRateHz.toLocaleString()} Hz.`);
+    }
+    return confirmed;
+  }
+
+  private once(key: string, read: () => Promise<Uint8Array | null>): Promise<Uint8Array | null> {
+    const pending = this.staticReads.get(key);
+    if (pending) return pending;
+    const started = read();
+    this.staticReads.set(key, started);
+    started.catch(() => this.staticReads.delete(key));
+    return started;
+  }
+
+  private async request(command: RazerCommand): Promise<Uint8Array> {
+    const run = this.queue.then(() => this.exchange(command), () => this.exchange(command));
+    this.queue = run.catch(() => undefined);
+    return await run;
+  }
+
+  private async exchange(command: RazerCommand): Promise<Uint8Array> {
+    await this.open();
+    await this.device.sendFeatureReport(RAZER_REPORT_ID, encodeRazerRequest(command, VIPER_TRANSACTION_ID));
+    for (let attempt = 0; attempt < RESPONSE_ATTEMPTS; attempt += 1) {
+      await this.delay(RESPONSE_DELAY_MS);
+      const reply = this.copyDataView(await this.device.receiveFeatureReport(RAZER_REPORT_ID));
+      try {
+        return decodeRazerResponse(reply, command);
+      } catch (error) {
+        if (error instanceof RazerProtocolError && error.status === RAZER_STATUS.busy) continue;
+        throw error;
+      }
+    }
+    throw new Error("The mouse stayed busy — it may be asleep or out of range.");
+  }
+
+  private copyDataView(view: DataView): Uint8Array {
+    return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+  }
+
+  private delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+  }
+}

--- a/src/devices/registry.ts
+++ b/src/devices/registry.ts
@@ -8,6 +8,7 @@ import { OrbitalHidClient } from "./orbital/hid.ts";
 import { PulsarHidClient } from "./pulsar/pulsar-hid.ts";
 import { PulsarProHidClient } from "./pulsar/pulsar-pro-hid.ts";
 import { RazerHidClient } from "./razer/hid.ts";
+import { RazerViperHidClient } from "./razer/viper-hid.ts";
 import { RazerViperMiniHidClient } from "./razer/viper-mini-hid.ts";
 import { RazerViperV4ProHidClient } from "./razer/viper-v4-pro-hid.ts";
 import { TeevolutionHidClient } from "./teevolution/hid.ts";
@@ -15,7 +16,7 @@ import { VgnF2HidClient } from "./vgn/hid.ts";
 import { WLMouseHidClient } from "./wlmouse/hid.ts";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | TeevolutionHidClient | AtkHidClient | VgnF2HidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | TeevolutionHidClient | AtkHidClient | VgnF2HidClient;
 
 export interface DeviceDriver {
   brand: string;
@@ -38,6 +39,7 @@ export const DEVICE_DRIVERS: readonly DeviceDriver[] = [
   { brand: "Orbital", supports: (device) => OrbitalHidClient.isSupported(device), create: (device) => new OrbitalHidClient(device), score: () => 6 },
   { brand: "Razer", supports: (device) => RazerHidClient.isSupported(device), create: (device) => new RazerHidClient(device), score: () => 6 },
   { brand: "Razer", supports: (device) => RazerViperMiniHidClient.isSupported(device), create: (device) => new RazerViperMiniHidClient(device), score: () => 6 },
+  { brand: "Razer", supports: (device) => RazerViperHidClient.isSupported(device), create: (device) => new RazerViperHidClient(device), score: () => 6 },
   { brand: "ATK", supports: (device) => AtkHidClient.isSupported(device), create: (device) => new AtkHidClient(device), score: () => 5 },
   { brand: "Razer", supports: (device) => RazerViperV4ProHidClient.isSupported(device), create: (device) => new RazerViperV4ProHidClient(device), score: () => 7 },
 ];

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -33,6 +33,12 @@ export const RAZER_VIPER_MINI_CONTROL_FILTERS: HIDDeviceFilter[] = [0x008a].map(
   (productId) => ({ vendorId: VENDOR_ID.razer, productId, usagePage: 0x01, usage: 0x02 }),
 );
 
+// The original Viper exposes the same single Generic Desktop Mouse control
+// interface, so it gets the same narrow collection filter.
+export const RAZER_VIPER_CONTROL_FILTERS: HIDDeviceFilter[] = [0x0078].map(
+  (productId) => ({ vendorId: VENDOR_ID.razer, productId, usagePage: 0x01, usage: 0x02 }),
+);
+
 // Synapse Web exposes the V4 control interface through a single top-level
 // Generic Desktop or Consumer collection with Feature reports. Request both
 // pages so the browser offers that interface, then the driver rejects ordinary
@@ -121,6 +127,7 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   ...RAZER_VIPER_V2_CONTROL_FILTERS,
   ...RAZER_VIPER_V3_CONTROL_FILTERS,
   ...RAZER_VIPER_MINI_CONTROL_FILTERS,
+  ...RAZER_VIPER_CONTROL_FILTERS,
   { vendorId: VENDOR_ID.vgn, productId: 0xfb56 },
   { vendorId: VENDOR_ID.vgn, productId: 0xfb57 },
   { vendorId: VENDOR_ID.atk, usagePage: 0xff02, usage: 2 },


### PR DESCRIPTION
Currently only DPI can be changed, more settings like lighting need to be added.
The base Viper was pretty much identical to the Viper Mini so its code is just the Mini's code but with the Viper's PID.

## Bugs:
* DPI Light on the bottom doesn't change when the DPI changes, though changing the DPI from the mouse updates the website.

Test Results
```
ℹ tests 202
ℹ suites 0
ℹ pass 202
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 3038.1474
```

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/70653566-fb16-4d9c-841f-746396dd571e" />
