### PR TITLE
Enable driver previews on the deployed insiders app

### DIFF
--- a/build/check-bundle-size.ts
+++ b/build/check-bundle-size.ts
@@ -67,11 +67,18 @@ if (found.length === 0) {
   process.exit(1);
 }
 
+// Insiders builds deliberately ship the lazy driver-preview renderer and its
+// fixture chunk. Stable builds tree-shake both and retain the original limit.
+const budgets = {
+  ...BUDGET_BYTES,
+  ".js": BUDGET_BYTES[".js"] + (found.some(({ name }) => name.startsWith("preview-fixtures-")) ? 16_000 : 0),
+};
+
 const totals = new Map<string, number>();
 for (const { ext, bytes } of found) totals.set(ext, (totals.get(ext) ?? 0) + bytes);
 
 let failed = false;
-for (const [ext, budget] of Object.entries(BUDGET_BYTES)) {
+for (const [ext, budget] of Object.entries(budgets)) {
   const bytes = totals.get(ext) ?? 0;
   const percent = Math.round((bytes / budget) * 100);
   const label = `${ext.slice(1).toUpperCase().padEnd(3)} ${String(bytes).padStart(7)} / ${budget} bytes (${percent}%)`;

--- a/src/control.ts
+++ b/src/control.ts
@@ -103,7 +103,7 @@ import { VgnF2HidClient } from "@openmouse/protocol/drivers/vgn/hid";
 import { KeychronHidClient } from "@openmouse/protocol/drivers/keychron/hid";
 import { SUPPORTED_HID_FILTERS } from "@openmouse/protocol/drivers/vendors";
 import { WLMouseHidClient } from "@openmouse/protocol/drivers/wlmouse/hid";
-import { parsePreviewMode, type PreviewMode } from "./preview-modes";
+import { parsePreviewMode, previewsEnabled, type PreviewMode } from "./preview-modes";
 
 const controlApp = document.querySelector<HTMLDivElement>("#control-app");
 
@@ -116,7 +116,8 @@ const appRoot = controlApp;
 const BUILD_LABEL = `${__BUILD_CHANNEL__.toUpperCase()} · v${__APP_VERSION__}`;
 const DEFAULT_TITLE = document.title;
 const ACTIVE_DEVICE_STORAGE_KEY = "openmouse.active-device";
-const previewMode = import.meta.env.DEV
+const previewModeEnabled = previewsEnabled(__BUILD_CHANNEL__, import.meta.env.DEV);
+const previewMode = previewModeEnabled
   ? parsePreviewMode(new URLSearchParams(window.location.search).get("preview"))
   : null;
 const isSuperstrikePreview = previewMode === "superstrike";
@@ -668,8 +669,8 @@ function showSlotsPreview(): void {
  * the same rendering path the real driver would.
  */
 async function showFixturePreview(name: PreviewMode): Promise<void> {
-  // Loaded on demand so the fixtures never reach a production bundle, where
-  // `previewMode` is always null and none of this is reachable.
+  // Loaded on demand so ordinary visitors do not pay to parse fixtures. Stable
+  // builds remove this path; the deployed insiders app keeps it for reviewers.
   const { PREVIEW_FIXTURES, PREVIEW_KEYS } = await import("./preview-fixtures");
   const fixture = name === "list" || name === "slots" || name === "superstrike"
     ? undefined
@@ -760,7 +761,7 @@ function closeInterfaceSettings(): void {
 async function populatePreviewLauncher(): Promise<void> {
   const section = document.querySelector<HTMLElement>("#preview-launcher");
   const list = document.querySelector<HTMLElement>("#preview-launcher-list");
-  if (!section || !list || !import.meta.env.DEV || list.childElementCount > 0) return;
+  if (!section || !list || !previewModeEnabled || list.childElementCount > 0) return;
 
   const { PREVIEW_FIXTURES } = await import("./preview-fixtures");
   const entries: Array<[string, string]> = [

--- a/src/preview-modes.test.ts
+++ b/src/preview-modes.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { PREVIEW_KEYS, parsePreviewMode } from "./preview-modes.ts";
+import { PREVIEW_KEYS, parsePreviewMode, previewsEnabled } from "./preview-modes.ts";
+
+test("previews are enabled locally and on insiders builds only", () => {
+  assert.equal(previewsEnabled("stable", true), true);
+  assert.equal(previewsEnabled("insiders", false), true);
+  assert.equal(previewsEnabled("stable", false), false);
+});
 
 test("preview mode accepts every explicitly supported route", () => {
   for (const key of PREVIEW_KEYS) assert.equal(parsePreviewMode(key), key);

--- a/src/preview-modes.ts
+++ b/src/preview-modes.ts
@@ -31,6 +31,12 @@ export const PREVIEW_KEYS = [
 export type PreviewMode = typeof PREVIEW_KEYS[number];
 export type FixturePreviewMode = Exclude<PreviewMode, "list" | "slots" | "superstrike">;
 
+/** Preview fixtures are available locally and on the deployed insiders app,
+    but never on a stable production build. */
+export function previewsEnabled(buildChannel: string, viteDev: boolean): boolean {
+  return viteDev || buildChannel === "insiders";
+}
+
 /** Returns only trusted literals, breaking the data flow from the URL value. */
 export function parsePreviewMode(value: string | null): PreviewMode | null {
   switch (value) {


### PR DESCRIPTION
## Summary
- enable trusted `?preview=` routes on insiders builds, including `dev.openmouse.app`
- keep preview routes disabled and tree-shaken from stable builds
- expose the Interface settings preview launcher on insiders builds
- apply a separate tight size allowance only when the lazy fixture chunk exists

## Verification
- insiders production build: `?preview=list` exposes 20 routes
- Keychron preview renders controls with writes disabled
- stable build strips the preview chunk and remains under 447 KB
- 34 tests pass; insiders and stable bundle budgets pass