### PR TITLE
fix(supported): alias more live-catalog brand typos and fix IGM brand

### DIFF
--- a/src/supported-live.test.ts
+++ b/src/supported-live.test.ts
@@ -33,6 +33,15 @@ test("canonicalBrand folds brand aliases onto the canonical name", () => {
   assert.equal(canonicalBrand("Redragon"), "Redragon");
   assert.equal(canonicalBrand("Logitec"), "Logitech");
   assert.equal(canonicalBrand("glorius"), "Glorious");
+  assert.equal(canonicalBrand("redrasgon"), "Redragon");
+  assert.equal(canonicalBrand("Raser"), "Razer");
+  assert.equal(canonicalBrand("Logitech G"), "Logitech");
+  assert.equal(canonicalBrand("thecosmicbyte"), "Cosmic Byte");
+  assert.equal(canonicalBrand("Dunevoyger"), "Dune Voyager");
+  assert.equal(canonicalBrand("HSXJ"), "HXSJ");
+  assert.equal(canonicalBrand("Razer Basilisk"), "Razer");
+  assert.equal(canonicalBrand("MX Anywhere 3s"), "Logitech");
+  assert.equal(canonicalBrand("ROG"), "ASUS ROG");
   assert.equal(canonicalBrand("rapoo Vpro"), "Rapoo");
   assert.equal(canonicalBrand("Eyooso"), "E-YOOSO");
   assert.equal(canonicalBrand("e-yooso"), "E-YOOSO");

--- a/src/supported-live.ts
+++ b/src/supported-live.ts
@@ -35,9 +35,22 @@ const CANONICAL_BRAND_BY_KEY = new Map(
 
 const BRAND_TYPOS: Record<string, string> = {
   reddragon: "Redragon",
+  redrasgon: "Redragon",
   logitec: "Logitech",
+  logitechg: "Logitech",
   glorius: "Glorious",
+  raser: "Razer",
+  razerbasilisk: "Razer",
+  razerviper8k: "Razer",
+  thecosmicbyte: "Cosmic Byte",
+  dunevoyger: "Dune Voyager",
+  hsxj: "HXSJ",
   rapoovpro: "Rapoo",
+  mxanywhere2: "Logitech",
+  mxanywhere3: "Logitech",
+  mxanywhere3s: "Logitech",
+  hyperxpulsefirehastle2: "HyperX",
+  rog: "ASUS ROG",
 };
 
 /**

--- a/src/supported-mice.ts
+++ b/src/supported-mice.ts
@@ -557,6 +557,6 @@ export const MICE: Mouse[] = [
     note: "Protocol unknown" },
   { brand: "DeadSkull",     model: "Orbit Wired",       status: "unknown",   req: 1,
     note: "Protocol unknown" },
-  { brand: "IGM",           model: "IGM-6000",          status: "unknown",   req: 1,
+  { brand: "ISY",           model: "IGM-6000",          status: "unknown",   req: 1,
     note: "Protocol unknown" },
 ];


### PR DESCRIPTION
## What  Follow-up audit of the live support catalog against the static table found more free-text brand errors that rendered as their own groups:  - typos: redrasgon, Raser, Logitec, Logitech G, glorius, thecosmicbyte, Dunevoyger, HSXJ - brand+model pasted into the brand field: Razer Basilisk, razer viper 8k, MX Anywhere 3s/3/2, "hyper x pulsefire hastle 2", ROG - static table fix: "IGM IGM-6000" -> "ISY IGM-6000" (ISY is the real brand; the catalog already uses ISY, and the two now merge)  All fold onto the canonical brand name via BRAND_TYPOS / canonicalBrand().  ## Verification  - Live catalog: distinct rendered brands drop 161 -> 115; every Redragon-family row renders as Redragon - Model-level near-miss scan found no actionable duplicates (edit-distance hits are distinct real products like G502 vs G305) - npm test: 81 pass - npm run build: clean 