### PR TITLE
fix: resolve Viper Mini and Cobra artwork in preview mode

### DIFF
--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -20,6 +20,8 @@ test("fixture previews resolve product art without a HID device", () => {
   assert.equal(deviceImage(null, "CRDRAKO KO-ONE"), "/devices/crdrako-ko-one.png");
   assert.equal(deviceImage(null, "Zaunkoenig M3K"), "/devices/zaunkoenig-m3k.png");
   assert.equal(deviceImage(null, "Zaunkoenig M2K"), "/devices/zaunkoenig-m3k.png");
+  assert.equal(deviceImage(null, "Viper Mini"), "/devices/razer-viper-mini.webp");
+  assert.equal(deviceImage(null, "Cobra"), "/devices/razer-cobra.webp");
 });
 
 test("Attack Shark R5 Ultra wired and wireless share the same artwork", () => {

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -83,6 +83,8 @@ export function deviceImage(device: HIDDevice | null | undefined, displayName = 
   if (/superlight/i.test(displayName)) return "/devices/logitech-pro-x-superlight-2c.png";
   if (/\bop1\b/i.test(displayName)) return "/devices/endgame-gear-op1-8k.png";
   if (/\bviper\s*v2\s*pro\b/i.test(displayName)) return "/devices/razer-viper-v2-pro.png";
+  if (/\bviper\s*mini\b/i.test(displayName)) return "/devices/razer-viper-mini.webp";
+  if (/\bcobra\b/i.test(displayName)) return "/devices/razer-cobra.webp";
   if (/\bnape\s*pro\b/i.test(displayName)) return "/devices/keychron-nape-pro.png";
   if (/\bko-one\b/i.test(displayName)) return "/devices/crdrako-ko-one.png";
   if (/\br5\s*ultra\b/i.test(displayName)) return "/devices/attackshark-r5-ultra.png";


### PR DESCRIPTION
Fixes product artwork not resolving in preview mode for the Razer Viper Mini and Razer Cobra.

The two were keyed by product id only (`1532:008a` / `1532:00a3`), so they matched when a real mouse was connected but fell through to `unknown-device.png` in preview mode, where no HID device exists and artwork resolves by display name. Adds name fallbacks in `src/ui/device-images.ts` plus coverage in `src/ui/device-images.test.ts`.

Verification: `npm run check` passes, 59/59 tests.
