### PR TITLE
fix(supported): fold live-catalog brand typos onto canonical names

### DIFF
--- a/src/supported-live.test.ts
+++ b/src/supported-live.test.ts
@@ -29,30 +29,40 @@ test("canonicalBrand folds brand aliases onto the canonical name", () => {
   assert.equal(canonicalBrand("Reddragon"), "Redragon");
   assert.equal(canonicalBrand("  REDDRAGON  "), "Redragon");
   assert.equal(canonicalBrand("Red Dragon"), "Redragon");
+  assert.equal(canonicalBrand("redragon"), "Redragon");
   assert.equal(canonicalBrand("Redragon"), "Redragon");
+  assert.equal(canonicalBrand("Logitec"), "Logitech");
+  assert.equal(canonicalBrand("glorius"), "Glorious");
+  assert.equal(canonicalBrand("rapoo Vpro"), "Rapoo");
   assert.equal(canonicalBrand("Eyooso"), "E-YOOSO");
   assert.equal(canonicalBrand("e-yooso"), "E-YOOSO");
   assert.equal(canonicalBrand("E-YOOSO"), "E-YOOSO");
   assert.equal(canonicalBrand("Logitech"), "Logitech");
+  assert.equal(canonicalBrand("LogiTech"), "Logitech");
+  assert.equal(canonicalBrand("steelseries"), "SteelSeries");
+  assert.equal(canonicalBrand("AttackShark"), "Attack Shark");
+  assert.equal(canonicalBrand("g-wolves"), "G-Wolves");
 });
 
-test("Reddragon requests merge under the Redragon brand instead of a new group", () => {
-  const merged = mergeLiveMice(BASE, live({}, [
-    {
-      id: "r1",
-      manufacturer: "Reddragon",
-      model: "M725",
-      connection: "Wired",
-      features: [],
-      can_test: false,
-      status: "submitted",
-      vote_count: 7,
-      created_at: "2026-01-01T00:00:00Z",
-    },
-  ]));
-  assert.equal(merged.filter((m) => m.brand === "Reddragon").length, 0, "no Reddragon brand may exist");
-  const redragon = merged.find((m) => m.brand === "Redragon");
-  assert.deepEqual([redragon?.brand, redragon?.model, redragon?.status, redragon?.req], ["Redragon", "M725", "pending", 7]);
+test("every Redragon variant merges under the canonical brand, not a new group", () => {
+  for (const variant of ["Reddragon", "REDDRAGON", "Red Dragon", "redragon", "RedDragon"]) {
+    const merged = mergeLiveMice(BASE, live({}, [
+      {
+        id: "r1",
+        manufacturer: variant,
+        model: "M712-RGB",
+        connection: "Wired",
+        features: [],
+        can_test: false,
+        status: "submitted",
+        vote_count: 7,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ]));
+    assert.equal(merged.filter((m) => m.brand === variant).length, 0, `no ${variant} brand may exist`);
+    const redragon = merged.find((m) => m.brand === "Redragon");
+    assert.deepEqual([redragon?.brand, redragon?.model, redragon?.status, redragon?.req], ["Redragon", "M712-RGB", "pending", 7]);
+  }
 });
 
 test("registrySupportedModels lists named driver-covered models without receivers or dupes", () => {

--- a/src/supported-live.ts
+++ b/src/supported-live.ts
@@ -3,7 +3,7 @@ import { LAMZU_PRODUCTS } from "@openmouse/protocol/lamzu";
 import { KEYCHRON_PRODUCTS } from "@openmouse/protocol/keychron";
 import { ORBITAL_DEVICES } from "@openmouse/protocol/orbital";
 
-import type { Mouse } from "./supported-mice.ts";
+import { MICE, type Mouse } from "./supported-mice.ts";
 import { listSupportRequests, type SupportRequest } from "./support-requests.ts";
 
 /**
@@ -25,15 +25,28 @@ export function normalizeKey(part: string): string {
 }
 
 /**
+ * Canonical display names come from the static table, keyed by their
+ * normalized form, so any casing/spacing variant of a known brand renders
+ * with the same name. Spelling typos need explicit aliases on top.
+ */
+const CANONICAL_BRAND_BY_KEY = new Map(
+  [...new Set(MICE.map((m) => m.brand))].map((brand) => [normalizeKey(brand), brand] as const),
+);
+
+const BRAND_TYPOS: Record<string, string> = {
+  reddragon: "Redragon",
+  logitec: "Logitech",
+  glorius: "Glorious",
+  rapoovpro: "Rapoo",
+};
+
+/**
  * Catalog submissions carry free-text manufacturer names, so brand typos and
  * aliases collapse onto the canonical name used by the static table.
  */
 export function canonicalBrand(brand: string): string {
-  const canonical: Record<string, string> = {
-    reddragon: "Redragon",
-    eyooso: "E-YOOSO",
-  };
-  return canonical[normalizeKey(brand)] ?? brand;
+  const key = normalizeKey(brand);
+  return BRAND_TYPOS[key] ?? CANONICAL_BRAND_BY_KEY.get(key) ?? brand;
 }
 
 function brandModelKey(brand: string, model: string): string {


### PR DESCRIPTION
## What  The supported-devices page was still showing multiple similar Redragon groups, some misspelled. Root cause: the support catalog stores manufacturer as free text, and canonicalBrand() only folded the exact reddragon typo. Querying the live catalog (377 rows) showed:  - redragon (lowercase) x5 and RedDragon x2 alongside Redragon x13 - other typos: Logitec, Glorius, rapoo Vpro  ## Fix  canonicalBrand() now: - derives canonical display names from the static table keyed by normalized form, so any casing/spacing variant of a known brand (e.g. redragon, LogiTech, steelseries, g-wolves) renders with the canonical name - keeps an explicit alias map for genuine spelling typos (reddragon, logitec, glorius, rapoovpro)  ## Verification  - Verified against the live catalog: all 20 Redragon-family rows render under Redragon; distinct brands drop 161 -> 127 - npm test: 81 pass - npm run build: clean 