### PR TITLE
chore(protocol): bump to ba64a12 for the X3 M dongle name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -460,7 +460,7 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+https://github.com/OpenMouse-Project/mouse-protocol.git#3c3a4452197a57e3f2fed2323012244f3a175986",
+      "resolved": "git+https://github.com/OpenMouse-Project/mouse-protocol.git#ba64a12d7633d58967c213cd44eef10d12e465e0",
       "integrity": "sha512-htpO6JBZSdbkx5NUfBaABufH7CXfjqA+C8rx4zGYdjb/FXrb9LE5nt7suuIvt03E8185x2I8dUyg/AjpJKjgvQ==",
       "engines": {
         "node": ">=20"


### PR DESCRIPTION
The 0x5402 1K Dongle now reports as Pulsar X3 M instead of the generic product name.