### PR TITLE
Implemented button mapping for the vv3p

### DIFF
--- a/build/check-bundle-size.ts
+++ b/build/check-bundle-size.ts
@@ -13,8 +13,10 @@ const BUDGET_BYTES: Record<string, number> = {
   // reconnection, and recent device support, which have since grown further
   // with the supported-device page and MX Master remap controls. Preview
   // fixtures retain their separate allowance below; the measured aggregate
-  // is 573.4 kB with them, plus the ~11 kB Hall of Fame chunk.
-  ".js": 590_000,
+  // is 573.4 kB with them, plus the ~11 kB Hall of Fame chunk. Raised again
+  // from 590 kB for the Razer button-mapping card and its codec: the measured
+  // aggregate is 588.2 kB, which left under 2 kB of headroom.
+  ".js": 600_000,
 };
 
 const ASSETS = join("dist", "assets");

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -29,6 +29,7 @@ import {
   NinjutsoClickCard,
   NinjutsoSensorCard,
   ProcessingCard,
+  RazerButtonCard,
   PulsarProCard,
   SignalCard,
   SleepCard,
@@ -139,6 +140,7 @@ function Workspace({
     show(has.eggPolling, ["performance"]) ? <EggPollingCard key="eggpolling" snapshot={snapshot} /> : null,
     show(has.eggCpi, ["performance"]) ? <EggCpiCard key="eggcpi" snapshot={snapshot} /> : null,
     show(has.eggButtons, ["buttons"]) ? <EggButtonCard key="eggbuttons" snapshot={snapshot} /> : null,
+    show(has.razerButtons, ["buttons"]) ? <RazerButtonCard key="razerbuttons" snapshot={snapshot} /> : null,
     show(has.mxMasterButtons, ["buttons"])
       ? <MxMasterButtonsCard key="mxmaster-buttons" snapshot={snapshot} /> : null,
     show(has.pulsarPro, ["profiles"]) ? <PulsarProCard key="pulsarpro" snapshot={snapshot} /> : null,

--- a/src/app/cards/AdvancedCards.tsx
+++ b/src/app/cards/AdvancedCards.tsx
@@ -6,6 +6,17 @@ import {
   type EggButtonMapping,
   type EggSpdtMode,
 } from "@openmouse/protocol/drivers/endgame/egg-op1-hid";
+import {
+  RAZER_BUTTON_CONTROLS,
+  RAZER_BUTTON_CONTROL_LABEL,
+  RAZER_BUTTON_MAPPINGS,
+  RAZER_LOCKED_BUTTON_CONTROL,
+  RAZER_TOGGLE_CONTROLS,
+  RAZER_TOGGLE_CONTROL_INFO,
+  type RazerButtonControl,
+  type RazerButtonMapping,
+  type RazerToggleControl,
+} from "@openmouse/protocol/razer";
 import { teevolutionSensorModeUi } from "@openmouse/protocol/teevolution";
 import * as control from "../../device/controller";
 import { PULSAR_SLEEP_OPTIONS } from "../../device/controller";
@@ -737,6 +748,111 @@ export function EggCpiCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNo
         </div>
       </article>
     </Collapsible>
+  );
+}
+
+/**
+ * Two genuinely different kinds of control share one card.
+ *
+ * `RAZER_BUTTON_CONTROLS` are cross-assignable to each other's action or
+ * Disabled. `RAZER_TOGGLE_CONTROLS` only switch between their own captured
+ * factory action and Disabled — cross-assigning those has never been tested on
+ * hardware, so the driver does not offer it and neither does this. The two
+ * families deliberately share no control names and no option labels, which is
+ * what keeps one group's rows from reading the other's state out of the single
+ * `razerButtonMappings` dict.
+ *
+ * Laid out with `button-remap-list`/`button-remap-row` to match
+ * `MxMasterButtonsCard`, the other remap card in this same tab.
+ */
+export function RazerButtonCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNode {
+  const mappings = snapshot.status?.razerButtonMappings;
+  if (!mappings) return null;
+  const busy = snapshot.settingInProgress;
+  const rows: Array<{ key: string; name: string; current: string; options: readonly string[]; locked: boolean }> = [];
+  for (const con of RAZER_BUTTON_CONTROLS) {
+    const current = mappings[con];
+    if (!current) continue;
+    rows.push({
+      key: `razer-button-${con}`,
+      name: RAZER_BUTTON_CONTROL_LABEL[con],
+      current,
+      options: RAZER_BUTTON_MAPPINGS,
+      // Left Click is fixed on the Standard layer — Synapse enforces the same
+      // restriction, and the driver throws rather than send it.
+      locked: con === RAZER_LOCKED_BUTTON_CONTROL,
+    });
+  }
+  for (const con of RAZER_TOGGLE_CONTROLS) {
+    const current = mappings[con];
+    if (!current) continue;
+    const info = RAZER_TOGGLE_CONTROL_INFO[con];
+    rows.push({
+      key: `razer-toggle-${con}`,
+      name: info.label,
+      current,
+      options: [info.enabledLabel, "Disabled"],
+      locked: false,
+    });
+  }
+  if (rows.length === 0) return null;
+  const anyStaged = snapshot.pending.keys.some((key) => key.startsWith("razer-button-") || key.startsWith("razer-toggle-"));
+  const lockedName = rows.find((row) => row.locked)?.name;
+  return (
+    <article id="razer-button-settings" className={`setting-card${anyStaged ? " is-staged" : ""}`}>
+      {/*
+        No count badge here, unlike MxMasterButtonsCard. Its control count is
+        worth showing because it varies per device once virtual and
+        firmware-locked controls are filtered out; this set is fixed at seven,
+        so a badge would only ever read "7".
+      */}
+      <div className="setting-heading compact">
+        <div><p>BUTTONS</p><h2>Mapping</h2></div>
+      </div>
+      <div className="button-remap-list">
+        {rows.map((row) => {
+          const staged = snapshot.pending.keys.includes(row.key);
+          const known = row.options.includes(row.current);
+          return (
+            <label
+              key={row.key}
+              className={`button-remap-row${staged ? " is-staged" : ""}`}
+              data-pending-key={row.key}
+            >
+              <span>{row.name}</span>
+              {row.locked ? <output>{row.current}</output> : (
+                <select
+                  value={row.current}
+                  disabled={busy}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    if (row.key.startsWith("razer-button-")) {
+                      control.applyRazerButtonMapping(
+                        row.key.slice("razer-button-".length) as RazerButtonControl,
+                        value as RazerButtonMapping,
+                      );
+                    } else {
+                      control.applyRazerToggleControl(
+                        row.key.slice("razer-toggle-".length) as RazerToggleControl,
+                        value,
+                      );
+                    }
+                  }}
+                >
+                  {known ? null : <option value={row.current} disabled>{row.current}</option>}
+                  {row.options.map((option) => <option key={option}>{option}</option>)}
+                </select>
+              )}
+            </label>
+          );
+        })}
+      </div>
+      {lockedName ? (
+        <small className="setting-note">
+          {lockedName} is fixed on the Standard layer and cannot be reassigned or disabled.
+        </small>
+      ) : null}
+    </article>
   );
 }
 

