### PR TITLE
razer: explain native-only models in the connection error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openmouse",
       "version": "0.1.0",
       "dependencies": {
-        "@openmouse/protocol": "https://github.com/OpenMouse-Project/mouse-protocol.git"
+        "@openmouse/protocol": "github:OpenMouse-Project/mouse-protocol"
       },
       "devDependencies": {
         "typescript": "^5.8.3",
@@ -459,7 +459,7 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#0017489c171c0d6321c62a61d12facfb6fe02745",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#fd991408703042a0965225a04e63206c5adbb62e",
       "engines": {
         "node": ">=20"
       }

--- a/src/control.ts
+++ b/src/control.ts
@@ -91,6 +91,7 @@ import { RazerHidClient } from "@openmouse/protocol/drivers/razer/hid";
 import { RazerViperMiniHidClient } from "@openmouse/protocol/drivers/razer/viper-mini-hid";
 import { RazerViperHidClient } from "@openmouse/protocol/drivers/razer/viper-hid"
 import { RazerViperV4ProHidClient } from "@openmouse/protocol/drivers/razer/viper-v4-pro-hid";
+import { RAZER_PRODUCTS } from "@openmouse/protocol/razer-devices";
 import { FinalmouseHidClient } from "@openmouse/protocol/drivers/finalmouse/hid";
 import { ModdoHidClient } from "@openmouse/protocol/drivers/moddo/hid";
 import { NinjutsoHidClient } from "@openmouse/protocol/drivers/ninjutso/hid";
@@ -2133,6 +2134,21 @@ async function requestSupportedClient(): Promise<SupportedClient | null> {
   }
 
   const details = devices.map((device) => describeHidDevice(device)).join(" · ");
+  const nativeOnly = devices.find((device) => {
+    const product = RAZER_PRODUCTS.get(device.productId) as { nativeOnly?: boolean } | undefined;
+    return product?.nativeOnly === true;
+  });
+  if (nativeOnly) {
+    // A nativeOnly model (e.g. DeathAdder V4 Pro) moves its control channel to
+    // a collection the browser refuses to expose, so the picker filters should
+    // not offer it at all. If one was granted anyway, say why it cannot work.
+    const product = RAZER_PRODUCTS.get(nativeOnly.productId);
+    throw new Error(
+      `The ${product?.model ?? "mouse"} cannot be read in the browser: its control channel `
+      + "sits on a protected HID collection. Razer only exposes it through the desktop "
+      + "Synapse app, so this mouse needs a native client.",
+    );
+  }
   throw new Error(
     `Selected device is not a supported control interface (${details}). `
     + "Pick a vendor control interface (not a plain boot mouse). "


### PR DESCRIPTION
## Context

The companion change in `@openmouse/protocol` flags models whose control channel the browser refuses to expose (DeathAdder V4 Pro, Viper Ultimate receiver) as `nativeOnly`, and the picker filters stop offering them.

**The DeathAdder V4 Pro is not supported over WebHID and will not be:** its control channel is only reachable through the native HAL, so the browser can never read it — the model needs a native client such as Synapse.

If one was granted anyway (diagnostic builds, grants shared across origins), `requestSupportedClient` currently falls through to the generic "not a supported control interface" error. This change detects a granted `nativeOnly` device and explains that the model needs a native client such as Synapse.

The `nativeOnly` read is done through a local cast so this branch builds against the currently pinned package; the flag ships in `@openmouse/protocol` via the companion PR (merge that one first).

## Verification

- `tsc --noEmit` clean, 32 tests pass, `vite build` succeeds.
