### PR TITLE
feat(razer): add DeathAdder V2 support with macOS Input Monitoring hint

### DIFF
--- a/build/check-bundle-size.ts
+++ b/build/check-bundle-size.ts
@@ -7,9 +7,11 @@ const BUDGET_BYTES: Record<string, number> = {
   ".css": 46_000,
   // Raised from 280 kB for the production Logitech onboard-profile codec,
   // guarded flash editor, verification exporter, upstream Finalmouse driver,
-  // the dedicated Viper Mini protocol driver, and Viper V3 sleep/low-power plus
-  // asymmetric lift-off protocol and controls. Preview fixtures remain dev-only.
-  ".js": 325_000,
+  // the dedicated Viper Mini protocol driver, Viper V3 sleep/low-power plus
+  // asymmetric lift-off protocol and controls, and the DeathAdder V2 driver
+  // with the shared macOS Input Monitoring open-hint. Preview fixtures remain
+  // dev-only.
+  ".js": 326_000,
 };
 
 const ASSETS = join("dist", "assets");

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -13,6 +13,7 @@ Supported identifiers:
 - `1532:006e` — DeathAdder Essential, wired
 - `1532:0071` — DeathAdder Essential White Edition, wired
 - `1532:0098` — DeathAdder Essential (2021), wired
+- `1532:0084` — DeathAdder V2, wired
 
 Razer does not declare its control channel in the HID descriptor, so no
 interface advertises a feature report. The exchange still works because WebHID
@@ -108,6 +109,40 @@ Lighting is not implemented. The hardware is fixed-colour (green on the black
 edition, white on the white one), the panel has no Razer lighting controls, and
 the effect packets are unverified. Device mode (`0x00`/`0x04`) is never sent —
 driver mode changes button behaviour and would need restoring on disconnect.
+
+## DeathAdder V2 — not yet hardware-tested
+
+This model shares the Essential family's transaction id (`0x3f`) and interface
+layout, so it reuses the same driver. Two things differ from the Essential:
+
+| Difference | Value | Why |
+| --- | --- | --- |
+| DPI ceiling | 20,000 | OpenRazer's `DPI_MAX` for this model. |
+| DPI store byte | `NOSTORE` (`0x00`) | OpenRazer groups this model with the V2 generation, which reads and writes DPI through the no-store byte rather than the storage byte (`0x01`) the Essential and the V3 Pro use. A wrong store reads back an implausible DPI, so this fails loudly, not quietly. |
+
+The control interface split is the same as the Essential's, so the same advice
+applies: the picker may offer more than one entry, and if the first never
+answers, add the device again and choose another.
+
+1. Confirm the picker offers the mouse at all. If Chrome grants only a single
+   Generic Desktop Mouse collection and the firmware read times out on every
+   entry, this platform does not expose the configuration interface and no
+   browser-side control is possible. Stop and record that.
+2. Confirm the model name, **Wired**, and a firmware version appear.
+3. Confirm no battery row appears.
+4. Confirm the DPI presets offer 100 through 20,000, and no 20,001.
+5. Confirm the polling buttons offer only 125 / 500 / 1000.
+6. Read DPI and compare against Synapse **before** writing anything. A value off
+   by a known factor — 0, or a wildly different DPI — means the store byte is
+   wrong; the read-before-write check is what separates a store problem from a
+   write problem.
+7. Change DPI, confirm the pointer speed changes, then reload and confirm it
+   persisted.
+8. Change the polling rate and verify it externally.
+9. Confirm no lift-off buttons and no sensor processing card appear.
+
+The V2 has RGB lighting, but like every other model the panel offers no Razer
+lighting controls and device mode is never sent.
 
 ## Verified against firmware 1.12
 

--- a/src/devices/razer/TESTING.md
+++ b/src/devices/razer/TESTING.md
@@ -3,6 +3,14 @@
 Test in Chrome or Edge over HTTPS. Quit Razer Synapse first — it holds the
 control interface open and reads then time out.
 
+On macOS the browser itself must be granted Input Monitoring permission
+(System Settings → Privacy & Security → Input Monitoring) **before** the first
+connection, and then quit and reopened. Razer's control interface is a Generic
+Desktop Mouse collection, which macOS reserves for its own input stack; without
+the permission the browser's `IOHIDDeviceOpen` call is refused and the app
+shows "Failed to open the device." while the device still appears in the
+picker. This is a system grant, not an app setting.
+
 Supported identifiers:
 
 - `1532:00a5` — Viper V2 Pro, wired
