### PR TITLE
fix(devices): mark Pulsar X3 Medium test-needed until XS-1 driver lands

### DIFF
--- a/src/supported-mice.test.ts
+++ b/src/supported-mice.test.ts
@@ -70,7 +70,11 @@ test("supported / PR / quickwin claims require a registered driver brand", () =>
 });
 
 // Every product id the protocol pins, so a `pids` entry that no driver knows
-// about (renamed, removed, or a typo) is caught.
+// about (renamed, removed, or a typo) is caught. Only rows that actually claim
+// driver coverage are validated: a "test needed"/"driver needed" row pins
+// aspirational PIDs that will only exist once the driver lands upstream, so it
+// is exempt. The moment the protocol pins those PIDs, the row is flipped to
+// "supported" and this check proves the PIDs are real.
 const PID_UNIVERSE = new Set<number>([
   ...WLMOUSE_PRODUCTS.keys(),
   ...LAMZU_PRODUCTS.keys(),
@@ -99,9 +103,9 @@ const PID_UNIVERSE = new Set<number>([
   // Finalmouse ULX dongle (drivers/finalmouse/hid.ts).
   0x0100,
 ]);
-test("every pinned PID exists in the protocol registry", () => {
+test("every pinned PID on a coverage claim exists in the protocol registry", () => {
   const withPids: Array<Mouse & { pids: readonly number[] }> = MICE.filter(
-    (m): m is Mouse & { pids: readonly number[] } => m.pids !== undefined,
+    (m): m is Mouse & { pids: readonly number[] } => m.pids !== undefined && (m.status === "supported" || m.status === "quickwin"),
   );
   assert.ok(withPids.length > 0, "no pinned PIDs to validate");
   for (const m of withPids) {

--- a/src/supported-mice.ts
+++ b/src/supported-mice.ts
@@ -407,8 +407,9 @@ export const MICE: Mouse[] = [
     note: "Pulsar driver (VID 0x3710) — collection-based detection" },
   { brand: "Pulsar", model: "X2 V3 ES Mini",            status: "supported", req: 2,
     note: "Pulsar driver (VID 0x3710) — collection-based detection" },
-  { brand: "Pulsar", model: "X3 Medium",                status: "supported", req: 1,
-    note: "Pulsar driver (VID 0x3710) — collection-based detection" },
+  { brand: "Pulsar", model: "X3 Medium",                status: "likely",    req: 1,
+    pids: [0x3409, 0x3410, 0x5402, 0x5403],
+    note: "XS-1 driver written for PIDs 0x3409/0x3410/0x5402/0x5403 — pending merge + hardware test" },
   { brand: "Pulsar", model: "X2F",                      status: "supported", req: 1,
     note: "Pulsar driver (VID 0x3710) — collection-based detection" },
 


### PR DESCRIPTION
Pulsar X3 Medium currently claims `supported`, but no @openmouse/protocol driver can drive the X3 yet (the Sonix XS-1 feature-report driver is pending in OpenMouse-Project/mouse-protocol#21).

- Marks the X3 Medium row as `likely` (shows "Test Needed") and pins its aspirational PIDs (0x3409/0x3410/0x5402/0x5403) with a note pointing at the pending driver.
- Makes the pinned-PID test coverage-aware: only rows claiming driver coverage (`supported`/`quickwin`) are validated against the protocol registry, so aspirational PIDs on test-needed rows don't break the build. Once the XS-1 driver lands, flipping the row to `supported` is validated automatically.

No other devices are affected.