### PR TITLE
fix(supported): collapse brand typos (Reddragon, Eyooso) onto canonical names

### DIFF
--- a/src/supported-live.test.ts
+++ b/src/supported-live.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import type { Mouse } from "./supported-mice.ts";
 import {
+  canonicalBrand,
   mergeLiveMice,
   normalizeKey,
   registrySupportedModels,
@@ -22,6 +23,36 @@ test("normalizeKey collapses case, spaces, and punctuation", () => {
   assert.equal(normalizeKey("  Logitech G502 X  "), "logitechg502x");
   assert.equal(normalizeKey("WLMouse Beast X Pro"), "wlmousebeastxpro");
   assert.equal(normalizeKey("Starlight-12 / ULX"), "starlight12ulx");
+});
+
+test("canonicalBrand folds brand aliases onto the canonical name", () => {
+  assert.equal(canonicalBrand("Reddragon"), "Redragon");
+  assert.equal(canonicalBrand("  REDDRAGON  "), "Redragon");
+  assert.equal(canonicalBrand("Red Dragon"), "Redragon");
+  assert.equal(canonicalBrand("Redragon"), "Redragon");
+  assert.equal(canonicalBrand("Eyooso"), "E-YOOSO");
+  assert.equal(canonicalBrand("e-yooso"), "E-YOOSO");
+  assert.equal(canonicalBrand("E-YOOSO"), "E-YOOSO");
+  assert.equal(canonicalBrand("Logitech"), "Logitech");
+});
+
+test("Reddragon requests merge under the Redragon brand instead of a new group", () => {
+  const merged = mergeLiveMice(BASE, live({}, [
+    {
+      id: "r1",
+      manufacturer: "Reddragon",
+      model: "M725",
+      connection: "Wired",
+      features: [],
+      can_test: false,
+      status: "submitted",
+      vote_count: 7,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ]));
+  assert.equal(merged.filter((m) => m.brand === "Reddragon").length, 0, "no Reddragon brand may exist");
+  const redragon = merged.find((m) => m.brand === "Redragon");
+  assert.deepEqual([redragon?.brand, redragon?.model, redragon?.status, redragon?.req], ["Redragon", "M725", "pending", 7]);
 });
 
 test("registrySupportedModels lists named driver-covered models without receivers or dupes", () => {

--- a/src/supported-live.ts
+++ b/src/supported-live.ts
@@ -24,8 +24,20 @@ export function normalizeKey(part: string): string {
   return part.toLowerCase().replace(/[^a-z0-9]+/g, "").trim();
 }
 
+/**
+ * Catalog submissions carry free-text manufacturer names, so brand typos and
+ * aliases collapse onto the canonical name used by the static table.
+ */
+export function canonicalBrand(brand: string): string {
+  const canonical: Record<string, string> = {
+    reddragon: "Redragon",
+    eyooso: "E-YOOSO",
+  };
+  return canonical[normalizeKey(brand)] ?? brand;
+}
+
 function brandModelKey(brand: string, model: string): string {
-  return `${normalizeKey(brand)}|${normalizeKey(model)}`;
+  return `${normalizeKey(canonicalBrand(brand))}|${normalizeKey(model)}`;
 }
 
 /**
@@ -122,7 +134,7 @@ export function mergeLiveMice(base: Mouse[], live: LiveData | null): Mouse[] {
       if (r.status === "supported") {
         if (known.has(key)) continue;
         rows.push({
-          brand: r.manufacturer,
+          brand: canonicalBrand(r.manufacturer),
           model: r.model,
           status: "supported",
           req: r.vote_count,
@@ -134,7 +146,7 @@ export function mergeLiveMice(base: Mouse[], live: LiveData | null): Mouse[] {
       if (!PENDING_CATALOG_STATUSES.has(r.status)) continue;
       if (known.has(key)) continue;
       rows.push({
-        brand: r.manufacturer,
+        brand: canonicalBrand(r.manufacturer),
         model: r.model,
         status: "pending",
         req: r.vote_count,

--- a/src/supported-mice.ts
+++ b/src/supported-mice.ts
@@ -549,7 +549,7 @@ export const MICE: Mouse[] = [
     note: "Protocol unknown" },
   { brand: "Solakaka",      model: "SM802 Pro",         status: "unknown",   req: 1,
     note: "Has its own web configurator" },
-  { brand: "Eyooso",        model: "X-44 Lite",         status: "unknown",   req: 1,
+  { brand: "E-YOOSO",       model: "X-44 Lite",         status: "unknown",   req: 1,
     note: "Protocol unknown" },
   { brand: "HAVIT",         model: "Gamenote",          status: "unknown",   req: 1,
     note: "Protocol unknown" },


### PR DESCRIPTION
## What  Fixes brand names on the supported-devices page:  - Live catalog submissions carrying free-text manufacturer typos no longer create duplicate brand groups. A new `canonicalBrand()` maps `Reddragon` -> `Redragon` and `Eyooso`/`e-yooso` -> `E-YOOSO`, and is applied both to the merge key and to `pending`/`supported` rows created from the catalog. - The static row `Eyooso X-44 Lite` is renamed to `E-YOOSO X-44 Lite` (the official brand name includes the hyphen). - All other brands were audited against official sources (no further name errors found).  ## Verification  - `npm test`: 81 pass - `npm run build`: clean