### PR TITLE
Show M3K and KO-ONE artwork in fixture previews

### DIFF
--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { deviceImage } from "./device-images.ts";
+
+test("fixture previews resolve product art without a HID device", () => {
+  assert.equal(deviceImage(null, "CRDRAKO KO-ONE"), "/devices/crdrako-ko-one.png");
+  assert.equal(deviceImage(null, "Zaunkoenig M3K"), "/devices/zaunkoenig-m3k.png");
+  assert.equal(deviceImage(null, "Zaunkoenig M2K"), "/devices/zaunkoenig-m3k.png");
+});

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -65,5 +65,7 @@ export function deviceImage(device: HIDDevice | null | undefined, displayName = 
   if (/\bop1\s*8k\b/i.test(displayName)) return "/devices/endgame-gear-op1-8k.png";
   if (/\bviper\s*v2\s*pro\b/i.test(displayName)) return "/devices/razer-viper-v2-pro.png";
   if (/\bnape\s*pro\b/i.test(displayName)) return "/devices/keychron-nape-pro.png";
+  if (/\bko-one\b/i.test(displayName)) return "/devices/crdrako-ko-one.png";
+  if (/\bm[23]k\b/i.test(displayName)) return "/devices/zaunkoenig-m3k.png";
   return "/devices/unknown-device.png";
 }


### PR DESCRIPTION
## Summary
- resolve M3K/M2K artwork by display name when no HID device exists
- resolve CRDRAKO KO-ONE artwork by display name in fixture mode
- preserve existing VID/PID mappings for real hardware

## Verification
- 35 tests pass, including new preview-art regression coverage
- production-style M3K image: 800×800
- production-style KO-ONE image: 2048×2048
- bundle budgets pass