### PR TITLE
Add Keychron Nape Pro auto-sleep controls

### DIFF
--- a/src/app/cards/AdvancedCards.tsx
+++ b/src/app/cards/AdvancedCards.tsx
@@ -9,11 +9,94 @@ import {
 import { teevolutionSensorModeUi } from "@openmouse/protocol/teevolution";
 import * as control from "../../device/controller";
 import { PULSAR_SLEEP_OPTIONS } from "../../device/controller";
-import { selectableValues, sleepLabel } from "../../device/options";
+import { selectableValues, sleepLabel, sleepParts, sleepTotalSeconds, KEYCHRON_SLEEP_MAX_HOURS, KEYCHRON_SLEEP_MAX_SECONDS, KEYCHRON_SLEEP_MIN_SECONDS } from "../../device/options";
 import type { ControlSnapshot } from "../../device/types";
 import { Collapsible, Segmented, SwitchRow } from "../ui";
 
 const SIGNAL_WORDS = ["Very weak", "Weak", "Fair", "Good", "Excellent"];
+
+function KeychronSleepPicker({
+  sleepTimeout,
+  disabled,
+}: {
+  sleepTimeout: number;
+  disabled: boolean;
+}): ReactNode {
+  const synced = sleepParts(sleepTimeout);
+  const [hours, setHours] = useState(synced.hours);
+  const [minutes, setMinutes] = useState(synced.minutes);
+  const [seconds, setSeconds] = useState(synced.seconds);
+
+  useEffect(() => {
+    const next = sleepParts(sleepTimeout);
+    setHours(next.hours);
+    setMinutes(next.minutes);
+    setSeconds(next.seconds);
+  }, [sleepTimeout]);
+
+  const total = sleepTotalSeconds(hours, minutes, seconds);
+  const dirty = total !== sleepTimeout;
+
+  function commit(): void {
+    if (disabled || !dirty) return;
+    if (total < KEYCHRON_SLEEP_MIN_SECONDS) {
+      control.reportStatus("The sleep time cannot be less than 1 minute.");
+      return;
+    }
+    if (total > KEYCHRON_SLEEP_MAX_SECONDS) return;
+    control.applyPulsarValue("sleep", total);
+  }
+
+  function bind(
+    value: number,
+    setValue: (next: number) => void,
+    max: number,
+  ) {
+    return {
+      value,
+      disabled,
+      min: 0,
+      max,
+      inputMode: "numeric" as const,
+      onChange: (event: { currentTarget: HTMLInputElement }) => {
+        const raw = event.currentTarget.value;
+        if (raw === "") {
+          setValue(0);
+          return;
+        }
+        const next = Number(raw);
+        if (!Number.isInteger(next)) return;
+        setValue(Math.min(max, Math.max(0, next)));
+      },
+      onBlur: () => commit(),
+      onKeyDown: (event: { key: string; preventDefault: () => void }) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          commit();
+        }
+      },
+    };
+  }
+
+  return (
+    <div className="sleep-time-picker" role="group" aria-label="Auto sleep timeout">
+      <label>
+        <input id="sleep-hours" type="number" aria-label="Hours" {...bind(hours, setHours, KEYCHRON_SLEEP_MAX_HOURS)} />
+        <span>h</span>
+      </label>
+      <span className="sleep-time-sep" aria-hidden="true">:</span>
+      <label>
+        <input id="sleep-minutes" type="number" aria-label="Minutes" {...bind(minutes, setMinutes, 59)} />
+        <span>m</span>
+      </label>
+      <span className="sleep-time-sep" aria-hidden="true">:</span>
+      <label>
+        <input id="sleep-seconds" type="number" aria-label="Seconds" {...bind(seconds, setSeconds, 59)} />
+        <span>s</span>
+      </label>
+    </div>
+  );
+}
 
 export function SignalCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNode {
   const strength = snapshot.status?.signalStrength;
@@ -57,12 +140,14 @@ export function SleepCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNod
   const status = snapshot.status;
   if (!status) return null;
   const { traits, capabilities } = snapshot;
+  const keychronSleep = status.ui?.family === "keychron-nape";
 
   let options: ReadonlyArray<readonly [number, string]> = PULSAR_SLEEP_OPTIONS;
-  if (traits.directMode) {
-    const seconds = capabilities?.sleepOptions ?? [10, 30, 60, 300, 600, 1800];
+  if (!keychronSleep && traits.directMode) {
+    const offered = capabilities?.sleepOptions ?? [10, 30, 60, 300, 600, 1800];
+    const seconds = selectableValues(offered, status.sleepTimeout) ?? offered;
     options = seconds.map((value) => [value, sleepLabel(value)] as const);
-  } else if (capabilities?.razerSleepOptions != null) {
+  } else if (!keychronSleep && capabilities?.razerSleepOptions != null) {
     // Seconds throughout — sleepLabel, the staged command text and
     // setSleepTimeout all read seconds, which Pulsar's option values are not.
     // Sleep and low power are Viper V3 protocol; the legacy Viper Mini driver
@@ -70,7 +155,7 @@ export function SleepCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNod
     const seconds = selectableValues(capabilities.razerSleepOptions, status.sleepTimeout);
     if (seconds === null) return null;
     options = seconds.map((value) => [value, sleepLabel(value)] as const);
-  } else if (traits.teevolution && capabilities?.teevolutionProfile && status.connectionType) {
+  } else if (!keychronSleep && traits.teevolution && capabilities?.teevolutionProfile && status.connectionType) {
     options = capabilities.teevolutionProfile.sleepOptions.map(
       (value) => [value, sleepLabel(value * 10)] as const,
     );
@@ -100,14 +185,21 @@ export function SleepCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNod
           </button>
         ) : null}
       </div>
-      <select
-        id="sleep-select"
-        value={status.sleepTimeout ?? ""}
-        disabled={!asleep}
-        onChange={(event) => control.applyPulsarValue("sleep", Number(event.currentTarget.value))}
-      >
-        {options.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
-      </select>
+      {keychronSleep && asleep ? (
+        <KeychronSleepPicker
+          sleepTimeout={status.sleepTimeout!}
+          disabled={snapshot.settingsPending}
+        />
+      ) : (
+        <select
+          id="sleep-select"
+          value={status.sleepTimeout ?? ""}
+          disabled={!asleep}
+          onChange={(event) => control.applyPulsarValue("sleep", Number(event.currentTarget.value))}
+        >
+          {options.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+        </select>
+      )}
     </article>
   );
 }

--- a/src/app/cards/availability.test.ts
+++ b/src/app/cards/availability.test.ts
@@ -85,6 +85,20 @@ test("Pulsar keeps the shared advanced cards", () => {
   assert.equal(has.eggFilter, false);
 });
 
+test("Keychron Nape Pro gets Auto sleep without debounce or signal", () => {
+  const has = cardAvailability(snapshot({
+    status: {
+      brand: "Keychron",
+      ui: { family: "keychron-nape", showAdvancedSection: true },
+      sleepTimeout: 600,
+    },
+  }));
+  assert.equal(has.advancedHost, true);
+  assert.equal(has.sleep, true);
+  assert.equal(has.debounce, false);
+  assert.equal(has.signal, false);
+});
+
 test("a driver may opt into the advanced section and still suppress its cards", () => {
   const has = cardAvailability(snapshot({
     status: {

--- a/src/control-devices.css
+++ b/src/control-devices.css
@@ -5,6 +5,12 @@
 #pulsar-advanced input[type="number"]:focus, #pulsar-advanced select:focus { border-color: var(--faint); box-shadow: 0 0 0 2px rgb(255 255 255 / 4%); }
 #pulsar-advanced input:disabled, #pulsar-advanced select:disabled { cursor: not-allowed; opacity: .45; }
 #pulsar-advanced input[type="checkbox"] { width: .85rem; height: .85rem; margin: 0; accent-color: var(--ui-accent); }
+#pulsar-advanced .sleep-time-picker { display: flex; align-items: start; gap: .35rem; margin-top: .35rem; }
+#pulsar-advanced .sleep-time-picker label { display: grid; gap: .2rem; min-width: 0; flex: 1 1 0; color: var(--faint); font-size: .58rem; text-align: center; }
+#pulsar-advanced .sleep-time-picker input[type="number"] { width: 100%; margin-top: 0; padding: .48rem .35rem; text-align: center; font-variant-numeric: tabular-nums; appearance: textfield; -moz-appearance: textfield; }
+#pulsar-advanced .sleep-time-picker input[type="number"]::-webkit-outer-spin-button,
+#pulsar-advanced .sleep-time-picker input[type="number"]::-webkit-inner-spin-button { margin: 0; appearance: none; }
+#pulsar-advanced .sleep-time-sep { flex: 0 0 auto; padding-top: .48rem; color: var(--muted); font-size: .9rem; line-height: 1.2; }
 
 #pulsar-advanced.egg-advanced-layout { grid-template-columns: repeat(3, minmax(0, 1fr)) !important; gap: .55rem !important; }
 #pulsar-advanced.egg-advanced-layout > .setting-card { min-height: 0 !important; padding: .72rem !important; }

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -165,6 +165,7 @@ const teevolutionClient = (): TeevolutionHidClient | null => activeAs(Teevolutio
 const finalmouseClient = (): FinalmouseHidClient | null => activeAs(FinalmouseHidClient);
 const orbitalClient = (): OrbitalHidClient | null => activeAs(OrbitalHidClient);
 const vgnClient = (): VgnF2HidClient | null => activeAs(VgnF2HidClient);
+const keychronClient = (): KeychronHidClient | null => activeAs(KeychronHidClient);
 /** Pulsar is the fallback: any supported client no dedicated driver claims. */
 const pulsarClient = (): PulsarClient | null =>
   active !== null && !isEggWeClient(active) && !DEDICATED.some((cls) => active instanceof cls)
@@ -365,6 +366,10 @@ function setReadStatus(text: string): void {
   emit();
 }
 
+export function reportStatus(text: string): void {
+  setReadStatus(text);
+}
+
 function setOnboardStatus(text: string): void {
   onboardStatus = text;
   emit();
@@ -401,9 +406,14 @@ function requireClientMethod<K extends string>(
 function readCapabilities(): DeviceCapabilities {
   const razer = activeAs<RazerHidClient>(RazerHidClient);
   const dm = dmClient();
+  const keychron = keychronClient();
   return {
     canDisableSleep: dm?.canDisableSleep === true,
-    sleepOptions: dm ? [...dm.getSleepOptions()] : null,
+    sleepOptions: dm
+      ? [...dm.getSleepOptions()]
+      : keychron
+        ? [...keychron.getSleepOptions()]
+        : null,
     debounceMaxMs: dm?.getDebounceMaxMs() ?? null,
     razerSleepOptions: razer?.getSleepOptions() ?? null,
     razerLowPowerOptions: razer?.getLowPowerOptions() ?? null,
@@ -1159,7 +1169,11 @@ async function activateClientNow(client: SupportedClient): Promise<void> {
     const status = await client.readStatus();
     dpiOptions = await client.getDpiOptions();
     const dm = dmClient();
+    const keychron = keychronClient();
     if (dm) lastSleepSeconds = status.sleepTimeout ?? dm.getSleepOptions()[0] ?? 60;
+    else if (keychron) {
+      lastSleepSeconds = status.sleepTimeout ?? keychron.getSleepOptions()[0] ?? 60;
+    }
     deviceStatuses.set(client.device, status);
     capabilities = readCapabilities();
     applyStatus(status);
@@ -2242,7 +2256,7 @@ export function applyPulsarToggle(setting: PulsarToggleSetting, enabled: boolean
 
 export function applyPulsarValue(setting: "debounce" | "sleep", value: number): void {
   if (!(pulsarClient() ?? dmClient() ?? orbitalClient() ?? razerClient()
-    ?? viperClient() ?? teevolutionClient() ?? vgnClient())) return;
+    ?? viperClient() ?? teevolutionClient() ?? vgnClient() ?? keychronClient())) return;
   const asleep = value !== WLMOUSE_SLEEP_NEVER;
   stageChange({
     key: setting,

--- a/src/device/options.ts
+++ b/src/device/options.ts
@@ -1,7 +1,38 @@
 export function sleepLabel(seconds: number): string {
   if (seconds < 60) return `${seconds} seconds`;
-  const minutes = seconds / 60;
-  return minutes === 1 ? "1 minute" : `${minutes} minutes`;
+  if (seconds % 3600 === 0) {
+    const hours = seconds / 3600;
+    return hours === 1 ? "1 hour" : `${hours} hours`;
+  }
+  if (seconds % 60 === 0) {
+    const minutes = seconds / 60;
+    return minutes === 1 ? "1 minute" : `${minutes} minutes`;
+  }
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const rest = seconds % 60;
+  const parts: string[] = [];
+  if (hours) parts.push(hours === 1 ? "1 hour" : `${hours} hours`);
+  if (minutes) parts.push(minutes === 1 ? "1 minute" : `${minutes} minutes`);
+  if (rest) parts.push(`${rest} seconds`);
+  return parts.join(" ");
+}
+
+export const KEYCHRON_SLEEP_MAX_HOURS = 12;
+export const KEYCHRON_SLEEP_MIN_SECONDS = 60;
+export const KEYCHRON_SLEEP_MAX_SECONDS = KEYCHRON_SLEEP_MAX_HOURS * 3600 + 59 * 60 + 59;
+
+export function sleepParts(totalSeconds: number): { hours: number; minutes: number; seconds: number } {
+  const clamped = Math.max(0, Math.floor(totalSeconds));
+  return {
+    hours: Math.floor(clamped / 3600),
+    minutes: Math.floor((clamped % 3600) / 60),
+    seconds: clamped % 60,
+  };
+}
+
+export function sleepTotalSeconds(hours: number, minutes: number, seconds: number): number {
+  return hours * 3600 + minutes * 60 + seconds;
 }
 
 export function selectableValues(offered: number[], current: number | null | undefined): number[] | null {

--- a/src/device/traits.ts
+++ b/src/device/traits.ts
@@ -44,6 +44,7 @@ const BY_FAMILY: Readonly<Record<string, Partial<DriverTraits>>> = {
   crdrako: DIRECT_MODE,
   atk: DIRECT_MODE,
   ninjutso: { ...DIRECT_MODE, ninjutso: true },
+  "keychron-nape": { advancedSection: true, sleep: true, directMode: true },
 };
 
 const BY_BRAND: Readonly<Record<string, string>> = {

--- a/src/preview-fixtures.ts
+++ b/src/preview-fixtures.ts
@@ -492,6 +492,7 @@ const KEYCHRON: MouseStatus = {
     hideUnsupportedPollingRates: true,
     hideProcessingCard: true,
     forceShowBattery: true,
+    showAdvancedSection: true,
     pollingNote: "Nape Pro exposes polling through Keychron's misc HID commands when the firmware allows it.",
   },
   batteryPercent: 76,
@@ -504,6 +505,7 @@ const KEYCHRON: MouseStatus = {
   connectionDetail: "Wired USB · 90° orientation · DPI stage 2/5",
   liftOffDistance: null,
   supportedLiftOffDistances: [],
+  sleepTimeout: 600,
   firmware: ["v1.0.4"],
 };
 


### PR DESCRIPTION
## Summary
- Enable Advanced sleep for `keychron-nape` with a Launcher-style h:m:s picker (not the preset dropdown used by other mice).
- Wire Keychron sleep through capabilities / `applyPulsarValue`, and surface under-1-minute errors in the status bar.
- Update the Keychron preview fixture so Advanced + sleep show in `?preview=keychron`.

Depends on the matching mouse-protocol sleep PR (Nape Pro get/set sleep APIs).