--- a/src/app/cards/availability.test.ts
+++ b/src/app/cards/availability.test.ts
@@ -182,3 +182,14 @@ test("low power needs the Razer capability, not merely a reported threshold", ()
     capabilities: { razerLowPowerOptions: [5, 10, 15, 20] },
   })).lowPower, true);
 });
+
+test("the Razer buttons card appears only when the driver reported mappings", () => {
+  const withMappings = cardAvailability(snapshot({
+    status: { brand: "Razer", razerButtonMappings: { leftClick: "Left Click" } },
+  }));
+  assert.equal(withMappings.razerButtons, true);
+
+  // A Razer that never answered the class 0x02 read leaves the field undefined
+  // — the tab must stay empty rather than render a card with no rows.
+  assert.equal(cardAvailability(snapshot({ status: { brand: "Razer" } })).razerButtons, false);
+});

--- a/src/app/cards/availability.ts
+++ b/src/app/cards/availability.ts
@@ -24,6 +24,7 @@ export interface CardAvailability {
   eggPolling: boolean;
   eggCpi: boolean;
   eggButtons: boolean;
+  razerButtons: boolean;
   mxMasterButtons: boolean;
   pulsarPro: boolean;
   profiles: boolean;
@@ -53,6 +54,7 @@ const NOTHING: CardAvailability = {
   eggPolling: false,
   eggCpi: false,
   eggButtons: false,
+  razerButtons: false,
   mxMasterButtons: false,
   pulsarPro: false,
   profiles: false,
@@ -125,6 +127,11 @@ export function cardAvailability(snapshot: ControlSnapshot): CardAvailability {
     // "the device is an MX Master".
     // Not gated on `host`: Logitech opts out of the shared advanced section,
     // and this card lives in the buttons tab regardless.
+    // Razer has no BY_FAMILY entry in traits.ts — it reaches the advanced
+    // section through the ui.showAdvancedSection escape hatch — so this reads
+    // the driver's own field directly. Only the base RazerHidClient populates
+    // it, and only for a product whose profile sets buttonMapping.
+    razerButtons: status.razerButtonMappings != null,
     mxMasterButtons: traits.logitech && (snapshot.buttons?.length ?? 0) > 0,
     pulsarPro: host && isPulsarProProtocol(status),
   };

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -89,6 +89,13 @@ import {
 import { PulsarProHidClient } from "@openmouse/protocol/drivers/pulsar/pulsar-pro-hid";
 import { OrbitalHidClient } from "@openmouse/protocol/drivers/orbital/hid";
 import { RazerHidClient } from "@openmouse/protocol/drivers/razer/hid";
+import {
+  RAZER_BUTTON_CONTROL_LABEL,
+  RAZER_TOGGLE_CONTROL_INFO,
+  type RazerButtonControl,
+  type RazerButtonMapping,
+  type RazerToggleControl,
+} from "@openmouse/protocol/razer";
 import { RazerViperMiniHidClient } from "@openmouse/protocol/drivers/razer/viper-mini-hid";
 import { RazerCobraHidClient } from "@openmouse/protocol/drivers/razer/cobra-hid";
 import { RazerViperHidClient } from "@openmouse/protocol/drivers/razer/viper-hid";
@@ -2628,6 +2635,52 @@ export function applyLowPowerThreshold(percent: number): void {
     },
     apply: async () => {
       await requireClientMethod("setLowPowerThreshold", "low power mode").setLowPowerThreshold(percent);
+    },
+  });
+}
+
+/**
+ * Only the base `RazerHidClient` carries the class `0x02` button commands —
+ * the Viper Mini, Viper and Cobra siblings claim their own single product ids
+ * and have never been checked against it.
+ */
+function razerButtonClient(): RazerHidClient | null {
+  return activeAs<RazerHidClient>(RazerHidClient);
+}
+
+export function applyRazerButtonMapping(control: RazerButtonControl, mapping: RazerButtonMapping): void {
+  if (!razerButtonClient()) return;
+  stageChange({
+    key: `razer-button-${control}`,
+    label: `${RAZER_BUTTON_CONTROL_LABEL[control]} → ${mapping}`,
+    command: `Change ${RAZER_BUTTON_CONTROL_LABEL[control]} mapping`,
+    progress: `Changing ${RAZER_BUTTON_CONTROL_LABEL[control]} mapping…`,
+    preview: (status) => {
+      if (status.razerButtonMappings) status.razerButtonMappings[control] = mapping;
+    },
+    apply: async () => {
+      const client = razerButtonClient();
+      if (!client) throw new Error("The mouse is no longer connected.");
+      await client.setButtonMapping(control, mapping);
+    },
+  });
+}
+
+export function applyRazerToggleControl(control: RazerToggleControl, label: string): void {
+  if (!razerButtonClient()) return;
+  const name = RAZER_TOGGLE_CONTROL_INFO[control].label;
+  stageChange({
+    key: `razer-toggle-${control}`,
+    label: `${name} → ${label}`,
+    command: `Change ${name}`,
+    progress: `Changing ${name}…`,
+    preview: (status) => {
+      if (status.razerButtonMappings) status.razerButtonMappings[control] = label;
+    },
+    apply: async () => {
+      const client = razerButtonClient();
+      if (!client) throw new Error("The mouse is no longer connected.");
+      await client.setToggleControl(control, label);
     },
   });
 }

