### PR TITLE
feat: demo rework, Discord webhook, accent themes, OS detection & Linux fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,62 @@
 # OpenMouse
 
-OpenMouse is a website for managing supported gaming mice in one place.
+OpenMouse is a browser-based app for managing supported gaming mice in one place.
+It uses the WebHID API to communicate with devices directly from Chrome or Edge — no separate desktop utility required.
 
-The goal is to let you connect a mouse, view its information, and change settings
-like DPI and polling rate without installing a different app for every brand.
+## Features
 
-The website currently includes an interactive preview of the planned interface.
-It is only a demo and does not make changes to a real mouse.
+- **DPI control** — view and change sensitivity presets
+- **Polling rate** — switch between 125 Hz – 8 KHz where supported
+- **Battery & firmware** — read live status from wireless mice
+- **Lift-off distance**, debounce, motion sync, and more per brand
+- Supports Logitech, Pulsar, Endgame Gear, and WLMouse hardware
 
-## Future plans
+## Browser support
 
-OpenMouse will begin with a small number of supported mice and grow one device at
-a time. Future versions are planned to include verified device controls, more
-supported models, and an offline-ready app.
+| Browser | WebHID | Status |
+|---------|--------|--------|
+| Chrome  | ✅ | Fully supported |
+| Edge    | ✅ | Fully supported |
+| Firefox | ❌ | WebHID not implemented |
+| Safari  | ❌ | WebHID not implemented |
 
-OpenMouse is planned to become open-source software, but it is not currently
-licensed for use, modification, or redistribution. A license will be selected
-before the project's full release. You can follow its progress, suggest a
-mouse, or share feedback through GitHub and the OpenMouse Discord.
+## Development
+
+```bash
+npm install
+npm run dev      # start local dev server
+npm run build    # production build (requires tsc + vite)
+npm test         # run protocol unit tests
+```
+
+Copy `.env.example` to `.env` and fill in your Supabase credentials if you need the license/access-gate functions.
+
+## Mouse Check — Diagnostics & Discord Reporting
+
+**Mouse Check** is a companion Tauri desktop app for checking whether a mouse is WebHID compatible.
+It scans native HID devices, tests the Razer protocol over every interface, and generates a full diagnostic report.
+
+### Where to enter your Discord Webhook URL
+
+1. Open **Mouse Check**
+2. Select your mouse from the device list and click **Run Diagnostics**
+3. When the **Discord Report** section appears at the bottom, paste your Discord Webhook URL into the field labeled *"Discord Webhook URL (saved locally)"*
+4. Click **Send to Discord**
+
+The webhook URL is saved in your browser's `localStorage` under the key `om-discord-webhook`.
+It is **never** stored in the app code, never committed to the repository, and never sent anywhere other than Discord.
+
+**How to create a webhook:**
+Discord server → Channel settings → Integrations → Webhooks → New Webhook → Copy Webhook URL
+
+## Stack
+
+- **Vite 6** + **TypeScript 5** — build tooling
+- **WebHID** — browser API for direct HID device access
+- **Cloudflare Pages** — hosting + edge functions (access gate)
+- **Supabase** — license verification (optional, for access gate)
+
+## License
+
+Not currently licensed for use, modification, or redistribution.
+A license will be selected before the project's full public release.

--- a/control-app.html
+++ b/control-app.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#09090b" />
-    <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="icon" href="/favicon.ico?v=2" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/favicon-32.png?v=2" sizes="32x32" />
+    <link rel="icon" type="image/svg+xml" href="/favicon-dark.svg?v=2" sizes="any" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2" sizes="180x180" />
     <meta name="robots" content="noindex, nofollow" />
     <title>OpenMouse Control</title>
   </head>

--- a/demo.html
+++ b/demo.html
@@ -5,8 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#09090b" />
     <link rel="icon" href="/favicon.ico?v=2" sizes="32x32" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png?v=2" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
+    <link rel="icon" type="image/png" href="/favicon-32.png?v=2" sizes="32x32" />
+    <link rel="icon" type="image/svg+xml" href="/favicon-dark.svg?v=2" sizes="any" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2" sizes="180x180" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />

--- a/src/control.ts
+++ b/src/control.ts
@@ -1216,6 +1216,26 @@ function clientSupportScore(device: HIDDevice): number {
   return 0;
 }
 
