### PR TITLE
feat(keychron): claim the M6 with its own driver instead of Pulsar's

### DIFF
--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -109,6 +109,7 @@ import { TeevolutionHidClient } from "@openmouse/protocol/drivers/teevolution/hi
 import { teevolutionProfileForCid } from "@openmouse/protocol/teevolution";
 import { VgnF2HidClient } from "@openmouse/protocol/drivers/vgn/hid";
 import { KeychronHidClient } from "@openmouse/protocol/drivers/keychron/hid";
+import { KeychronM6HidClient } from "@openmouse/protocol/drivers/keychron/m6-hid";
 import { FantechHidClient } from "@openmouse/protocol/drivers/fantech/hid";
 import { WallhackMouseHidClient } from "@openmouse/protocol/drivers/wallhack/mouse-hid";
 import { WallhackKeyboardHidClient } from "@openmouse/protocol/drivers/wallhack/keyboard-hid";
@@ -163,7 +164,7 @@ function activeAs<T>(...classes: ClientClass<T>[]): T | null {
 
 const DM_CLASSES = [WLMouseHidClient, LamzuHidClient, AtkHidClient, NinjutsoHidClient] as const;
 const RAZER_CLASSES = [RazerHidClient, RazerViperMiniHidClient, RazerViperHidClient, RazerCobraHidClient] as const;
-const NEEDS_OPEN = [TeevolutionHidClient, VgnF2HidClient, KeychronHidClient, ModdoHidClient, ZaunkoenigHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient] as const;
+const NEEDS_OPEN = [TeevolutionHidClient, VgnF2HidClient, KeychronHidClient, KeychronM6HidClient, ModdoHidClient, ZaunkoenigHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient] as const;
 const DEDICATED = [
   ...DM_CLASSES, ...RAZER_CLASSES, ...NEEDS_OPEN,
   EggOp1HidClient, LogitechHidppClient, OrbitalHidClient, RazerViperV4ProHidClient, FinalmouseHidClient,


### PR DESCRIPTION
> **Draft: blocked on OpenMouse-Project/mouse-protocol#33.** This branch imports `@openmouse/protocol/drivers/keychron/m6-hid`, which only exists on that PR's branch. CI installs from the lockfile pin, so the type check fails until #33 merges and the pin moves. Ready to review as a change; not ready to be green.

## Why

The M6 driver in mouse-protocol is enough for the registry to *detect* the mouse, but not for the app to drive it. The sidebar lists it as "Keychron · Available", and activating it fails with:

```
client.describeCollections is not a function
```

`pulsarClient()` is a negative check: any active client not listed in `DEDICATED` is assumed to be a Pulsar client and routed into `showPulsarExplorer()`, which calls `describeCollections()` — a method only the Pulsar drivers have. So a new driver class is broken by default until it is named in that list, and the error message points nowhere near the cause.

This is not specific to any one transport: the M6 fails the same way in Chrome over WebHID as it does through OpenMouse Bridge.

## What changes

`KeychronM6HidClient` joins `NEEDS_OPEN`, next to the Nape Pro's `KeychronHidClient`. Its `open()` is what attaches the input-report listener its query/reply exchanges depend on, and `NEEDS_OPEN` feeds `DEDICATED`, so one entry covers both needs.

## Verification

Wired Keychron M6 on macOS. Before: sidebar row stuck at "Keychron · Available", activation throwing. After: connects and reports 800 DPI, 500 Hz, and battery, and a DPI change (800 → 1600 → 800) flashes to the mouse and reads back.

Locally `npm run build` and `npm test` pass with the #33 driver installed.

## Worth considering separately

`pulsarClient()` treating "unclaimed" as "Pulsar" means every future driver hits this same trap, with an error that names a Pulsar-only method. Inverting it — an explicit Pulsar list, with unclaimed clients reported as unsupported — would turn a confusing runtime failure into an obvious one. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