--- a/src/preview-fixtures.ts
+++ b/src/preview-fixtures.ts
@@ -314,6 +314,15 @@ const RAZER: MouseStatus = {
   supportedLiftOffDistances: [],
   connectionType: "Wireless",
   connectionDetail: "HyperSpeed receiver",
+  razerButtonMappings: {
+    leftClick: "Left Click",
+    rightClick: "Right Click",
+    mouse4: "Disabled",
+    mouse5: "Mouse Button 5",
+    scrollUp: "Scroll Up",
+    scrollDown: "Disabled",
+    sensitivityButton: "Cycle Up Sensitivity Stages",
+  },
   firmware: ["1.01.00"],
 };
 


### PR DESCRIPTION
**Branch is ready** (`ce64c30`, one clean commit on current `dev`). CI will be
red until PR 1 merges — open as a draft, or wait.

**Base:** `OpenMouse-Project/openmouse` `dev`
**Head:** `Pochiiko/openmouse` `vv3p-button-mapping`

### Remaining steps

1. ~~Rebase onto current `origin/dev`~~ — done.
2. PR 1 merged.
3. Bump `package-lock.json` to the merged protocol commit (currently pins
   `#b6bce148...`, which predates the change). **This is the CI fix.**
4. Re-run `npm run check` and `npm run size`.

