### PR TITLE
Prevent overlapping HID++ clients from corrupting feature resolution

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -187,6 +187,10 @@ let lastDiagnosticCommand: string | null = null;
 let lastDiagnosticError: string | null = null;
 /** Prevents overlapping reconnect loops from leaving the UI stuck on "Reconnecting…". */
 let reconnectInFlight = false;
+/** True while a device activation is mid-flight, so refreshes and connects queue instead of racing it. */
+let activationInProgress = false;
+/** Serializes device activation so two clients never open the same HID device at once. */
+let activationQueue: Promise<void> = Promise.resolve();
 let sidebarHidden = false;
 
 async function statusAfterWrite(client: SupportedClient): Promise<MouseStatus> {
@@ -1905,7 +1909,25 @@ function statusNameForClient(client: SupportedClient): string {
   return client.device.productName || "the selected mouse";
 }
 
-async function activateClient(client: SupportedClient): Promise<void> {
+async function activateClientNow(client: SupportedClient): Promise<void> {
+  // A refresh that started before this activation may still be reading the
+  // device this activation is about to take over. Let it drain first so the
+  // two HID++ request streams cannot consume each other's replies.
+  while (refreshInProgress) {
+    await new Promise<void>((resolve) => window.setTimeout(resolve, 25));
+  }
+  // Only one client may stay open on a receiver at a time. HID++ replies carry
+  // no request identity, so two open clients on the same device answer each
+  // other's pending probes and corrupt the resolved feature indices (surfacing
+  // as "does not expose DPI/report-rate controls").
+  for (const previous of [
+    activeClient, activePulsarClient, activeEggClient, activeEggWeClient,
+    activeFinalmouseClient, activeDmClient, activeOrbitalClient, activeRazerClient,
+    activeViperClient, activeTeevolutionClient, activeVgnClient, activeKeychronClient,
+    activeModdoClient,
+  ]) {
+    if (previous && previous !== client) await previous.close().catch(() => undefined);
+  }
   resetDeviceSpecificPanels();
   // Staged changes belong to the mouse they were made on.
   clearPendingChanges();
@@ -2037,6 +2059,24 @@ async function activateClient(client: SupportedClient): Promise<void> {
   setConnectionButtons(false, "Add device");
 }
 
+/**
+ * Serializes activation: the browser can fire a connect event while a reconnect
+ * loop is already opening a client, and two activations would each open the
+ * same receiver at once (see the close loop in activateClientNow).
+ */
+function activateClient(client: SupportedClient): Promise<void> {
+  const run = activationQueue.then(async () => {
+    activationInProgress = true;
+    try {
+      await activateClientNow(client);
+    } finally {
+      activationInProgress = false;
+    }
+  });
+  activationQueue = run.then(() => undefined, () => undefined);
+  return run;
+}
+
 function showDisconnectedState(): void {
   if (refreshTimer !== null) {
     window.clearInterval(refreshTimer);
@@ -2074,6 +2114,14 @@ function showDisconnectedState(): void {
 }
 
 function handleHidConnect(event: HIDConnectionEvent): void {
+  // Reconnect paths can re-fire connect for the device that is already active.
+  // Re-activating would close and reopen the same receiver for nothing; worse,
+  // two clients on one receiver interleave their HID++ probes and corrupt each
+  // other's feature resolution, so skip unless this is a new device.
+  if (activeDevice === event.device) {
+    void renderDeviceSidebar();
+    return;
+  }
   const client = createSupportedClient(event.device);
   if (!client) {
     void renderDeviceSidebar();
@@ -4020,7 +4068,7 @@ function startAutomaticRefresh(): void {
 
 async function refreshStatus(): Promise<void> {
   const client = activeSettingsClient();
-  if (!client || refreshInProgress || settingInProgress) return;
+  if (!client || refreshInProgress || settingInProgress || activationInProgress) return;
   if ("pollIntervalMs" in client && Number((client as { pollIntervalMs: number }).pollIntervalMs) <= 0) {
     return;
   }


### PR DESCRIPTION
## Problem

Logitech HID++ mice over a receiver (reproduced with a G502 X HEAT) intermittently failed to apply settings:

- `Set DPI` → "This mouse does not expose DPI controls."
- `Set polling rate` → "This mouse does not expose report-rate controls."
- Background refreshes → "The mouse rejected that setting (invalid function)."

WebHID tracing showed every feature probe being issued twice, interleaved — two HID++ clients open on the same receiver at once. HID++ replies carry no request identity, so a reply to one client's `getFeature` probe resolves the *other* client's pending probe. That corrupts the surviving client's cached feature indices — e.g. `0x2202` resolved to index 7 (the reply for legacy `0x2201`), so the driver called extended-DPI function `0x50` on a legacy feature and got an invalid-function error.

## Root cause

`handleHidConnect` and the reconnect loop could both call `activateClient` concurrently, and `activateClient` never closed the previously active client. Both clients stayed open on the same receiver and consumed each other's replies.

## Fix

- `activateClient` now closes the previously active client before the replacement opens its device, so only one client stays open per receiver.
- Activations are serialized through a queue so connect events and the reconnect loop cannot run two activations at once.
- `handleHidConnect` ignores connect events for the device that is already active.
- `refreshStatus` skips while an activation is in flight, and activation waits for an in-flight refresh to drain, keeping a single HID++ request stream per device.

## Verification

- G502 X HEAT hardware test: DPI 8000 and 125 Hz polling now apply; background refreshes no longer throw.
- All 35 unit tests pass.

No behavior change for other drivers; the close/serialize logic only ever fires on device switches.