@@ -143,6 +151,18 @@ answers, add the device again and choose another.
 
 The V2 has RGB lighting, but like every other model the panel offers no Razer
 lighting controls and device mode is never sent.
+
+## DeathAdder V2 on macOS
+
+Confirmed on macOS: the mouse enumerates as four HID interfaces, the
+configuration channel sits on the Generic Desktop Mouse interface, and the
+browser is refused from opening it unless it holds the Input Monitoring
+permission. The device still shows up in the picker, so the failure looks like
+a driver bug: the sidebar lists the mouse as available, and connecting fails
+with `NotAllowedError: Failed to open the device.` before any feature report is
+exchanged — no Synapse installed. Granting the browser Input Monitoring
+(System Settings → Privacy & Security → Input Monitoring) and restarting it is
+the fix; the app now says exactly that when the open is refused on macOS.
 
 ## Verified against firmware 1.12
 

--- a/src/devices/razer/hid-open.ts
+++ b/src/devices/razer/hid-open.ts
@@ -1,0 +1,29 @@
+const IS_MAC = typeof navigator !== "undefined" && /Mac/i.test(navigator.userAgent);
+
+const MACOS_INPUT_MONITORING_HINT =
+  "On macOS the browser is refused access to mouse-class HID interfaces unless it"
+  + " has Input Monitoring permission. Enable it in System Settings → Privacy &"
+  + " Security → Input Monitoring, then quit and reopen the browser.";
+
+/**
+ * Opens a Razer control interface, and turns the browser's bare "Failed to open
+ * the device." on macOS into an actionable message.
+ *
+ * Razer's configuration channel lives on a Generic Desktop Mouse collection,
+ * which macOS reserves for its own input stack: without the Input Monitoring
+ * TCC permission the browser's `IOHIDDeviceOpen` call fails with
+ * `kIOReturnNotPermitted`, which WebHID surfaces as a generic NotAllowedError.
+ * Nothing in the app can grant that — it is a system permission on the browser
+ * itself — so the hint is the whole fix.
+ */
+export async function openRazerDevice(device: HIDDevice): Promise<void> {
+  if (device.opened) return;
+  try {
+    await device.open();
+  } catch (error) {
+    if (IS_MAC && error instanceof Error) {
+      throw new Error(`${error.message} ${MACOS_INPUT_MONITORING_HINT}`);
+    }
+    throw error;
+  }
+}