### Title
feat(razer): add the Viper V3 Pro button mapping panel

### Body

Adds the Buttons-tab Mapping card for the Razer Viper V3 Pro.

> [!IMPORTANT]
> **Blocked on OpenMouse-Project/mouse-protocol#22.** CI will fail here until
> that lands — `MouseStatus.razerButtonMappings` and the `RazerButton*` /
> `RazerToggle*` exports come from it. Once it merges, this needs a
> `package-lock.json` bump to the new protocol commit and CI goes green.

## What it adds

- **`RazerButtonCard`** (`AdvancedCards.tsx`) in the `buttons` tab, laid out with
  `button-remap-list`/`button-remap-row` to match `MxMasterButtonsCard`, the
  other remap card in that tab. Left Click renders as a plain value with an
  explanatory note rather than a disabled select, since it is fixed on the
  Standard layer — Synapse enforces the same restriction.
- **`applyRazerButtonMapping` / `applyRazerToggleControl`** (`controller.ts`),
  staged through the pending-changes system like every other setting, with
  per-row `data-pending-key` so a staged row highlights.
- **`razerButtons`** in `availability.ts`, computed from
  `status.razerButtonMappings != null`. Razer has no `BY_FAMILY` entry in
  `traits.ts` — it reaches the advanced section through the
  `ui.showAdvancedSection` escape hatch — so this reads the driver's field
  directly rather than inventing a family trait.
- Preview fixture mappings, so the card renders in `?preview=razer`.
- JS bundle budget 590 → 600 kB. The measured aggregate was 588.2 kB, leaving
  under 2 kB of headroom.

## Two control families, one dict

The card renders both families from a single `razerButtonMappings` dict keyed by
control name. That is safe because the driver guarantees the two families share
no control names and no option labels — there is a test in the protocol PR
asserting exactly that.

The four cross-assignable buttons offer the full mapping list. The three toggle
controls (Scroll Up, Scroll Down, sensitivity button) offer only their own
action or Disabled, because cross-assigning those has never been tested on
hardware and the driver does not expose it.

## Verification

- `npm run check`: build clean, 79/79 tests.
- `npm run size`: CSS 99%, JS 99%.
- Rendered in `?preview=razer` and on real hardware (Viper V3 Pro, `0x00c1`
  HyperSpeed receiver, Synapse closed): 7 rows, correct per-family option sets,
  Left Click locked, no console errors.
- Writes confirmed physically through this panel: remapping Mouse Button 4 to
  Right Click made the button open the context menu, and disabling Scroll Down
  stopped the wheel scrolling. Both restored afterwards.

## Not included

Hypershift and Scroll Click are not exposed — see the protocol PR for why.