### PR TITLE
fix: hide scrollbars and prevent horizontal overflow

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -28,7 +28,13 @@
 }
 
 * { box-sizing: border-box; }
-body { margin: 0; min-width: 320px; transition: background-color .35s ease, color .35s ease; }
+body { margin: 0; min-width: 320px; overflow-x: clip; transition: background-color .35s ease, color .35s ease; }
+/* Hide scrollbars while keeping scroll functionality.
+   overflow-x: clip on body prevents horizontal overflow from 100vw elements (e.g. .brand-marquee)
+   without creating a new scroll context (unlike overflow-x: hidden).
+   scrollbar-width: none (Firefox/Chrome) + ::-webkit-scrollbar (Safari) hides the vertical scrollbar. */
+html { scrollbar-width: none; }
+html::-webkit-scrollbar, body::-webkit-scrollbar { display: none; }
 a { color: inherit; text-decoration: none; }
 button:focus-visible, a:focus-visible, summary:focus-visible {
   outline: 2px solid var(--accent-dark);


### PR DESCRIPTION
## Problem
The landing page had horizontal overflow caused by `.brand-marquee` using `width: 100vw`, 
which includes the scrollbar width. This created a visible horizontal scrollbar.

## Device Specifications
- **OS:** Windows
- **Screen Size:** 1536 × 864px
- **Viewport:** 1536 × 695px
- **DPR:** 1.25
- **Browser:** Chrome (Chromium-based)

## Screenshots
**Before**

<img width="1917" height="865" alt="image" src="https://github.com/user-attachments/assets/28014fc1-734c-4aa1-ace3-fa9b848b973c" />
**After**

<img width="1916" height="867" alt="image" src="https://github.com/user-attachments/assets/7b275f4c-f642-4511-b10f-e707c53dc8e8" />

## Fix
- Added `overflow-x: clip` on `body` to prevent horizontal overflow
- Added `scrollbar-width: none` on `html` + `::-webkit-scrollbar` to hide the vertical scrollbar

No layout or functionality changes and scrolling still works normally.