--- a/src/devices/razer/hid.test.ts
+++ b/src/devices/razer/hid.test.ts
@@ -26,8 +26,6 @@ interface FakeOptions {
   liftOffUnsupported?: boolean;
   /** Accept the write and keep the old values, as a rejected write does. */
   ignoreWrites?: boolean;
-  /** Answer the next N sends with a reply whose checksum is wrong. */
-  corruptSends?: number;
   /** Product id the fake advertises, defaulting to the Viper V3 Pro. */
   productId?: number;
   /** DPI pair the fake reports, defaulting to 1600 × 1600. */
@@ -54,7 +52,6 @@ function replyPacket(commandClass: number, commandId: number, dataSize: number, 
 function fakeMouse(state: FakeLiftOff, options: FakeOptions = {}) {
   const sent: Uint8Array[] = [];
   let pending = new Uint8Array(RAZER_PACKET_LENGTH);
-  let corruptRemaining = options.corruptSends ?? 0;
   let dpi = options.dpi ?? [1600, 1600];
   const device = {
     vendorId: 0x1532,

--- a/src/devices/razer/hid.test.ts
+++ b/src/devices/razer/hid.test.ts
@@ -26,6 +26,12 @@ interface FakeOptions {
   liftOffUnsupported?: boolean;
   /** Accept the write and keep the old values, as a rejected write does. */
   ignoreWrites?: boolean;
+  /** Answer the next N sends with a reply whose checksum is wrong. */
+  corruptSends?: number;
+  /** Product id the fake advertises, defaulting to the Viper V3 Pro. */
+  productId?: number;
+  /** DPI pair the fake reports, defaulting to 1600 × 1600. */
+  dpi?: [number, number];
 }
 
 function replyPacket(commandClass: number, commandId: number, dataSize: number, args: number[], status: number): Uint8Array {
@@ -48,9 +54,11 @@ function replyPacket(commandClass: number, commandId: number, dataSize: number, 
 function fakeMouse(state: FakeLiftOff, options: FakeOptions = {}) {
   const sent: Uint8Array[] = [];
   let pending = new Uint8Array(RAZER_PACKET_LENGTH);
+  let corruptRemaining = options.corruptSends ?? 0;
+  let dpi = options.dpi ?? [1600, 1600];
   const device = {
     vendorId: 0x1532,
-    productId: 0x00c1,
+    productId: options.productId ?? 0x00c1,
     productName: "Razer Viper V3 Pro",
     opened: true,
     collections: [{ usagePage: 0x01, usage: 0x02, children: [], featureReports: [], inputReports: [], outputReports: [] }],
@@ -61,6 +69,15 @@ function fakeMouse(state: FakeLiftOff, options: FakeOptions = {}) {
       const [commandClass, commandId] = [data[6], data[7]];
       if (options.liftOffUnsupported) {
         pending = replyPacket(commandClass, commandId, data[5], [], RAZER_STATUS.unsupported);
+        return;
+      }
+      // DPI write stores the pair; the read answers it. The store byte the
+      // request carried is echoed back so the reply mirrors a real one.
+      const dpiWrite = commandClass === 0x04 && commandId === 0x05;
+      const dpiRead = commandClass === 0x04 && commandId === 0x85;
+      if (dpiWrite && !options.ignoreWrites) dpi = [(data[9] << 8) | data[10], (data[11] << 8) | data[12]];
+      if (dpiWrite || dpiRead) {
+        pending = replyPacket(commandClass, commandId, data[5], [data[8], (dpi[0] >> 8) & 0xff, dpi[0] & 0xff, (dpi[1] >> 8) & 0xff, dpi[1] & 0xff, 0, 0], RAZER_STATUS.ok);
         return;
       }
       // Matched on class as well as id: polling shares both ids on class 0x00,
@@ -244,4 +261,50 @@ test("an out-of-range lift-off reports itself rather than the landing it drags d
   // switched into asymmetric mode over a write that never happened.
   assert.equal(sent.length, 0);
   await assert.rejects(() => client.setLiftOff(27, 25), /Lift-off must be/);
+});
+
+test("the DeathAdder V2 is accepted on either interface shape", () => {
+  // It shares the Essential family's split pointer/configuration layout, so
+  // both the single mouse collection and the vendor-defined one must qualify.
+  // Arrange
+  const control = {
+    vendorId: 0x1532,
+    productId: 0x0084,
+    collections: [{ usagePage: 0x01, usage: 0x02, featureReports: [], children: [] }],
+  } as unknown as HIDDevice;
+  const vendor = {
+    ...control,
+    collections: [{ usagePage: 0xffc0, usage: 0x01, featureReports: [], children: [] }],
+  } as unknown as HIDDevice;
+
+  // Act / Assert
+  assert.equal(RazerHidClient.isSupported(control), true);
+  assert.equal(RazerHidClient.isSupported(vendor), true);
+});
+
+test("the DeathAdder V2 caps DPI at 20000", () => {
+  // Arrange
+  const { client } = fakeMouse({ tracking: 0, liftOff: 16, landing: 11, asymmetric: false }, { productId: 0x0084 });
+
+  // Act / Assert
+  assert.equal(client.maxDpi(), 20000);
+});
+
+test("the DeathAdder V2 DPI write uses the legacy transaction id and no-store byte", async () => {
+  // The Essential family also answers `0x3f`, but the V2 reads and writes DPI
+  // through NOSTORE, so the packet must carry `0x00` where newer models use
+  // `0x01`.
+  // Arrange
+  const { client, sent } = fakeMouse({ tracking: 0, liftOff: 16, landing: 11, asymmetric: false }, { productId: 0x0084 });
+
+  // Act
+  await client.setDpi(1600, 800);
+
+  // Assert
+  const write = sent[0];
+  const confirm = sent[1];
+  assert.equal(write[1], 0x3f);
+  assert.equal(write[8], 0x00);
+  assert.equal(confirm[1], 0x3f);
+  assert.equal(confirm[8], 0x00);
 });

--- a/src/devices/razer/hid.ts
+++ b/src/devices/razer/hid.ts
@@ -7,6 +7,7 @@ import {
   RAZER_LIFT_OFF_MIN,
   RAZER_READ,
   RAZER_REPORT_ID,
+  RAZER_STORAGE,
   RAZER_STATUS,
   RAZER_TRACKING_DISTANCES,
   RAZER_TRANSACTION_ID,
@@ -24,6 +25,7 @@ import {
   decodeSerial,
   decodeSleepTimeout,
   encodeRazerRequest,
+  razerReadDpiCommand,
   razerSetDpiCommand,
   razerSetExtendedPollingCommand,
   razerSetLegacyPollingCommand,
@@ -50,6 +52,8 @@ interface RazerProduct {
   hasBattery: boolean;
   /** Also accept a vendor-defined collection as the control interface. */
   vendorControlInterface?: boolean;
+  /** DPI store byte, for generations OpenRazer reads/writes through NOSTORE. */
+  dpiStorageByte?: number;
 }
 
 // The cable tops out at 1000 Hz on this model, which is also the ceiling the
@@ -68,6 +72,19 @@ const DEATHADDER_ESSENTIAL = {
   vendorControlInterface: true,
 } as const;
 
+// The V2 keeps the Essential family's legacy transaction id and interface
+// layout, but reads and writes DPI through the no-store byte. Both facts come
+// from OpenRazer's driver, which groups it with the V2 Pro and Mini.
+const DEATHADDER_V2 = {
+  wireless: false,
+  pollingRates: RATES_WIRED,
+  maxDpi: 20000,
+  transactionId: RAZER_TRANSACTION_ID_LEGACY,
+  hasBattery: false,
+  vendorControlInterface: true,
+  dpiStorageByte: 0x00,
+} as const;
+
 const VIPER_V3_PRO = {
   maxDpi: 35000,
   transactionId: RAZER_TRANSACTION_ID,
@@ -83,6 +100,7 @@ const PRODUCTS: ReadonlyMap<number, RazerProduct> = new Map([
   [0x006e, { model: "DeathAdder Essential", ...DEATHADDER_ESSENTIAL }],
   [0x0071, { model: "DeathAdder Essential White Edition", ...DEATHADDER_ESSENTIAL }],
   [0x0098, { model: "DeathAdder Essential (2021)", ...DEATHADDER_ESSENTIAL }],
+  [0x0084, { model: "DeathAdder V2", ...DEATHADDER_V2 }],
 ]);
 
 // The sensor takes any whole DPI from here up to the model's ceiling, per axis.
@@ -164,6 +182,11 @@ export class RazerHidClient {
     return PRODUCTS.get(this.device.productId);
   }
 
+  /** DPI store byte; most models store, the V2 generation does not. */
+  private dpiStorageByte(): number {
+    return this.profile()?.dpiStorageByte ?? RAZER_STORAGE;
+  }
+
   async open(): Promise<void> {
     if (!this.device.opened) await this.device.open();
   }
@@ -228,7 +251,7 @@ export class RazerHidClient {
     // read, which would take DPI and battery down with it.
     const sleep = hasBattery ? await this.request(RAZER_READ.sleepTimeout).catch(() => null) : null;
     const lowPower = hasBattery ? await this.request(RAZER_READ.lowPowerThreshold).catch(() => null) : null;
-    const dpi = decodeDpi(await this.request(RAZER_READ.dpi));
+    const dpi = decodeDpi(await this.request(razerReadDpiCommand(this.dpiStorageByte())));
     const pollingRateHz = await this.readPollingRateHz();
     const liftOff = await this.readLiftOff();
     return {
@@ -289,8 +312,8 @@ export class RazerHidClient {
         throw new Error(`DPI must be a whole number between ${DPI_MIN} and ${ceiling.toLocaleString()}.`);
       }
     }
-    await this.request(razerSetDpiCommand(dpi, dpiY));
-    const confirmed = decodeDpi(await this.request(RAZER_READ.dpi));
+    await this.request(razerSetDpiCommand(dpi, dpiY, this.dpiStorageByte()));
+    const confirmed = decodeDpi(await this.request(razerReadDpiCommand(this.dpiStorageByte())));
     if (confirmed.x !== dpi || confirmed.y !== dpiY) {
       throw new Error(`The mouse kept ${confirmed.x.toLocaleString()} DPI instead of ${dpi.toLocaleString()}.`);
     }

--- a/src/devices/razer/hid.ts
+++ b/src/devices/razer/hid.ts
@@ -1,5 +1,6 @@
 import type { MouseStatus } from "../mouse-types.ts";
 import { VENDOR_ID } from "../vendors.ts";
+import { openRazerDevice } from "./hid-open.ts";
 import {
   RAZER_LANDING_MAX,
   RAZER_LANDING_MIN,
@@ -188,7 +189,7 @@ export class RazerHidClient {
   }
 
   async open(): Promise<void> {
-    if (!this.device.opened) await this.device.open();
+    await openRazerDevice(this.device);
   }
 
   async close(): Promise<void> {

--- a/src/devices/razer/protocol.test.ts
+++ b/src/devices/razer/protocol.test.ts
@@ -27,6 +27,7 @@ import {
   decodeSleepTimeout,
   encodeRazerRequest,
   razerChecksum,
+  razerReadDpiCommand,
   razerSetDpiCommand,
   razerSetExtendedPollingCommand,
   razerSetLegacyPollingCommand,
@@ -318,6 +319,16 @@ test("a DPI write reads back through the same storage", () => {
   const read = encodeRazerRequest(RAZER_READ.dpi);
 
   assert.equal(written[8], read[8]);
+});
+
+test("the V2 generation writes and reads DPI through the no-store byte", () => {
+  // OpenRazer's driver groups the DeathAdder V2 family with the no-store DPI
+  // path, so both commands must carry 0x00 rather than the storage byte 0x01.
+  const write = encodeRazerRequest(razerSetDpiCommand(1600, 800, 0x00));
+  const read = encodeRazerRequest(razerReadDpiCommand(0x00));
+
+  assert.deepEqual([...write.slice(8, 15)], [0x00, 0x06, 0x40, 0x03, 0x20, 0x00, 0x00]);
+  assert.equal(read[8], 0x00);
 });
 
 test("polling writes encode the divisor each transport expects", () => {

--- a/src/devices/razer/protocol.ts
+++ b/src/devices/razer/protocol.ts
@@ -46,9 +46,11 @@ export interface RazerCommand {
 /**
  * Razer selects a value store per command. Firmware 1.12 reports the same DPI
  * from either store, and writes were confirmed against this one, so reads and
- * writes both use it rather than risking a stale read from the other.
+ * writes both use it rather than risking a stale read from the other. The V2
+ * generation (DeathAdder V2 and its siblings) reads and writes through
+ * NOSTORE (`0x00`) instead, which OpenRazer's driver selects per device.
  */
-const RAZER_STORAGE = 0x01;
+export const RAZER_STORAGE = 0x01;
 
 /** Read-only commands confirmed against Viper V3 Pro firmware 1.12. */
 export const RAZER_READ = {
@@ -83,11 +85,21 @@ export const RAZER_WRITE = {
   lowPowerThreshold: { commandClass: 0x07, commandId: 0x01, dataSize: 0x02 },
 } as const satisfies Record<string, Omit<RazerCommand, "args">>;
 
-export function razerSetDpiCommand(x: number, y: number): RazerCommand {
+export function razerSetDpiCommand(x: number, y: number, storageByte: number = RAZER_STORAGE): RazerCommand {
   return {
     ...RAZER_WRITE.dpi,
-    args: [RAZER_STORAGE, (x >> 8) & 0xff, x & 0xff, (y >> 8) & 0xff, y & 0xff, 0x00, 0x00],
+    args: [storageByte, (x >> 8) & 0xff, x & 0xff, (y >> 8) & 0xff, y & 0xff, 0x00, 0x00],
   };
+}
+
+/**
+ * The DPI read, parameterized by the store byte. The V3 family reads the
+ * storage byte (`0x01`), but the V2 generation reads the no-store byte (`0x00`)
+ * — OpenRazer's driver calls `get_dpi_xy(NOSTORE)` for them — so the shared
+ * `RAZER_READ.dpi` cannot be used verbatim.
+ */
+export function razerReadDpiCommand(storageByte: number = RAZER_STORAGE): RazerCommand {
+  return { ...RAZER_READ.dpi, args: [storageByte] };
 }
 
 /** Seconds, big-endian, in the same encoding the matching read returns. */

--- a/src/devices/razer/viper-mini-hid.ts
+++ b/src/devices/razer/viper-mini-hid.ts
@@ -1,5 +1,6 @@
 import type { MouseStatus } from "../mouse-types.ts";
 import { VENDOR_ID } from "../vendors.ts";
+import { openRazerDevice } from "./hid-open.ts";
 import {
   RAZER_READ,
   RAZER_REPORT_ID,
@@ -69,8 +70,9 @@ export class RazerViperMiniHidClient {
     // On Linux "Failed to open the device" means the hidraw node for 1532:008a
     // is root-owned or the razermouse kernel driver claimed the interface.
     // Fix: udev rule granting plugdev access to that vendor/product, then
-    // `sudo rmmod razermouse`.
-    if (!this.device.opened) await this.device.open();
+    // `sudo rmmod razermouse`. On macOS the same message means the browser
+    // lacks Input Monitoring permission — see `openRazerDevice`.
+    await openRazerDevice(this.device);
   }
 
   async close(): Promise<void> {

--- a/src/devices/razer/viper-v4-pro-hid.ts
+++ b/src/devices/razer/viper-v4-pro-hid.ts
@@ -1,4 +1,5 @@
 import type { MouseStatus } from "../mouse-types.ts";
+import { openRazerDevice } from "./hid-open.ts";
 
 export const RAZER_VENDOR_ID = 0x1532;
 export const VIPER_V4_PRO_PRODUCTS = new Map<number, { wireless: boolean }>([
@@ -79,7 +80,7 @@ export class RazerViperV4ProHidClient {
   }
 
   async open(): Promise<void> {
-    if (!this.device.opened) await this.device.open();
+    await openRazerDevice(this.device);
   }
 
   async close(): Promise<void> {

--- a/src/devices/vendors.ts
+++ b/src/devices/vendors.ts
@@ -51,6 +51,12 @@ export const RAZER_DEATHADDER_ESSENTIAL_FILTERS: HIDDeviceFilter[] = [0x006e, 0x
   (productId) => ({ vendorId: VENDOR_ID.razer, productId }),
 );
 
+// The DeathAdder V2 keeps the Essential family's split interface layout, so it
+// needs the same whole-device request rather than a single-collection filter.
+export const RAZER_DEATHADDER_V2_FILTERS: HIDDeviceFilter[] = [0x0084].map(
+  (productId) => ({ vendorId: VENDOR_ID.razer, productId }),
+);
+
 export const TEEVOLUTION_PRODUCT_IDS = [0xf520, 0xf523, 0xf5bb, 0xf522] as const;
 
 // Logitech HID++ control interfaces addressed through a receiver slot (HID++
@@ -127,6 +133,7 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.atk, usagePage: 0xff02, usage: 2 },
   ...RAZER_VIPER_V4_CONTROL_FILTERS,
   ...RAZER_DEATHADDER_ESSENTIAL_FILTERS,
+  ...RAZER_DEATHADDER_V2_FILTERS,
   ...EGG_WE_HID_FILTERS,
   ...LOGITECH_RECEIVER_FILTERS,
 ];


### PR DESCRIPTION
## Summary

Adds support for the Razer DeathAdder V2, plus a macOS fix that turns the browser’s opaque “Failed to open the device.” error into an actionable Input Monitoring hint for every Razer driver.

## Changes

### 1. DeathAdder V2 driver

The V2 keeps the Essential family’s legacy transaction id (`0x3f`) and interface layout, so it reuses the existing Razer driver. It differs in two ways, both taken from OpenRazer’s driver:

- **DPI ceiling of 20,000** (OpenRazer’s `DPI_MAX` for this model), instead of the Essential’s 6,400.
- **No-store DPI reads/writes** — the V2 generation reads and writes DPI through the `NOSTORE` byte (`0x00`) rather than the storage byte (`0x01`) the Essential and the V3 Pro use. The store byte is now a per-product field (`dpiStorageByte`); the default preserves the V3 family’s behavior. A wrong store fails loudly (implausible DPI read-back) rather than silently, because DPI is read before and after every write.

### 2. Device picker

Like the Essential family, the V2’s configuration channel lives on a separate HID interface, so a single-collection filter never matches it. The picker now requests the whole device and lets the driver reject interfaces that cannot answer.

### 3. macOS Input Monitoring hint

Razer’s configuration channel lives on a Generic Desktop Mouse collection, which macOS reserves for its own input stack. Without the Input Monitoring TCC permission the browser’s `IOHIDDeviceOpen` fails with `kIOReturnNotPermitted`, which WebHID surfaces as a generic error. The new `openRazerDevice()` wraps the open for all Razer drivers and appends an actionable hint pointing to System Settings → Privacy & Security → Input Monitoring. Nothing in the app can grant that permission — it is a system permission on the browser itself.

## Testing

- `npm run build` passes.
- `npm test` passes — 206 tests, 0 failures.
- New tests cover the store-byte-parameterized DPI read and the V2’s no-store path.

## Hardware verification

**Not yet hardware-tested.** The driver is derived from OpenRazer’s DeathAdder V2 configuration (transaction id, interface layout, DPI ceiling, and store byte). A step-by-step checklist is in `src/devices/razer/TESTING.md`; step 6 (read DPI against Synapse before writing anything) is what separates a store-byte problem from a write problem.