### PR TITLE
Fix the tab nav dropping below the MX Master cards on Advanced

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -208,7 +208,7 @@ function Workspace({
 
       {showLogitechDetails ? <LogitechDetails snapshot={snapshot} /> : null}
       {showMxMaster ? (
-        <section className="settings-grid device-data" data-workspace-host role="tabpanel" aria-label="MX Master settings">
+        <section id="logitech-mx-master-settings" className="settings-grid device-data" data-workspace-host role="tabpanel" aria-label="MX Master settings">
           <MxMasterCards snapshot={snapshot} />
         </section>
       ) : null}

--- a/src/control.css
+++ b/src/control.css
@@ -1058,6 +1058,10 @@ body { height: 100vh; overflow: hidden; }
 #performance-settings { order: 3; }
 #lighting-settings { order: 4; }
 #logitech-onboard { order: 5; }
+/* The MX Master feature cards are the primary Advanced-tab content; without an
+   order they fall to 0 and render above the sticky tab nav (order 1), pushing
+   it into the middle of the page. Place them just before Device details. */
+#logitech-mx-master-settings { order: 5; }
 #logitech-device-details { order: 6; }
 #logitech-analog-button-settings { order: 7; }
 #pulsar-advanced { order: 8; }


### PR DESCRIPTION
On a Logitech MX Master, the Advanced tab renders its tab-bar nav **in the
middle of the page**, below the Haptics / MagSpeed / Friendly name / Easy-Switch
cards instead of above them. On a tab tall enough to scroll, that parks the nav
off the top of the viewport, so it looks like the navigation has disappeared and
there is no way back to the other tabs.

## Cause

The panel layout places every workspace section with a per-id flex `order`
(`#performance-settings` order 3, `#lighting-settings` 4, `#logitech-onboard` 5,
`#logitech-device-details` 6, … the sticky tab nav is order 1). The MX Master
settings section is the **one panel with no id**, so it fell to the default
`order: 0` and rendered ahead of the nav.

## Fix

Give that section an id (`logitech-mx-master-settings`) and an `order` (5, just
before Device details), matching how every sibling panel is already positioned.
Two lines; no behaviour change beyond the nav returning to the top.

## Scope

Independent of any device protocol — pure layout. Pre-existing on `dev`: the MX
Master card group is a `<section>` from #82, and the id-based ordering that the
rest of the panels use was never applied to it.

## Testing

- `npm run check` green.
- Confirmed on hardware (MX Master 4): the Advanced tab's nav renders at the
  top, above Haptics, with the four cards below it, then Device details and
  Diagnostics in their existing order.
