### PR TITLE
fix: sync input styles with light and dark themes

### DIFF
--- a/src/supported.css
+++ b/src/supported.css
@@ -211,6 +211,7 @@
 [data-theme="dark"] .spill-likely    { background: #451a03; color: #fcd34d; }
 [data-theme="dark"] .spill-driver    { background: #431407; color: #fdba74; }
 [data-theme="dark"] .spill-unknown   { background: #1e293b; color: #94a3b8; }
+[data-theme="dark"] .search-input    { background: #ffffff; color: #000000; }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) .spill-supported { background: #14532d; color: #86efac; }


### PR DESCRIPTION
## Problem
The `.search-input` on the supported devices page had no dark theme override, 
causing it to inherit dark background/text colors that made it hard to read or 
visually inconsistent with the rest of the themed UI.

**Before**

<img width="1896" height="860" alt="image" src="https://github.com/user-attachments/assets/816f66d2-c5c6-4856-aff9-971d1816709a" />

**After**

<img width="1881" height="852" alt="image" src="https://github.com/user-attachments/assets/62287873-36ea-4284-b445-8f2ef9e5617b" />

## Fix
Added an explicit `[data-theme="dark"] .search-input` rule in `supported.css` 
to set proper background and text colors in dark mode.


## Device Specifications
- **OS:** Windows
- **Screen Size:** 1536 × 864px
- **Viewport:** 1536 × 695px
- **DPR:** 1.25
- **Browser:** Chrome (Chromium-based)