### PR TITLE
chore(deps): pin @openmouse/protocol to the wired button-mapping driver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -460,7 +460,7 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#4f56cdce5b201c08fca93e033577fc5ff1695e68",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#06997e461dadea0ca45d2894fcc7ebd825ad017c",
       "engines": {
         "node": ">=20"
       }


### PR DESCRIPTION
Blocked on OpenMouse-Project/mouse-protocol#26 — don't merge this until that one is merged.

That PR confirms class 0x02 button mapping over the Viper V3 Pro's cable. openmouse builds against an exact protocol commit, so the Buttons tab stays hidden over the cable until this pin moves.

Currently pinned to 35ccb8c, the head of #26, which isn't on main yet. Once #26 merges the pin needs regenerating against main's tip.

Lockfile only — no source change, since availability.ts never looks at the transport. npm run check: 81/81.