### PR TITLE
build: refresh protocol lock after merged drivers

### DIFF
--- a/build/check-bundle-size.ts
+++ b/build/check-bundle-size.ts
@@ -31,7 +31,9 @@ const BUDGET_BYTES: Record<string, number> = {
   // Protocol tests and preview fixtures remain unbundled.
   // Raised from 435 kB for Mouse Check's HID inventory UI and reuse of the
   // protocol package's validated Razer request/response codec.
-  ".js": 444_000,
+  // Raised from 444 kB after refreshing the protocol lock for Mouse Dock Pro,
+  // the Nape Pro codec tests/limits, and hardware-verified Razer corrections.
+  ".js": 446_000,
 };
 
 const ASSETS = join("dist", "assets");

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,7 +459,7 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#88cd1cb25cafa3a041530e2423dfe1d82af4c000",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#6a0a1074c1acfd13e94d9bdcaed4ad4218c972dd",
       "engines": {
         "node": ">=20"
       }


### PR DESCRIPTION
Refreshes the app lockfile to the final mouse-protocol/main commit after PRs #3, #4, and #5 merged. Also documents the resulting 1.0 kB JS bundle increase.

Validation: npm run check; npm run size.