### PR TITLE
Keep the Lighting tab when Teevolution DPI lighting is available.

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -282,7 +282,7 @@ export function App(): ReactNode {
     var tempTabs = WORKSPACE_TAB_ORDER;
     const has = cardAvailability(snapshot);
     if(status==null)return tempTabs;
-    if(!has.lighting)tempTabs=tempTabs.filter(tab=>tab!="lighting")
+    if(!has.lighting&&!has.teevolutionDpiLighting)tempTabs=tempTabs.filter(tab=>tab!="lighting")
     if(!has.eggButtons&&
        !has.razerButtons&&
        !has.mxMasterButtons&&


### PR DESCRIPTION
The tab filter only checked generic RGB, so Terra Pro lost its DPI indicator controls after unnecessary tabs were hidden.