+function detectOs(): string {
+  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  if (uaData?.platform) {
+    const p = uaData.platform.toLowerCase();
+    if (p.includes("windows")) return "Windows";
+    if (p.includes("mac")) return "macOS";
+    if (p.includes("linux")) return "Linux";
+    if (p.includes("android")) return "Android";
+    if (p.includes("ios")) return "iOS";
+  }
+  const ua = navigator.userAgent;
+  if (/Android/i.test(ua)) return "Android";
+  if (/iPhone|iPad|iPod/i.test(ua)) return "iOS";
+  if (/CrOS/i.test(ua)) return "ChromeOS";
+  if (/Win/i.test(ua)) return "Windows";
+  if (/Mac/i.test(ua)) return "macOS";
+  if (/Linux/i.test(ua)) return "Linux";
+  return "Unknown OS";
+}
+
 function describeHidDevice(device: HIDDevice): string {
   const name = device.productName || "unknown";
   const ids = `VID 0x${device.vendorId.toString(16)} PID 0x${device.productId.toString(16)}`;
@@ -1245,7 +1265,7 @@ async function connect(): Promise<void> {
     await activateClient(client);
   } catch (error) {
     const rawMessage = error instanceof Error ? error.message : "Unable to read the mouse.";
-    const message = rawMessage.includes("Failed to open the device") && /Linux/.test(navigator.userAgent)
+    const message = rawMessage.includes("Failed to open the device") && detectOs() === "Linux"
       ? "Failed to open the device. On Linux, WebHID requires a udev rule — run: "
         + "sudo sh -c 'echo KERNEL==\"hidraw*\", ATTRS{idVendor}==\"046d\", TAG+=\"uaccess\" > /etc/udev/rules.d/99-openmouse.rules' "
         + "&& sudo udevadm control --reload-rules && sudo udevadm trigger — then replug the receiver."
@@ -1748,6 +1768,9 @@ function buildDiscordReport(): string {
   const connectionDetail = document.querySelector<HTMLElement>("#connection-detail")?.textContent ?? "";
   const readStatus = document.querySelector<HTMLElement>("#read-status")?.textContent ?? "";
 
+  const os = detectOs();
+  const browser = navigator.userAgent.match(/Chrome\/([\d.]+)/)?.[0] ?? navigator.userAgent.split(" ").pop() ?? "—";
+
   const lines: string[] = [
     `OpenMouse · ${name}`,
     `DPI: ${dpi}  |  Polling: ${polling}  |  Battery: ${battery}`,
@@ -1756,6 +1779,7 @@ function buildDiscordReport(): string {
   lines.push(`Firmware: ${firmware}`);
   lines.push(`Connection: ${connection}${connectionDetail ? " · " + connectionDetail : ""}`);
   if (readStatus) lines.push(`Status: ${readStatus}`);
+  lines.push(`OS: ${os}  |  ${browser}`);
   return lines.join("\n");
 }
 

--- a/src/control.ts
+++ b/src/control.ts
@@ -73,7 +73,7 @@ function hasActiveClient(): boolean {
 
 type BatteryMode = "charging" | "discharging";
 type InterfaceDensity = "Compact" | "Comfortable";
-type InterfaceTheme = "Emerald" | "Violet" | "Ice" | "Ember" | "Mono";
+type InterfaceTheme = "Emerald" | "Violet" | "Ice" | "Ember" | "Mono" | "Berry Frost" | "Aurora Dust" | "Neon Pulse" | "Ocean Rose" | "Solar Pop" | "Lime Crush" | "Sunrise Sorbet" | "Cyber Bloom" | "Mint Eclipse";
 
 interface InterfacePreferences {
   density: InterfaceDensity;
@@ -105,7 +105,7 @@ function loadInterfacePreferences(): InterfacePreferences {
     const saved = JSON.parse(localStorage.getItem(INTERFACE_SETTINGS_KEY) ?? "{}") as Partial<InterfacePreferences>;
     return {
       density: saved.density === "Comfortable" ? "Comfortable" : "Compact",
-      theme: ["Emerald", "Violet", "Ice", "Ember", "Mono"].includes(saved.theme ?? "")
+      theme: ["Emerald", "Violet", "Ice", "Ember", "Mono", "Berry Frost", "Aurora Dust", "Neon Pulse", "Ocean Rose", "Solar Pop", "Lime Crush", "Sunrise Sorbet", "Cyber Bloom", "Mint Eclipse"].includes(saved.theme ?? "")
         ? saved.theme as InterfaceTheme
         : "Emerald",
       reducedMotion: saved.reducedMotion === true,
@@ -140,7 +140,7 @@ function applyInterfacePreferences(): void {
 function renderControl(): void {
   appRoot.innerHTML = `
     <style>
-      .control-shell { --ui-accent:#69d28d;--ui-accent-ink:#07120b;--ui-accent-soft:rgb(105 210 141 / 16%) }
+      .control-shell { --ui-accent:#69d28d;--ui-accent-end:var(--ui-accent);--ui-accent-ink:#07120b;--ui-accent-soft:rgb(105 210 141 / 16%) }
       .build-identity { display:flex;align-items:center;gap:.65rem;margin-bottom:4rem }
       .build-identity .demo-wordmark { margin-bottom:0 }
       .build-badge { display:inline-flex;align-items:center;min-height:1.35rem;padding:.2rem .45rem;border:1px solid color-mix(in srgb,var(--ui-accent) 35%,transparent);border-radius:999px;background:var(--ui-accent-soft);color:var(--ui-accent);font-family:"JetBrains Mono",ui-monospace,monospace;font-size:.52rem;font-weight:700;letter-spacing:.07em;line-height:1;white-space:nowrap }
@@ -148,6 +148,15 @@ function renderControl(): void {
       .control-shell[data-interface-theme="ice"] { --ui-accent:#67d8ff;--ui-accent-ink:#06161d;--ui-accent-soft:rgb(103 216 255 / 16%) }
       .control-shell[data-interface-theme="ember"] { --ui-accent:#ff9b62;--ui-accent-ink:#211006;--ui-accent-soft:rgb(255 155 98 / 17%) }
       .control-shell[data-interface-theme="mono"] { --ui-accent:#f1f1f3;--ui-accent-ink:#09090b;--ui-accent-soft:rgb(241 241 243 / 13%) }
+      .control-shell[data-interface-theme="berry frost"] { --ui-accent:#B24592;--ui-accent-end:#F15F79;--ui-accent-ink:#fff;--ui-accent-soft:rgb(178 69 146 / 17%) }
+      .control-shell[data-interface-theme="aurora dust"] { --ui-accent:#B993D6;--ui-accent-end:#8CA6DB;--ui-accent-ink:#0e0716;--ui-accent-soft:rgb(185 147 214 / 17%) }
+      .control-shell[data-interface-theme="neon pulse"] { --ui-accent:#8a2387;--ui-accent-end:#f27121;--ui-accent-ink:#fff;--ui-accent-soft:rgb(138 35 135 / 17%) }
+      .control-shell[data-interface-theme="ocean rose"] { --ui-accent:#aa4b6b;--ui-accent-end:#3b8d99;--ui-accent-ink:#fff;--ui-accent-soft:rgb(170 75 107 / 18%) }
+      .control-shell[data-interface-theme="solar pop"] { --ui-accent:#FF6A00;--ui-accent-end:#FFD500;--ui-accent-ink:#1a0800;--ui-accent-soft:rgb(255 106 0 / 17%) }
+      .control-shell[data-interface-theme="lime crush"] { --ui-accent:#A1FFCE;--ui-accent-end:#F9F586;--ui-accent-ink:#0a150b;--ui-accent-soft:rgb(161 255 206 / 14%) }
+      .control-shell[data-interface-theme="sunrise sorbet"] { --ui-accent:#f7797d;--ui-accent-end:#c6ffdd;--ui-accent-ink:#1a0508;--ui-accent-soft:rgb(247 121 125 / 17%) }
+      .control-shell[data-interface-theme="cyber bloom"] { --ui-accent:#ff0099;--ui-accent-end:#9b2472;--ui-accent-ink:#fff;--ui-accent-soft:rgb(255 0 153 / 17%) }
+      .control-shell[data-interface-theme="mint eclipse"] { --ui-accent:#99f2c8;--ui-accent-end:#1f4037;--ui-accent-ink:#041a0c;--ui-accent-soft:rgb(153 242 200 / 15%) }
       .control-shell .sidebar-action::before { color:var(--ui-accent) }
       .sidebar-device-list { display:grid;gap:.45rem }
       .sidebar-device-list .device-select { width:100%;color:inherit }
@@ -155,7 +164,7 @@ function renderControl(): void {
       .sidebar-device-list button.device-select:hover { border-color:#4a4a4f;background:#1b1b1e }
       .sidebar-device-list button.device-select.is-selected { border-color:#55555b;background:#202023 }
       .control-shell .device-dot:not(.is-idle), .control-shell .device-status > .status-dot:not(.is-idle), .control-shell .panel-footer .live-status-label i { background:var(--ui-accent);box-shadow:0 0 0 3px var(--ui-accent-soft) }
-      .control-shell .segmented button.selected, .control-shell .setting-action button:not(:disabled), .control-shell .dpi-header-actions button:not(:disabled) { border-color:var(--ui-accent);background:var(--ui-accent);color:var(--ui-accent-ink) }
+      .control-shell .segmented button.selected, .control-shell .setting-action button:not(:disabled), .control-shell .dpi-header-actions button:not(:disabled) { border-color:transparent;background:linear-gradient(135deg,var(--ui-accent),var(--ui-accent-end));color:var(--ui-accent-ink) }
       .control-shell .dpi-header-actions { display:flex;align-items:center;gap:.45rem }
       .control-shell .dpi-header-actions button { padding:.38rem .6rem;border:1px solid #343438;border-radius:6px;background:#171719;color:#b3b3b7;font-size:.62rem;font-weight:700;white-space:nowrap }
       .control-shell .dpi-header-actions button:disabled { cursor:default;opacity:.45 }
@@ -227,7 +236,7 @@ function renderControl(): void {
       .interface-setting-card p { margin:0 0 .8rem;color:#85858a;font-size:.68rem;line-height:1.45 }
       .interface-setting-card select { width:100%;padding:.52rem;border:1px solid #39393e;border-radius:7px;background:#18181b;color:#eee;color-scheme:dark }
       .theme-preview { display:flex;gap:.32rem;margin-top:.65rem }
-      .theme-preview i { width:1.25rem;height:.28rem;border-radius:999px;background:var(--ui-accent);opacity:.2 }
+      .theme-preview i { width:1.25rem;height:.28rem;border-radius:999px;background:linear-gradient(to right,var(--ui-accent),var(--ui-accent-end));opacity:.2 }
       .theme-preview i:nth-child(2) { opacity:.35 }.theme-preview i:nth-child(3) { opacity:.55 }.theme-preview i:nth-child(4) { opacity:.75 }.theme-preview i:nth-child(5) { opacity:1 }
       .interface-switch-row { display:flex;align-items:center;justify-content:space-between;gap:.8rem;margin-top:.7rem;color:#c5c5c9;font-size:.72rem }
       .interface-switch-row input {
@@ -247,7 +256,7 @@ function renderControl(): void {
       .interface-switch-row input:checked {
         border-color:var(--ui-accent);
         background-color:var(--ui-accent);
-        background-image:radial-gradient(circle at calc(100% - .56rem) 50%,#07120b 0 .34rem,transparent .36rem);
+        background-image:radial-gradient(circle at calc(100% - .56rem) 50%,var(--ui-accent-ink) 0 .34rem,transparent .36rem);
       }
       .interface-switch-row input:focus-visible { box-shadow:0 0 0 3px var(--ui-accent-soft) }
       .interface-reset { margin-top:.75rem;padding:.55rem .75rem;border:1px solid #4a3436;border-radius:7px;background:#1c1315;color:#e7a7aa;font-size:.68rem;font-weight:650 }
@@ -344,7 +353,7 @@ function renderControl(): void {
           <header class="interface-settings-header"><div><p class="overline">OPENMOUSE</p><h2 id="interface-settings-title">Interface settings</h2></div><button id="close-interface-settings" class="interface-settings-back" type="button">Back to device</button></header>
           <div class="interface-settings-grid">
             <article class="interface-setting-card"><span>LAYOUT</span><h3>Interface density</h3><p>Choose tighter controls or add more breathing room throughout the panel.</p><select id="interface-density"><option>Compact</option><option>Comfortable</option></select></article>
-            <article class="interface-setting-card"><span>APPEARANCE</span><h3>Accent theme</h3><p>Customize active controls, status lights, switches, and focus highlights.</p><select id="interface-theme"><option>Emerald</option><option>Violet</option><option>Ice</option><option>Ember</option><option>Mono</option></select><div class="theme-preview" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i></div></article>
+            <article class="interface-setting-card"><span>APPEARANCE</span><h3>Accent theme</h3><p>Customize active controls, status lights, switches, and focus highlights.</p><select id="interface-theme"><option>Emerald</option><option>Violet</option><option>Ice</option><option>Ember</option><option>Mono</option><option>Berry Frost</option><option>Aurora Dust</option><option>Neon Pulse</option><option>Ocean Rose</option><option>Solar Pop</option><option>Lime Crush</option><option>Sunrise Sorbet</option><option>Cyber Bloom</option><option>Mint Eclipse</option></select><div class="theme-preview" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i></div></article>
             <article class="interface-setting-card"><span>MOTION</span><h3>Animation</h3><p>Disable interface transitions and animated state changes.</p><label class="interface-switch-row"><span>Reduce motion</span><input id="interface-reduced-motion" type="checkbox" /></label></article>
             <article class="interface-setting-card"><span>SECTIONS</span><h3>Advanced editors</h3><p>Choose whether CPI, button mapping, and experimental sections begin expanded.</p><label class="interface-switch-row"><span>Expand by default</span><input id="interface-expand-sections" type="checkbox" /></label></article>
             <article class="interface-setting-card"><span>EXPERIMENTAL</span><h3>Experimental controls</h3><p>Show or completely hide controls that may vary between firmware versions.</p><label class="interface-switch-row"><span>Show experimental settings</span><input id="interface-show-experimental" type="checkbox" /></label></article>

--- a/src/control.ts
+++ b/src/control.ts
@@ -43,6 +43,7 @@ const BATTERY_MAX_CONTINUOUS_GAP_MS = 10 * 60 * 1000;
 const BATTERY_MIN_ESTIMATE_SPAN_MS = 10 * 60 * 1000;
 const BATTERY_MAX_SAMPLES_PER_DEVICE = 500;
 const INTERFACE_SETTINGS_KEY = "openmouse-interface-settings-v1";
+const WEBHOOK_KEY = "om-discord-webhook";
 const BUILD_LABEL = `${__BUILD_CHANNEL__.toUpperCase()} · v${__APP_VERSION__}`;
 let activeClient: LogitechHidppClient | null = null;
 let activePulsarClient: PulsarClient | null = null;
@@ -264,6 +265,18 @@ function renderControl(): void {
         .control-shell .settings-grid > .setting-card { min-height:220px }
       }
       @media (max-width:720px) { .interface-settings-grid { grid-template-columns:1fr } }
+      .discord-section { display:flex;flex-wrap:wrap;align-items:center;gap:.5rem .6rem;padding:.7rem 0 .5rem;border-top:1px solid #1e1e21 }
+      #discord-webhook-input { flex:1;min-width:160px;padding:.42rem .62rem;border:1px solid #343438;border-radius:7px;background:#111113;color:#ececef;font-family:"DM Sans",ui-sans-serif,sans-serif;font-size:.72rem;outline:none;transition:border-color .18s }
+      #discord-webhook-input:focus { border-color:#55555a }
+      #discord-webhook-input::placeholder { color:#45454a }
+      #discord-send-btn { white-space:nowrap;padding:.42rem .9rem;border:none;border-radius:7px;background:#5865F2;color:#fff;font-size:.72rem;font-weight:700;font-family:"DM Sans",ui-sans-serif,sans-serif;cursor:pointer;transition:filter .15s,opacity .15s }
+      #discord-send-btn:hover:not(:disabled) { filter:brightness(1.12) }
+      #discord-send-btn:disabled { opacity:.5;cursor:not-allowed }
+      #discord-send-btn.ok { background:linear-gradient(135deg,#3ba55c,#2d8c4e) }
+      #discord-send-btn.err { background:linear-gradient(135deg,#c0392b,#943126) }
+      #discord-send-status { width:100%;font-size:.68rem;color:#55555a }
+      #discord-send-status.ok { color:#4db880 }
+      #discord-send-status.err { color:#e06c75 }
     </style>
     <div class="control-shell is-empty">
       <aside class="sidebar">
@@ -322,6 +335,11 @@ function renderControl(): void {
           <article id="pulsar-pro-settings" class="setting-card" style="display:none;min-height:0;padding:.8rem"><div class="setting-heading" style="margin-bottom:.55rem"><div><p>PRO</p><h2>Advanced</h2></div></div><div style="display:flex;justify-content:space-between;align-items:center;gap:.5rem;padding:.2rem 0;color:#b3b3b7;font-size:.7rem"><span>Wheel acceleration</span><button id="wheel-acceleration-toggle" type="button" role="switch" aria-checked="false" style="min-width:42px;padding:.2rem .45rem;border:1px solid #3a3a3f;border-radius:999px;background:#202023;color:#8b8b90;font-size:.58rem">Off</button></div><label style="display:block;margin-top:.35rem;color:#77777c;font-size:.62rem">Angle tuning<select id="angle-tuning-select" style="width:100%;margin-top:.2rem;padding:.4rem;border:1px solid #343438;border-radius:6px;background:#171719;color:#eee"></select></label><label style="display:block;margin-top:.35rem;color:#77777c;font-size:.62rem">Onboard profile<select id="profile-select" style="width:100%;margin-top:.2rem;padding:.4rem;border:1px solid #343438;border-radius:6px;background:#171719;color:#eee"><option value="1">Profile 1</option><option value="2">Profile 2</option><option value="3">Profile 3</option><option value="4">Profile 4</option><option value="5">Profile 5</option><option value="6">Profile 6</option></select></label></article>
         </section>
         <footer class="panel-footer device-data"><span class="live-status-label"><i></i>LIVE STATUS</span><span id="read-status">Add a supported device from the sidebar to read its current status.</span></footer>
+        <section class="discord-section device-data">
+          <input id="discord-webhook-input" type="text" placeholder="Discord Webhook URL (saved locally)" spellcheck="false" autocomplete="off" />
+          <button id="discord-send-btn" type="button">Send to Discord</button>
+          <span id="discord-send-status"></span>
+        </section>
         <section id="interface-settings-page" class="interface-settings-page" aria-labelledby="interface-settings-title">
           <header class="interface-settings-header"><div><p class="overline">OPENMOUSE</p><h2 id="interface-settings-title">Interface settings</h2></div><button id="close-interface-settings" class="interface-settings-back" type="button">Back to device</button></header>
           <div class="interface-settings-grid">
@@ -470,6 +488,16 @@ function renderControl(): void {
     panel.scrollTop += event.deltaY;
     event.preventDefault();
   }, { passive: false });
+  const discordInput = document.querySelector<HTMLInputElement>("#discord-webhook-input");
+  if (discordInput) {
+    discordInput.value = localStorage.getItem(WEBHOOK_KEY) ?? "";
+    discordInput.addEventListener("change", () => {
+      localStorage.setItem(WEBHOOK_KEY, discordInput.value.trim());
+    });
+  }
+  document.querySelector<HTMLButtonElement>("#discord-send-btn")?.addEventListener("click", () => {
+    void sendStatusToDiscord();
+  });
   populateInterfaceSettings();
   applyInterfacePreferences();
   navigator.hid?.addEventListener("connect", handleHidConnect);
@@ -1687,6 +1715,88 @@ async function refreshStatus(): Promise<void> {
     setText("#read-status", message);
   } finally {
     refreshInProgress = false;
+  }
+}
+
+function buildDiscordReport(): string {
+  const name = document.querySelector<HTMLElement>("#device-title")?.textContent ?? "—";
+  const dpi = document.querySelector<HTMLInputElement>("#dpi-output")?.value ?? "—";
+  const pollingBtn = document.querySelector<HTMLButtonElement>("[data-rate].selected");
+  const polling = pollingBtn ? `${Number(pollingBtn.dataset.rate).toLocaleString()} Hz` : "—";
+  const battery = document.querySelector<HTMLElement>("#battery-value")?.textContent ?? "—";
+  const batteryDetail = document.querySelector<HTMLElement>("#battery-detail")?.textContent ?? "";
+  const firmware = document.querySelector<HTMLElement>("#firmware-value")?.textContent ?? "—";
+  const connection = document.querySelector<HTMLElement>("#connection-value")?.textContent ?? "—";
+  const connectionDetail = document.querySelector<HTMLElement>("#connection-detail")?.textContent ?? "";
+  const readStatus = document.querySelector<HTMLElement>("#read-status")?.textContent ?? "";
+
+  const lines: string[] = [
+    `OpenMouse · ${name}`,
+    `DPI: ${dpi}  |  Polling: ${polling}  |  Battery: ${battery}`,
+  ];
+  if (batteryDetail && batteryDetail !== "Read after connection") lines.push(`Battery: ${batteryDetail}`);
+  lines.push(`Firmware: ${firmware}`);
+  lines.push(`Connection: ${connection}${connectionDetail ? " · " + connectionDetail : ""}`);
+  if (readStatus) lines.push(`Status: ${readStatus}`);
+  return lines.join("\n");
+}
+
+async function sendStatusToDiscord(): Promise<void> {
+  const urlInput = document.querySelector<HTMLInputElement>("#discord-webhook-input");
+  const statusEl = document.querySelector<HTMLElement>("#discord-send-status");
+  const btn = document.querySelector<HTMLButtonElement>("#discord-send-btn");
+  if (!urlInput || !statusEl || !btn) return;
+
+  const url = urlInput.value.trim();
+  if (!url) {
+    statusEl.className = "err";
+    statusEl.textContent = "Paste a Discord Webhook URL first.";
+    return;
+  }
+  if (!url.startsWith("https://discord.com/api/webhooks/") && !url.startsWith("https://discordapp.com/api/webhooks/")) {
+    statusEl.className = "err";
+    statusEl.textContent = "That doesn’t look like a Discord webhook URL.";
+    return;
+  }
+  if (!hasActiveClient()) {
+    statusEl.className = "err";
+    statusEl.textContent = "Connect a mouse first.";
+    return;
+  }
+  localStorage.setItem(WEBHOOK_KEY, url);
+  const text = buildDiscordReport();
+  btn.disabled = true;
+  btn.textContent = "Sending…";
+  statusEl.className = "";
+  statusEl.textContent = "";
+  try {
+    const wrapped = "```\n" + text + "\n```";
+    const content = wrapped.length <= 2000 ? wrapped : text.slice(0, 1990) + "\n…";
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "OpenMouse", content }),
+    });
+    if (res.ok || res.status === 204) {
+      btn.textContent = "✓ Sent!";
+      btn.classList.add("ok");
+      statusEl.className = "ok";
+      statusEl.textContent = "Report sent to Discord.";
+    } else {
+      const body = await res.text().catch(() => "");
+      throw new Error(`HTTP ${res.status}${body ? ": " + body.slice(0, 120) : ""}`);
+    }
+  } catch (e) {
+    btn.textContent = "Failed";
+    btn.classList.add("err");
+    statusEl.className = "err";
+    statusEl.textContent = String(e);
+  } finally {
+    setTimeout(() => {
+      btn.disabled = false;
+      btn.textContent = "Send to Discord";
+      btn.classList.remove("ok", "err");
+    }, 3000);
   }
 }
 

--- a/src/control.ts
+++ b/src/control.ts
@@ -1223,12 +1223,8 @@ function detectOs(): string {
     if (p.includes("windows")) return "Windows";
     if (p.includes("mac")) return "macOS";
     if (p.includes("linux")) return "Linux";
-    if (p.includes("android")) return "Android";
-    if (p.includes("ios")) return "iOS";
   }
   const ua = navigator.userAgent;
-  if (/Android/i.test(ua)) return "Android";
-  if (/iPhone|iPad|iPod/i.test(ua)) return "iOS";
   if (/CrOS/i.test(ua)) return "ChromeOS";
   if (/Win/i.test(ua)) return "Windows";
   if (/Mac/i.test(ua)) return "macOS";

--- a/src/control.ts
+++ b/src/control.ts
@@ -73,7 +73,7 @@ function hasActiveClient(): boolean {
 
 type BatteryMode = "charging" | "discharging";
 type InterfaceDensity = "Compact" | "Comfortable";
-type InterfaceTheme = "Emerald" | "Violet" | "Ice" | "Ember" | "Mono" | "Berry Frost" | "Aurora Dust" | "Neon Pulse" | "Ocean Rose" | "Solar Pop" | "Lime Crush" | "Sunrise Sorbet" | "Cyber Bloom" | "Mint Eclipse";
+type InterfaceTheme = "Emerald" | "Violet" | "Ice" | "Ember" | "Mono" | "Miku" | "Catppuccin Mocha" | "Catppuccin Macchiato" | "Catppuccin Frappé" | "Berry Frost" | "Aurora Dust" | "Neon Pulse" | "Ocean Rose" | "Solar Pop" | "Lime Crush" | "Sunrise Sorbet" | "Cyber Bloom" | "Mint Eclipse";
 
 interface InterfacePreferences {
   density: InterfaceDensity;
@@ -105,7 +105,7 @@ function loadInterfacePreferences(): InterfacePreferences {
     const saved = JSON.parse(localStorage.getItem(INTERFACE_SETTINGS_KEY) ?? "{}") as Partial<InterfacePreferences>;
     return {
       density: saved.density === "Comfortable" ? "Comfortable" : "Compact",
-      theme: ["Emerald", "Violet", "Ice", "Ember", "Mono", "Berry Frost", "Aurora Dust", "Neon Pulse", "Ocean Rose", "Solar Pop", "Lime Crush", "Sunrise Sorbet", "Cyber Bloom", "Mint Eclipse"].includes(saved.theme ?? "")
+      theme: ["Emerald", "Violet", "Ice", "Ember", "Mono", "Miku", "Catppuccin Mocha", "Catppuccin Macchiato", "Catppuccin Frappé", "Berry Frost", "Aurora Dust", "Neon Pulse", "Ocean Rose", "Solar Pop", "Lime Crush", "Sunrise Sorbet", "Cyber Bloom", "Mint Eclipse"].includes(saved.theme ?? "")
         ? saved.theme as InterfaceTheme
         : "Emerald",
       reducedMotion: saved.reducedMotion === true,
@@ -157,6 +157,10 @@ function renderControl(): void {
       .control-shell[data-interface-theme="sunrise sorbet"] { --ui-accent:#f7797d;--ui-accent-end:#c6ffdd;--ui-accent-ink:#1a0508;--ui-accent-soft:rgb(247 121 125 / 17%) }
       .control-shell[data-interface-theme="cyber bloom"] { --ui-accent:#ff0099;--ui-accent-end:#9b2472;--ui-accent-ink:#fff;--ui-accent-soft:rgb(255 0 153 / 17%) }
       .control-shell[data-interface-theme="mint eclipse"] { --ui-accent:#99f2c8;--ui-accent-end:#1f4037;--ui-accent-ink:#041a0c;--ui-accent-soft:rgb(153 242 200 / 15%) }
+      .control-shell[data-interface-theme="miku"] { --ui-accent:#39C5BB;--ui-accent-ink:#021a19;--ui-accent-soft:rgb(57 197 187 / 16%) }
+      .control-shell[data-interface-theme="catppuccin mocha"] { --ui-accent:#CBA6F7;--ui-accent-ink:#1e1e2e;--ui-accent-soft:rgb(203 166 247 / 17%) }
+      .control-shell[data-interface-theme="catppuccin macchiato"] { --ui-accent:#C6A0F6;--ui-accent-ink:#24273a;--ui-accent-soft:rgb(198 160 246 / 17%) }
+      .control-shell[data-interface-theme="catppuccin frappé"] { --ui-accent:#CA9EE6;--ui-accent-ink:#303446;--ui-accent-soft:rgb(202 158 230 / 17%) }
       .control-shell .sidebar-action::before { color:var(--ui-accent) }
       .sidebar-device-list { display:grid;gap:.45rem }
       .sidebar-device-list .device-select { width:100%;color:inherit }
@@ -353,7 +357,7 @@ function renderControl(): void {
           <header class="interface-settings-header"><div><p class="overline">OPENMOUSE</p><h2 id="interface-settings-title">Interface settings</h2></div><button id="close-interface-settings" class="interface-settings-back" type="button">Back to device</button></header>
           <div class="interface-settings-grid">
             <article class="interface-setting-card"><span>LAYOUT</span><h3>Interface density</h3><p>Choose tighter controls or add more breathing room throughout the panel.</p><select id="interface-density"><option>Compact</option><option>Comfortable</option></select></article>
-            <article class="interface-setting-card"><span>APPEARANCE</span><h3>Accent theme</h3><p>Customize active controls, status lights, switches, and focus highlights.</p><select id="interface-theme"><option>Emerald</option><option>Violet</option><option>Ice</option><option>Ember</option><option>Mono</option><option>Berry Frost</option><option>Aurora Dust</option><option>Neon Pulse</option><option>Ocean Rose</option><option>Solar Pop</option><option>Lime Crush</option><option>Sunrise Sorbet</option><option>Cyber Bloom</option><option>Mint Eclipse</option></select><div class="theme-preview" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i></div></article>
+            <article class="interface-setting-card"><span>APPEARANCE</span><h3>Accent theme</h3><p>Customize active controls, status lights, switches, and focus highlights.</p><select id="interface-theme"><option>Emerald</option><option>Violet</option><option>Ice</option><option>Ember</option><option>Mono</option><option>Miku</option><option>Catppuccin Mocha</option><option>Catppuccin Macchiato</option><option>Catppuccin Frappé</option><option>Berry Frost</option><option>Aurora Dust</option><option>Neon Pulse</option><option>Ocean Rose</option><option>Solar Pop</option><option>Lime Crush</option><option>Sunrise Sorbet</option><option>Cyber Bloom</option><option>Mint Eclipse</option></select><div class="theme-preview" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i></div></article>
             <article class="interface-setting-card"><span>MOTION</span><h3>Animation</h3><p>Disable interface transitions and animated state changes.</p><label class="interface-switch-row"><span>Reduce motion</span><input id="interface-reduced-motion" type="checkbox" /></label></article>
             <article class="interface-setting-card"><span>SECTIONS</span><h3>Advanced editors</h3><p>Choose whether CPI, button mapping, and experimental sections begin expanded.</p><label class="interface-switch-row"><span>Expand by default</span><input id="interface-expand-sections" type="checkbox" /></label></article>
             <article class="interface-setting-card"><span>EXPERIMENTAL</span><h3>Experimental controls</h3><p>Show or completely hide controls that may vary between firmware versions.</p><label class="interface-switch-row"><span>Show experimental settings</span><input id="interface-show-experimental" type="checkbox" /></label></article>
@@ -1240,7 +1244,12 @@ async function connect(): Promise<void> {
     setText("#read-status", `Reading ${statusNameForClient(client)}…`);
     await activateClient(client);
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unable to read the mouse.";
+    const rawMessage = error instanceof Error ? error.message : "Unable to read the mouse.";
+    const message = rawMessage.includes("Failed to open the device") && /Linux/.test(navigator.userAgent)
+      ? "Failed to open the device. On Linux, WebHID requires a udev rule — run: "
+        + "sudo sh -c 'echo KERNEL==\"hidraw*\", ATTRS{idVendor}==\"046d\", TAG+=\"uaccess\" > /etc/udev/rules.d/99-openmouse.rules' "
+        + "&& sudo udevadm control --reload-rules && sudo udevadm trigger — then replug the receiver."
+      : rawMessage;
     await activeEggClient?.close().catch(() => undefined);
     activeEggClient = null;
     await activeEggWeClient?.close().catch(() => undefined);

--- a/src/control.ts
+++ b/src/control.ts
@@ -1262,9 +1262,9 @@ async function connect(): Promise<void> {
   } catch (error) {
     const rawMessage = error instanceof Error ? error.message : "Unable to read the mouse.";
     const message = rawMessage.includes("Failed to open the device") && detectOs() === "Linux"
-      ? "Failed to open the device. On Linux, WebHID requires a udev rule — run: "
-        + "sudo sh -c 'echo KERNEL==\"hidraw*\", ATTRS{idVendor}==\"046d\", TAG+=\"uaccess\" > /etc/udev/rules.d/99-openmouse.rules' "
-        + "&& sudo udevadm control --reload-rules && sudo udevadm trigger — then replug the receiver."
+      ? "Failed to open the device. On Linux, WebHID needs a udev rule — run: "
+        + "echo 'KERNEL==\"hidraw*\", SUBSYSTEM==\"hidraw\", TAG+=\"uaccess\"' | sudo tee /etc/udev/rules.d/99-openmouse.rules "
+        + "&& sudo udevadm control --reload-rules && sudo udevadm trigger — then replug your mouse."
       : rawMessage;
     await activeEggClient?.close().catch(() => undefined);
     activeEggClient = null;

--- a/src/demo.css
+++ b/src/demo.css
@@ -16,81 +16,398 @@ button:focus-visible, a:focus-visible, input:focus-visible {
   outline-offset: 3px;
 }
 
+/* ── Shell ──────────────────────────────────────────── */
 .small-screen-blocker { display: none; }
-.demo-shell { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 100vh; }
-.sidebar { position: sticky; top: 0; display: flex; height: 100vh; flex-direction: column; padding: 1.5rem; border-right: 1px solid #29292d; background: #0d0d0f; }
-.demo-wordmark { margin-bottom: 4rem; font-size: 1.05rem; font-weight: 600; letter-spacing: -.025em; }
-.device-label, .overline { margin: 0 0 .7rem; color: #7f7f84; font-family: "JetBrains Mono", monospace; font-size: .63rem; letter-spacing: .1em; }
-.device-select { display: grid; grid-template-columns: auto 1fr; align-items: center; gap: .7rem; width: 100%; padding: .85rem; border: 1px solid #303034; border-radius: 10px; background: #161618; text-align: left; }
+.demo-shell { display: grid; grid-template-columns: 270px minmax(0, 1fr); min-height: 100vh; }
+
+/* ── Sidebar ─────────────────────────────────────────── */
+.sidebar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  height: 100vh;
+  flex-direction: column;
+  padding: 1.25rem 1rem;
+  border-right: 1px solid #1e1e21;
+  background: #0d0d0f;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.sidebar::-webkit-scrollbar { display: none; }
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+}
+.demo-wordmark { font-size: 1rem; font-weight: 600; letter-spacing: -.025em; }
+.sidebar-icons { display: flex; align-items: center; gap: .6rem; }
+.icon-link { display: flex; align-items: center; color: #55555a; transition: color .15s; }
+.icon-link:hover { color: #c8c8cc; }
+
+.device-label {
+  margin: 0 0 .55rem;
+  padding: 0 .2rem;
+  color: #55555a;
+  font-family: "JetBrains Mono", monospace;
+  font-size: .58rem;
+  letter-spacing: .1em;
+}
+.selected-device { padding: .2rem; margin-bottom: .25rem; }
+.selected-device strong { display: block; font-size: .95rem; font-weight: 500; letter-spacing: -.02em; }
+.device-connection {
+  display: flex;
+  align-items: center;
+  gap: .38rem;
+  margin-top: .3rem;
+  color: #77777c;
+  font-size: .68rem;
+}
+.device-dot {
+  width: .42rem;
+  height: .42rem;
+  border-radius: 50%;
+  background: #69d28d;
+  box-shadow: 0 0 0 3px rgb(105 210 141 / 15%);
+  flex-shrink: 0;
+}
+
+.device-select {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: .65rem;
+  width: 100%;
+  padding: .75rem .8rem;
+  border: 1px solid #2a2a2e;
+  border-radius: 9px;
+  background: #141416;
+  text-align: left;
+}
+.device-select.is-selected { border-color: #383840; background: #1b1b1f; }
 .device-select strong, .device-select small { display: block; }
-.device-select strong { font-size: .85rem; font-weight: 500; }
-.device-select small { margin-top: .2rem; color: #85858a; font-size: .68rem; }
-.device-dot { width: .48rem; height: .48rem; border-radius: 50%; background: #69d28d; box-shadow: 0 0 0 4px rgb(105 210 141 / 10%); }
-nav { display: grid; gap: .3rem; margin-top: 2.5rem; }
-.nav-item { padding: .7rem .8rem; border: 0; border-radius: 7px; background: transparent; color: #85858a; text-align: left; font-size: .82rem; }
-.nav-item:hover, .nav-item.active { background: #1b1b1e; color: #fff; }
-.sidebar-footer { display: grid; gap: .45rem; margin-top: auto; color: #66666b; font-size: .7rem; }
-.sidebar-footer a { color: #bdbdc1; }
-.sidebar-footer a:hover { color: #fff; }
+.device-select strong { font-size: .82rem; font-weight: 500; }
+.device-select small { margin-top: .18rem; color: #77777c; font-size: .65rem; }
 
-.control-panel { width: min(100% - 4rem, 1180px); margin: 0 auto; padding: 1.5rem 0 2rem; }
-.preview-banner { display: flex; align-items: center; gap: .8rem; padding: .65rem .8rem; border: 1px solid #303034; border-radius: 8px; background: #121214; color: #96969b; font-size: .72rem; }
-.preview-banner span { color: #f7f7f7; font-family: "JetBrains Mono", monospace; font-size: .62rem; letter-spacing: .08em; }
+.add-device-btn {
+  display: flex;
+  align-items: center;
+  gap: .4rem;
+  width: 100%;
+  margin-top: .35rem;
+  padding: .65rem .8rem;
+  border: 1px solid #252528;
+  border-radius: 8px;
+  background: transparent;
+  color: #77777c;
+  font-size: .76rem;
+  text-align: left;
+  transition: border-color .15s, color .15s;
+}
+.add-device-btn:not(:disabled):hover { border-color: #45454a; color: #ececef; }
+.add-device-btn:disabled { cursor: not-allowed; opacity: .5; }
+
+.sidebar-divider { margin: 1rem 0; border: none; border-top: 1px solid #1e1e21; }
+
+.sidebar-action {
+  display: flex;
+  align-items: center;
+  gap: .4rem;
+  width: 100%;
+  padding: .58rem .65rem;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: #77777c;
+  font-size: .76rem;
+  text-align: left;
+  transition: background .15s, color .15s;
+  text-decoration: none;
+}
+.sidebar-action:not(:disabled):hover, a.sidebar-action:hover { background: #18181b; color: #ececef; }
+.sidebar-action:disabled { cursor: not-allowed; }
+
+.sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  gap: .3rem;
+  margin-top: auto;
+  padding-top: 1rem;
+  color: #3d3d42;
+  font-family: "JetBrains Mono", monospace;
+  font-size: .55rem;
+  letter-spacing: .05em;
+}
+
+/* ── Control panel ──────────────────────────────────── */
+.control-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.preview-banner {
+  display: flex;
+  align-items: center;
+  gap: .8rem;
+  padding: .58rem .9rem;
+  border-bottom: 1px solid #1e1e21;
+  background: #0d0d0f;
+  color: #66666b;
+  font-size: .7rem;
+}
+.preview-banner span {
+  color: #f7f7f7;
+  font-family: "JetBrains Mono", monospace;
+  font-size: .58rem;
+  letter-spacing: .08em;
+}
 .preview-banner p { margin: 0; }
-.panel-header { display: flex; align-items: flex-end; justify-content: space-between; padding: 4rem 0 2rem; }
-.panel-header h1 { margin: 0; font-size: clamp(2.5rem, 5vw, 4.8rem); font-weight: 500; line-height: .95; letter-spacing: -.04em; }
-.device-status { display: flex; align-items: center; gap: .45rem; color: #adadb1; font-size: .75rem; }
-.device-status span { width: .45rem; height: .45rem; border-radius: 50%; background: #69d28d; }
 
-.device-overview { display: grid; grid-template-columns: 1.45fr 1fr; min-height: 330px; overflow: hidden; scroll-margin-top: 1.5rem; border: 1px solid #2b2b2f; border-radius: 14px; background: #111113; }
-.mouse-stage { position: relative; display: grid; min-height: 330px; place-items: center; overflow: hidden; background: radial-gradient(circle at 50% 45%, #29292d 0, #151517 40%, #101012 72%); }
-.mouse-stage::before { position: absolute; width: 430px; height: 430px; border: 1px solid #29292d; border-radius: 50%; content: ""; }
-.mouse-image { position: relative; width: min(290px, 68%); height: auto; filter: drop-shadow(0 30px 28px rgb(0 0 0 / 70%)); }
-.model-caption { position: absolute; right: 1rem; bottom: 1rem; color: #66666b; font-family: "JetBrains Mono", monospace; font-size: .58rem; letter-spacing: .1em; }
-.quick-stats { display: grid; grid-template-rows: repeat(3, 1fr); border-left: 1px solid #2b2b2f; }
-.quick-stats article { display: flex; flex-direction: column; justify-content: center; padding: 1.5rem; border-bottom: 1px solid #2b2b2f; }
+.status-bar {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .52rem .9rem;
+  border-bottom: 1px solid #1e1e21;
+  color: #77777c;
+  font-size: .7rem;
+}
+.status-dot {
+  width: .4rem;
+  height: .4rem;
+  border-radius: 50%;
+  background: #69d28d;
+  box-shadow: 0 0 0 3px rgb(105 210 141 / 12%);
+  flex-shrink: 0;
+}
+
+/* ── Tab bar ─────────────────────────────────────────── */
+.tab-bar {
+  display: flex;
+  border-bottom: 1px solid #1e1e21;
+  overflow-x: auto;
+  scrollbar-width: none;
+  flex-shrink: 0;
+}
+.tab-bar::-webkit-scrollbar { display: none; }
+
+.tab-btn {
+  position: relative;
+  padding: .72rem 1rem;
+  border: 0;
+  background: transparent;
+  color: #55555a;
+  font-size: .76rem;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: color .15s;
+}
+.tab-btn:not(:disabled):hover { color: #b3b3b7; }
+.tab-btn:disabled { cursor: not-allowed; opacity: .35; }
+.tab-btn.active { color: #f7f7f7; }
+.tab-btn.active::after {
+  position: absolute;
+  right: .45rem;
+  bottom: 0;
+  left: .45rem;
+  height: 1.5px;
+  border-radius: 1px;
+  background: #f7f7f7;
+  content: "";
+}
+
+/* ── Panels ──────────────────────────────────────────── */
+.panel { flex: 1; padding: 1.25rem clamp(1.25rem, 3vw, 2rem) 1rem; }
+
+.overline { margin: 0 0 .6rem; color: #77777c; font-family: "JetBrains Mono", monospace; font-size: .6rem; letter-spacing: .09em; }
+
+/* Overview */
+.device-overview {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  min-height: 300px;
+  overflow: hidden;
+  border: 1px solid #252528;
+  border-radius: 12px;
+  background: #0f0f11;
+}
+.mouse-stage {
+  position: relative;
+  display: grid;
+  min-height: 300px;
+  place-items: center;
+  overflow: hidden;
+  background: radial-gradient(circle at 50% 45%, #242428 0, #141416 40%, #0e0e10 72%);
+}
+.mouse-stage::before {
+  position: absolute;
+  width: 400px;
+  height: 400px;
+  border: 1px solid #252528;
+  border-radius: 50%;
+  content: "";
+}
+.mouse-image {
+  position: relative;
+  width: min(270px, 65%);
+  height: auto;
+  filter: drop-shadow(0 28px 26px rgb(0 0 0 / 70%));
+}
+.model-caption {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  color: #3d3d42;
+  font-family: "JetBrains Mono", monospace;
+  font-size: .55rem;
+  letter-spacing: .1em;
+}
+.quick-stats { display: grid; grid-template-rows: repeat(3, 1fr); border-left: 1px solid #252528; }
+.quick-stats article {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1.35rem 1.5rem;
+  border-bottom: 1px solid #252528;
+}
 .quick-stats article:last-child { border-bottom: 0; }
-.quick-stats span, .setting-heading p { margin: 0 0 .6rem; color: #77777c; font-family: "JetBrains Mono", monospace; font-size: .6rem; letter-spacing: .09em; }
-.quick-stats strong { font-size: 1.45rem; font-weight: 500; letter-spacing: -.025em; }
-.quick-stats small { margin-top: .2rem; color: #77777c; font-size: .68rem; }
-.meter { width: 100%; height: 3px; margin-top: .8rem; overflow: hidden; border-radius: 3px; background: #303034; }
+.quick-stats span, .setting-heading p {
+  margin: 0 0 .55rem;
+  color: #55555a;
+  font-family: "JetBrains Mono", monospace;
+  font-size: .58rem;
+  letter-spacing: .09em;
+}
+.quick-stats strong { font-size: 1.4rem; font-weight: 500; letter-spacing: -.025em; }
+.quick-stats small { margin-top: .2rem; color: #66666b; font-size: .67rem; }
+.meter { width: 100%; height: 2px; margin-top: .75rem; overflow: hidden; border-radius: 2px; background: #2a2a2e; }
 .meter i { display: block; height: 100%; background: #f7f7f7; }
 
-.settings-grid { display: grid; grid-template-columns: 1.15fr .85fr; gap: 1rem; margin-top: 1rem; scroll-margin-top: 1.5rem; }
-.setting-card { padding: 1.5rem; border: 1px solid #2b2b2f; border-radius: 12px; background: #111113; }
-.dpi-card { grid-row: span 2; }
-.setting-heading { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 2rem; }
-.setting-heading h2 { margin: 0; font-size: 1.15rem; font-weight: 500; letter-spacing: -.015em; }
-.setting-heading output { padding: .38rem .55rem; border: 1px solid #333338; border-radius: 6px; color: #d4d4d7; font-family: "JetBrains Mono", monospace; font-size: .68rem; }
-.info { display: grid; width: 1.25rem; height: 1.25rem; place-items: center; border: 1px solid #37373b; border-radius: 50%; color: #77777c; font-size: .65rem; }
-input[type="range"] { width: 100%; accent-color: #f7f7f7; }
-.range-labels { display: flex; justify-content: space-between; margin-top: .35rem; color: #66666b; font-family: "JetBrains Mono", monospace; font-size: .58rem; }
-.dpi-stages, .segmented { display: grid; grid-template-columns: repeat(4, 1fr); gap: .4rem; margin-top: 2rem; }
-.dpi-stages button, .segmented button { padding: .6rem .4rem; border: 1px solid #303034; border-radius: 7px; background: #18181b; color: #85858a; font-size: .72rem; }
-.dpi-stages button:hover, .segmented button:hover { border-color: #66666b; color: #fff; }
-.dpi-stages button.selected, .segmented button.selected { border-color: #f7f7f7; background: #f7f7f7; color: #09090b; }
-.segmented { margin-top: 0; }
-.segmented.two { grid-template-columns: repeat(2, 1fr); }
-.setting-note { display: block; margin-top: 1rem; color: #6f6f74; font-size: .68rem; }
-.toggle-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 1.4rem; padding-top: 1.2rem; border-top: 1px solid #29292d; }
-.toggle-row strong, .toggle-row small { display: block; }
-.toggle-row strong { font-size: .78rem; font-weight: 500; }
-.toggle-row small { margin-top: .25rem; color: #6f6f74; font-size: .65rem; }
-.toggle-row input { position: absolute; opacity: 0; pointer-events: none; }
-.toggle-row i { position: relative; width: 2rem; height: 1.1rem; flex: 0 0 auto; border-radius: 1rem; background: #343438; transition: background .2s ease; }
-.toggle-row i::after { position: absolute; top: .15rem; left: .15rem; width: .8rem; height: .8rem; border-radius: 50%; background: #929297; content: ""; transition: transform .2s ease, background .2s ease; }
-.toggle-row input:checked + i { background: #f7f7f7; }
-.toggle-row input:checked + i::after { background: #09090b; transform: translateX(.9rem); }
+/* Performance */
+.settings-stack { display: flex; flex-direction: column; gap: 1rem; max-width: 820px; }
+.setting-card { padding: 1.5rem; border: 1px solid #252528; border-radius: 12px; background: #0f0f11; }
+.setting-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+.setting-heading h2 { margin: 0; font-size: 1.1rem; font-weight: 500; letter-spacing: -.015em; }
+.setting-note { display: block; margin-top: 1rem; color: #55555a; font-size: .67rem; line-height: 1.5; }
 
-.panel-footer { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 1rem; padding: 1rem 0; color: #77777c; font-size: .72rem; }
-.panel-footer button { padding: .75rem 1rem; border: 0; border-radius: 8px; background: #f7f7f7; color: #09090b; font-size: .78rem; font-weight: 600; transition: transform .2s ease; }
-.panel-footer button:hover { transform: translateY(-2px); }
+/* DPI */
+.dpi-heading-right { display: flex; align-items: center; gap: .65rem; }
+.dpi-large { font-size: 1.5rem; font-weight: 500; letter-spacing: -.035em; color: #f7f7f7; }
+.custom-btn {
+  padding: .3rem .6rem;
+  border: 1px solid #343438;
+  border-radius: 6px;
+  background: #18181b;
+  color: #9b9ba0;
+  font-size: .65rem;
+  font-weight: 500;
+  transition: border-color .15s;
+}
+.custom-btn:not(:disabled):hover { border-color: #55555a; color: #ececef; }
+.custom-btn:disabled { cursor: not-allowed; opacity: .5; }
+.dpi-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: .38rem;
+}
+.dpi-grid button {
+  padding: .6rem .4rem;
+  border: 1px solid #2a2a2e;
+  border-radius: 7px;
+  background: #151517;
+  color: #77777c;
+  font-size: .72rem;
+  transition: border-color .15s, color .15s, background .15s;
+}
+.dpi-grid button:hover { border-color: #55555a; color: #ececef; background: #1b1b1f; }
+.dpi-grid button.selected { border-color: #f7f7f7; background: #f7f7f7; color: #09090b; }
 
+/* Polling slider */
+.polling-wrap { margin-top: 1.5rem; }
+.polling-range {
+  width: 100%;
+  height: 3px;
+  appearance: none;
+  border-radius: 3px;
+  background: #2e2e32;
+  outline: none;
+  cursor: pointer;
+}
+.polling-range::-webkit-slider-thumb {
+  appearance: none;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: #f7f7f7;
+  box-shadow: 0 0 0 3px #09090b, 0 0 0 4px #55555a;
+}
+.polling-range::-moz-range-thumb {
+  width: 15px;
+  height: 15px;
+  border: none;
+  border-radius: 50%;
+  background: #f7f7f7;
+}
+.polling-ticks {
+  display: flex;
+  justify-content: space-between;
+  margin-top: .45rem;
+  color: #3d3d42;
+  font-family: "JetBrains Mono", monospace;
+  font-size: .57rem;
+}
+
+/* ── Footer ──────────────────────────────────────────── */
+.panel-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: .85rem clamp(1.25rem, 3vw, 2rem);
+  border-top: 1px solid #1e1e21;
+  background: #0d0d0f;
+  flex-shrink: 0;
+}
+.footer-status { display: flex; flex-direction: column; gap: .2rem; }
+.footer-status span { font-size: .73rem; color: #9b9ba0; }
+.footer-status small { font-size: .63rem; color: #45454a; }
+.footer-actions { display: flex; align-items: center; gap: .5rem; flex-shrink: 0; }
+.revert-btn {
+  padding: .58rem .85rem;
+  border: 1px solid #2e2e32;
+  border-radius: 7px;
+  background: transparent;
+  color: #77777c;
+  font-size: .72rem;
+  transition: border-color .15s, color .15s;
+}
+.revert-btn:not(:disabled):hover { border-color: #4a4a50; color: #ececef; }
+.revert-btn:disabled { cursor: not-allowed; opacity: .4; }
+.apply-btn {
+  padding: .58rem 1rem;
+  border: 0;
+  border-radius: 7px;
+  background: #f7f7f7;
+  color: #09090b;
+  font-size: .72rem;
+  font-weight: 600;
+  transition: filter .15s;
+}
+.apply-btn:not(:disabled):hover { filter: brightness(1.06); }
+.apply-btn:disabled { cursor: not-allowed; opacity: .4; }
+
+/* ── Small screen blocker ────────────────────────────── */
 @media (max-width: 899px) {
   .demo-shell { display: none; }
   .small-screen-blocker { display: flex; }
 }
-
 .blocked-device .demo-shell { display: none; }
 .blocked-device .small-screen-blocker { display: flex; }
 .small-screen-blocker {
@@ -100,7 +417,17 @@ input[type="range"] { width: 100%; accent-color: #f7f7f7; }
   flex-direction: column;
   padding: clamp(2rem, 8vw, 7rem);
 }
-.blocker-mark { display: grid; width: 2.5rem; height: 2.5rem; margin-bottom: 4rem; place-items: center; border: 1px solid #343438; border-radius: 9px; font-family: "JetBrains Mono", monospace; font-size: .7rem; }
+.blocker-mark {
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-bottom: 4rem;
+  place-items: center;
+  border: 1px solid #343438;
+  border-radius: 9px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: .7rem;
+}
 .blocker-label { margin: 0 0 .8rem; color: #77777c; font-family: "JetBrains Mono", monospace; font-size: .62rem; letter-spacing: .1em; }
 .small-screen-blocker h1 { max-width: 500px; margin: 0; font-size: clamp(3rem, 8vw, 5rem); font-weight: 500; line-height: .92; letter-spacing: -.04em; }
 .small-screen-blocker > p:not(.blocker-label) { max-width: 440px; margin: 1.5rem 0 2rem; color: #99999e; line-height: 1.6; }

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -9,10 +9,39 @@ if (!demoApp) {
 const mobileNavigator = navigator as Navigator & { userAgentData?: { mobile?: boolean } };
 const isMobileDevice = mobileNavigator.userAgentData?.mobile === true
   || /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
-const DEMO_SETTINGS_KEY = "openmouse-demo-settings-v1";
 
 if (isMobileDevice) {
   document.documentElement.classList.add("blocked-device");
+}
+
+const DEMO_SETTINGS_KEY = "openmouse-demo-settings-v1";
+const POLLING_VALUES = [125, 250, 500, 1000] as const;
+type PollingValue = typeof POLLING_VALUES[number];
+const DPI_PRESETS = [400, 800, 1600, 3200, 6400] as const;
+
+let appliedDpi = 1600;
+let appliedPolling: PollingValue = 1000;
+let pendingDpi = appliedDpi;
+let pendingPolling: PollingValue = appliedPolling;
+
+try {
+  const saved = JSON.parse(localStorage.getItem(DEMO_SETTINGS_KEY) ?? "{}") as Partial<{ dpi: number; polling: number }>;
+  if (typeof saved.dpi === "number" && (DPI_PRESETS as readonly number[]).includes(saved.dpi)) {
+    appliedDpi = pendingDpi = saved.dpi;
+  }
+  if (typeof saved.polling === "number" && (POLLING_VALUES as readonly number[]).includes(saved.polling)) {
+    appliedPolling = pendingPolling = saved.polling as PollingValue;
+  }
+} catch {
+  // Use defaults if storage is unavailable.
+}
+
+function fmtDpi(dpi: number): string {
+  return `${dpi.toLocaleString()} DPI`;
+}
+
+function fmtHz(hz: number): string {
+  return hz >= 1000 ? `${hz / 1000}K Hz` : `${hz} Hz`;
 }
 
 demoApp.innerHTML = `
@@ -26,21 +55,41 @@ demoApp.innerHTML = `
 
   <div class="demo-shell">
     <aside class="sidebar">
-      <a class="demo-wordmark" href="/" aria-label="Back to OpenMouse">OpenMouse</a>
-      <div class="device-label">CONNECTED DEVICE</div>
-      <div class="device-select" aria-label="Selected device">
-        <span class="device-dot"></span>
-        <span><strong>Superlight 2C</strong><small>Logitech · Connected</small></span>
+      <div class="sidebar-header">
+        <a class="demo-wordmark" href="/" aria-label="Back to OpenMouse">OpenMouse</a>
+        <div class="sidebar-icons">
+          <a class="icon-link" href="https://discord.gg/5Vw9uQV3xB" target="_blank" rel="noreferrer" aria-label="Discord">
+            <svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true"><path fill="currentColor" d="M19.5 5.3A17.2 17.2 0 0 0 15.2 4l-.5 1a16 16 0 0 0-5.3 0l-.6-1a17.5 17.5 0 0 0-4.3 1.3C1.8 9.4 1 13.4 1.3 17.4a17.4 17.4 0 0 0 5.3 2.7l1.3-1.8a11 11 0 0 1-2-1l.5-.4a12.3 12.3 0 0 0 11.2 0l.6.4c-.7.4-1.3.7-2 1l1.3 1.8a17.4 17.4 0 0 0 5.3-2.7c.4-4.6-.8-8.5-3.3-12.1ZM8.3 15.2c-1 0-1.9-1-1.9-2.2s.9-2.2 1.9-2.2 1.9 1 1.9 2.2-.9 2.2-1.9 2.2Zm7.4 0c-1 0-1.9-1-1.9-2.2s.9-2.2 1.9-2.2 1.9 1 1.9 2.2-.9 2.2-1.9 2.2Z"/></svg>
+          </a>
+          <a class="icon-link" href="https://x.com/openmouseapp" target="_blank" rel="noreferrer" aria-label="X / Twitter">
+            <svg viewBox="0 0 24 24" width="15" height="15" aria-hidden="true"><path fill="currentColor" d="M17.751 3h3.067l-6.7 7.625L22 21h-6.172l-4.833-6.293L5.464 21H2.395l7.167-8.155L2 3h6.328l4.37 5.752zm-1.076 16.172h1.7L7.404 4.732H5.58z"/></svg>
+          </a>
+        </div>
       </div>
-      <nav aria-label="Device settings">
-        <button class="nav-item active" type="button" data-panel="overview">Overview</button>
-        <button class="nav-item" type="button" data-panel="performance">Performance</button>
-        <button class="nav-item" type="button" data-panel="buttons">Buttons</button>
-        <button class="nav-item" type="button" data-panel="profiles">Profiles</button>
-      </nav>
+
+      <p class="device-label">SELECTED DEVICE</p>
+      <div class="selected-device">
+        <strong>Superlight 2C</strong>
+        <div class="device-connection"><span class="device-dot"></span>Connected</div>
+      </div>
+
+      <p class="device-label" style="margin-top:1.75rem">CONNECTED DEVICES</p>
+      <button class="device-select is-selected" type="button" aria-pressed="true">
+        <span class="device-dot"></span>
+        <span><strong>Superlight 2C</strong><small>Logitech · Wireless</small></span>
+      </button>
+      <button class="add-device-btn" type="button" disabled>+ Add device</button>
+
+      <hr class="sidebar-divider" />
+      <button class="sidebar-action" type="button" disabled>
+        <svg viewBox="0 0 20 20" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M10 13a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM.87 10.8a1.5 1.5 0 0 1 0-1.6l1.19-1.87A1.5 1.5 0 0 1 3.84 6.7l.41.05c.36.04.72-.07 1-.28l.35-.27a1.5 1.5 0 0 0 .55-.96l.07-.41A1.5 1.5 0 0 1 7.7 3.5h2.6a1.5 1.5 0 0 1 1.47 1.33l.07.4a1.5 1.5 0 0 0 .55.97l.35.27c.28.2.64.32 1 .28l.41-.05a1.5 1.5 0 0 1 1.78.63l1.19 1.87a1.5 1.5 0 0 1 0 1.6l-1.19 1.87a1.5 1.5 0 0 1-1.78.63l-.41-.05a1.5 1.5 0 0 0-1 .28l-.35.27a1.5 1.5 0 0 0-.55.97l-.07.4a1.5 1.5 0 0 1-1.47 1.33H7.7a1.5 1.5 0 0 1-1.47-1.33l-.07-.41a1.5 1.5 0 0 0-.55-.96l-.35-.27a1.5 1.5 0 0 0-1-.28l-.41.05a1.5 1.5 0 0 1-1.78-.63z"/></svg>
+        Interface settings
+      </button>
+      <a class="sidebar-action" href="https://openmouse.app/mouse-check" target="_blank" rel="noreferrer">Mouse Check</a>
+
       <div class="sidebar-footer">
+        <span>INSIDERS · v0.1.0</span>
         <span>Interface concept</span>
-        <a href="/">Back to website</a>
       </div>
     </aside>
 
@@ -50,157 +99,174 @@ demoApp.innerHTML = `
         <p id="preview-message" aria-live="polite">This demo does not connect to or change a real device.</p>
       </div>
 
-      <header class="panel-header">
-        <div>
-          <p class="overline">LOGITECH</p>
-          <h1>Superlight 2C</h1>
-        </div>
-        <div class="device-status"><span></span>Connected</div>
-      </header>
+      <div class="status-bar">
+        <span class="status-dot"></span>
+        <span id="status-text">Current: ${fmtDpi(appliedDpi)} · ${fmtHz(appliedPolling)}</span>
+      </div>
 
-      <section class="device-overview">
-        <div class="mouse-stage" aria-label="Mouse preview">
-          <img class="mouse-image" src="/superlight-2c-black.png" alt="Top view of a black Logitech Superlight 2C gaming mouse" />
-          <span class="model-caption">SUPERLIGHT 2C</span>
-        </div>
-        <div class="quick-stats">
-          <article><span>BATTERY</span><strong>82%</strong><div class="meter"><i style="width:82%"></i></div></article>
-          <article><span>FIRMWARE</span><strong>1.2.4</strong><small>Up to date</small></article>
-          <article><span>CONNECTION</span><strong>Wireless</strong><small>2.4 GHz receiver</small></article>
+      <nav class="tab-bar" aria-label="Device settings">
+        <button class="tab-btn" type="button" data-tab="overview">Overview</button>
+        <button class="tab-btn active" type="button" data-tab="performance">Performance</button>
+        <button class="tab-btn" type="button" data-tab="lighting" disabled>Lighting</button>
+        <button class="tab-btn" type="button" data-tab="buttons" disabled>Buttons</button>
+        <button class="tab-btn" type="button" data-tab="profiles" disabled>Profiles</button>
+        <button class="tab-btn" type="button" data-tab="advanced" disabled>Advanced</button>
+      </nav>
+
+      <section id="panel-overview" class="panel" hidden>
+        <div class="device-overview">
+          <div class="mouse-stage" aria-label="Mouse preview">
+            <img class="mouse-image" src="/superlight-2c-black.png" alt="Top view of a black Logitech Superlight 2C gaming mouse" />
+            <span class="model-caption">SUPERLIGHT 2C</span>
+          </div>
+          <div class="quick-stats">
+            <article><span>BATTERY</span><strong>82%</strong><div class="meter"><i style="width:82%"></i></div></article>
+            <article><span>FIRMWARE</span><strong>1.2.4</strong><small>Up to date</small></article>
+            <article><span>CONNECTION</span><strong>Wireless</strong><small>2.4 GHz receiver</small></article>
+          </div>
         </div>
       </section>
 
-      <section class="settings-grid" aria-label="Mouse settings">
-        <article class="setting-card dpi-card">
-          <div class="setting-heading">
-            <div><p>DPI</p><h2>Sensitivity</h2></div>
-            <output id="dpi-output">1600 DPI</output>
-          </div>
-          <input id="dpi-range" type="range" min="100" max="3200" step="100" value="1600" aria-label="DPI sensitivity" />
-          <div class="range-labels"><span>100</span><span>3200</span></div>
-          <div class="dpi-stages" aria-label="DPI presets">
-            <button type="button" data-dpi="400">400</button>
-            <button type="button" data-dpi="800">800</button>
-            <button class="selected" type="button" data-dpi="1600">1600</button>
-            <button type="button" data-dpi="3200">3200</button>
-          </div>
-        </article>
+      <section id="panel-performance" class="panel">
+        <div class="settings-stack">
+          <article class="setting-card">
+            <div class="setting-heading">
+              <div><p>DPI</p><h2>Sensitivity</h2></div>
+              <div class="dpi-heading-right">
+                <span id="dpi-display" class="dpi-large">${fmtDpi(pendingDpi)}</span>
+                <button class="custom-btn" type="button" id="custom-dpi-btn" disabled>Custom</button>
+              </div>
+            </div>
+            <div class="dpi-grid" id="dpi-grid" aria-label="DPI presets">
+              ${DPI_PRESETS.map((dpi) =>
+                `<button type="button" data-dpi="${dpi}" class="${dpi === pendingDpi ? "selected" : ""}">${dpi.toLocaleString()}</button>`,
+              ).join("")}
+            </div>
+            <small id="dpi-note" class="setting-note">Current ${fmtDpi(appliedDpi)}</small>
+          </article>
 
-        <article class="setting-card">
-          <div class="setting-heading">
-            <div><p>POLLING RATE</p><h2>Report frequency</h2></div>
-            <span class="info">?</span>
-          </div>
-          <div class="segmented" data-control="polling">
-            <button type="button">125</button>
-            <button type="button">500</button>
-            <button class="selected" type="button">1000</button>
-            <button type="button">2000</button>
-          </div>
-          <small class="setting-note">Higher rates can use more battery.</small>
-        </article>
-
-        <article class="setting-card">
-          <div class="setting-heading">
-            <div><p>SENSOR</p><h2>Lift-off distance</h2></div>
-          </div>
-          <div class="segmented two" data-control="lift">
-            <button class="selected" type="button">Low</button>
-            <button type="button">High</button>
-          </div>
-          <label class="toggle-row">
-            <span><strong>Motion sync</strong><small>Align sensor data with USB reports.</small></span>
-            <input type="checkbox" checked />
-            <i aria-hidden="true"></i>
-          </label>
-        </article>
+          <article class="setting-card">
+            <div class="setting-heading">
+              <div><p>POLLING RATE</p><h2>Report frequency</h2></div>
+            </div>
+            <div class="polling-wrap">
+              <input id="polling-range" type="range" min="0" max="3" step="1" value="${POLLING_VALUES.indexOf(appliedPolling)}" class="polling-range" aria-label="Polling rate" />
+              <div class="polling-ticks" aria-hidden="true">
+                <span>125</span><span>250</span><span>500</span><span>1K</span>
+              </div>
+            </div>
+            <small class="setting-note">Stored in this mouse's onboard profile — OpenMouse writes it there.</small>
+          </article>
+        </div>
       </section>
 
       <footer class="panel-footer">
-        <span id="save-status">Preview settings have not been saved.</span>
-        <button id="save-button" type="button">Save changes</button>
+        <div class="footer-status">
+          <span id="pending-label">No pending changes</span>
+          <small id="pending-sub">Adjust a setting to preview it before writing.</small>
+        </div>
+        <div class="footer-actions">
+          <button id="revert-btn" type="button" class="revert-btn" disabled>↩ Revert</button>
+          <button id="apply-btn" type="button" class="apply-btn" disabled>⚡ Apply changes</button>
+        </div>
       </footer>
     </main>
   </div>
 `;
 
-const dpiRange = document.querySelector<HTMLInputElement>("#dpi-range");
-const dpiOutput = document.querySelector<HTMLOutputElement>("#dpi-output");
-const dpiButtons = document.querySelectorAll<HTMLButtonElement>("[data-dpi]");
-const segmentedControls = document.querySelectorAll<HTMLElement>(".segmented");
-const saveButton = document.querySelector<HTMLButtonElement>("#save-button");
-const saveStatus = document.querySelector<HTMLSpanElement>("#save-status");
-const previewMessage = document.querySelector<HTMLParagraphElement>("#preview-message");
-const navItems = document.querySelectorAll<HTMLButtonElement>(".nav-item");
+// Tab switching
+const tabBtns = document.querySelectorAll<HTMLButtonElement>(".tab-btn");
 
-function markChanged(): void {
-  if (saveStatus) saveStatus.textContent = "Preview settings have unsaved changes.";
-}
-
-function setDpi(value: number): void {
-  if (!dpiRange || !dpiOutput) return;
-  dpiRange.value = String(value);
-  dpiOutput.value = `${value} DPI`;
-  dpiButtons.forEach((button) => button.classList.toggle("selected", Number(button.dataset.dpi) === value));
-}
-
-dpiRange?.addEventListener("input", () => {
-  setDpi(Number(dpiRange.value));
-  markChanged();
-});
-dpiButtons.forEach((button) => button.addEventListener("click", () => {
-  setDpi(Number(button.dataset.dpi));
-  markChanged();
-}));
-
-segmentedControls.forEach((control) => {
-  control.querySelectorAll("button").forEach((button) => {
-    button.addEventListener("click", () => {
-      control.querySelectorAll("button").forEach((item) => item.classList.remove("selected"));
-      button.classList.add("selected");
-      markChanged();
-    });
-  });
-});
-
-saveButton?.addEventListener("click", () => {
-  if (!saveStatus || !saveButton) return;
-  try {
-    localStorage.setItem(DEMO_SETTINGS_KEY, JSON.stringify({
-      dpi: Number(dpiRange?.value ?? 1600),
-      polling: document.querySelector('[data-control="polling"] .selected')?.textContent?.trim(),
-      lift: document.querySelector('[data-control="lift"] .selected')?.textContent?.trim(),
-      motionSync: document.querySelector<HTMLInputElement>(".toggle-row input")?.checked,
-    }));
-  } catch {
-    saveStatus.textContent = "Settings could not be stored in this browser.";
-    return;
+function showTab(tabId: string): void {
+  tabBtns.forEach((btn) => btn.classList.toggle("active", btn.dataset.tab === tabId));
+  const overview = document.getElementById("panel-overview");
+  const performance = document.getElementById("panel-performance");
+  if (overview) overview.hidden = tabId !== "overview";
+  if (performance) performance.hidden = tabId !== "performance";
+  const msg = document.querySelector<HTMLElement>("#preview-message");
+  if (msg) {
+    msg.textContent = tabId === "overview"
+      ? "This demo shows a simulated device status — no real connection."
+      : "This demo does not connect to or change a real device.";
   }
-  saveButton.textContent = "Saved";
-  saveStatus.textContent = "Demo settings saved in this browser.";
-  window.setTimeout(() => {
-    saveButton.textContent = "Save changes";
-  }, 1600);
+}
+
+tabBtns.forEach((btn) => {
+  if (!btn.disabled) {
+    btn.addEventListener("click", () => showTab(btn.dataset.tab ?? "performance"));
+  }
 });
 
-document.querySelector<HTMLInputElement>(".toggle-row input")?.addEventListener("change", markChanged);
+// Pending state
+function hasPendingChanges(): boolean {
+  return pendingDpi !== appliedDpi || pendingPolling !== appliedPolling;
+}
 
-navItems.forEach((item) => {
-  item.addEventListener("click", () => {
-    navItems.forEach((navItem) => {
-      const isActive = navItem === item;
-      navItem.classList.toggle("active", isActive);
-      navItem.setAttribute("aria-pressed", String(isActive));
-    });
-    const plannedPanel = item.dataset.panel === "buttons" || item.dataset.panel === "profiles";
-    const target = item.dataset.panel === "overview"
-      ? document.querySelector(".device-overview")
-      : document.querySelector(".settings-grid");
-    target?.scrollIntoView({ behavior: "smooth", block: "start" });
-    if (previewMessage) {
-      previewMessage.textContent = plannedPanel
-        ? `${item.textContent} controls are planned for a future device profile.`
-        : "This demo does not connect to or change a real device.";
-    }
+function updatePendingState(): void {
+  const hasChanges = hasPendingChanges();
+  const pendingLabel = document.getElementById("pending-label");
+  const pendingSub = document.getElementById("pending-sub");
+  const revertBtn = document.getElementById("revert-btn") as HTMLButtonElement | null;
+  const applyBtn = document.getElementById("apply-btn") as HTMLButtonElement | null;
+  if (pendingLabel) pendingLabel.textContent = hasChanges ? "Pending changes" : "No pending changes";
+  if (pendingSub) {
+    pendingSub.textContent = hasChanges
+      ? "Preview is active — click Apply to write settings."
+      : "Adjust a setting to preview it before writing.";
+  }
+  if (revertBtn) revertBtn.disabled = !hasChanges;
+  if (applyBtn) applyBtn.disabled = !hasChanges;
+}
+
+// DPI controls
+const dpiGrid = document.getElementById("dpi-grid");
+const dpiDisplay = document.getElementById("dpi-display");
+const dpiNote = document.getElementById("dpi-note");
+
+function setDpi(dpi: number): void {
+  pendingDpi = dpi;
+  if (dpiDisplay) dpiDisplay.textContent = fmtDpi(dpi);
+  dpiGrid?.querySelectorAll<HTMLButtonElement>("[data-dpi]").forEach((btn) => {
+    btn.classList.toggle("selected", Number(btn.dataset.dpi) === dpi);
   });
+  updatePendingState();
+}
+
+dpiGrid?.querySelectorAll<HTMLButtonElement>("[data-dpi]").forEach((btn) => {
+  btn.addEventListener("click", () => setDpi(Number(btn.dataset.dpi)));
+});
+
+// Polling slider
+const pollingRange = document.querySelector<HTMLInputElement>("#polling-range");
+
+pollingRange?.addEventListener("input", () => {
+  pendingPolling = POLLING_VALUES[Number(pollingRange.value)];
+  updatePendingState();
+});
+
+// Apply / Revert
+const applyBtn = document.getElementById("apply-btn") as HTMLButtonElement | null;
+const revertBtn = document.getElementById("revert-btn") as HTMLButtonElement | null;
+const statusText = document.getElementById("status-text");
+
+applyBtn?.addEventListener("click", () => {
+  if (!hasPendingChanges() || !applyBtn) return;
+  appliedDpi = pendingDpi;
+  appliedPolling = pendingPolling;
+  if (dpiNote) dpiNote.textContent = `Current ${fmtDpi(appliedDpi)}`;
+  if (statusText) statusText.textContent = `Current: ${fmtDpi(appliedDpi)} · ${fmtHz(appliedPolling)}`;
+  try {
+    localStorage.setItem(DEMO_SETTINGS_KEY, JSON.stringify({ dpi: appliedDpi, polling: appliedPolling }));
+  } catch { /* ignore */ }
+  applyBtn.textContent = "Applied!";
+  window.setTimeout(() => { applyBtn.textContent = "⚡ Apply changes"; }, 1600);
+  updatePendingState();
+});
+
+revertBtn?.addEventListener("click", () => {
+  pendingDpi = appliedDpi;
+  pendingPolling = appliedPolling;
+  setDpi(appliedDpi);
+  if (pollingRange) pollingRange.value = String(POLLING_VALUES.indexOf(appliedPolling));
+  updatePendingState();
 });


### PR DESCRIPTION
## Summary

### Demo rework (`demo.ts`, `demo.css`, `demo.html`)
The demo was using an older sidebar-navigation layout. Replaced with the current control panel UI:

- **Tab bar** at the top (Overview, Performance active; Lighting / Buttons / Profiles / Advanced shown as disabled/planned)
- **Sidebar**: Discord + X icons, SELECTED DEVICE section, CONNECTED DEVICES list, Interface settings + Mouse Check links, build version footer
- **Status bar**: `• Current: 1,600 DPI · 1K Hz`
- **DPI**: 3-column button grid (was: range slider)
- **Polling rate**: slider with 125 / 250 / 500 / 1K tick labels (was: segmented buttons)
- **Footer**: "No pending changes" → Revert + ⚡ Apply changes flow, persisted to `localStorage`
- `demo.html`: SVG favicon added, favicon link order normalized

### Discord webhook report (`control.ts`)
Adds a webhook URL input below the live status footer. Visible only when a device is connected (`.device-data` CSS class). Posting sends current DPI, polling rate, battery, firmware, connection info, OS, and browser as a formatted code block.

- URL saved to `localStorage` key `om-discord-webhook` — never hardcoded, never committed
- Same key as Mouse Check so the URL is shared between both apps

### Accent themes — 13 new (`control.ts`)
Adds gradient support via a new `--ui-accent-end` CSS variable (defaults to `--ui-accent` for full backward compatibility with existing themes). Active buttons, DPI selection buttons, and theme preview pills now render `linear-gradient(135deg, --ui-accent, --ui-accent-end)`.

**Solid themes added:** Miku · Catppuccin Mocha · Catppuccin Macchiato · Catppuccin Frappé

**Gradient themes added:** Berry Frost · Aurora Dust · Neon Pulse · Ocean Rose · Solar Pop · Lime Crush · Sunrise Sorbet · Cyber Bloom · Mint Eclipse

Toggle switch dot color updated from hardcoded `#07120b` to `var(--ui-accent-ink)` so it stays readable across all themes.

### OS detection (`control.ts`)
Adds `detectOs()` — prefers `navigator.userAgentData.platform` (modern API), falls back to UA regex. Returns `Windows` / `macOS` / `Linux` / `ChromeOS` / `Unknown OS`. Used in two places:

- **Linux connection error**: when WebHID returns "Failed to open the device" on Linux, replaces the generic error with an actionable message including the udev command to fix it
- **Discord report**: last line now includes `OS: Linux | Chrome/x.x.x` for easier support

### Linux WebHID fix (`control.ts`)
When `detectOs() === "Linux"` and the device open fails, shows:
```
Failed to open the device. On Linux, WebHID needs a udev rule — run:
echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/99-openmouse.rules && sudo udevadm control --reload-rules && sudo udevadm trigger — then replug your mouse.
```
Uses a generic `SUBSYSTEM=="hidraw"` rule (not vendor-specific) so it works across all supported brands.

### `control-app.html`
Favicon link order normalized to match `demo.html`.

---

## Test plan

- [ ] `/demo.html` — Performance tab shows DPI grid + polling slider; Overview tab shows mouse image + stats
- [ ] Change DPI or polling → pending state activates → Apply writes to `localStorage` → status bar updates
- [ ] Revert resets to last applied state
- [ ] `/control-app` with a supported mouse connected → Discord webhook row appears below the live status footer
- [ ] Paste a valid Discord webhook URL → Send to Discord posts a formatted report including OS + browser line
- [ ] Interface settings → Accent theme dropdown shows all 18 options; gradient themes render gradient on buttons and preview pills
- [ ] On Linux: connect with a non-permitted device → error message shows udev command

🤖 Generated with [Claude Code](https://claude.com/claude-code)