### PR TITLE
Fix HID request cleanup and Pulsar Pro input validation

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -1083,6 +1083,8 @@ function showDisconnectedState(): void {
     window.clearInterval(refreshTimer);
     refreshTimer = null;
   }
+  const client = activeSettingsClient();
+  if (client) void client.close().catch(() => undefined);
   activeClient = null;
   activePulsarClient = null;
   activeEggClient = null;

--- a/src/logitech-hidpp.ts
+++ b/src/logitech-hidpp.ts
@@ -195,6 +195,10 @@ export class LogitechHidppClient {
 
   async close(): Promise<void> {
     this.device.removeEventListener("inputreport", this.onInputReport);
+    this.waiters.forEach((waiter) => waiter.reject(new Error("The Logitech device was closed.")));
+    this.waiters.length = 0;
+    this.rateChangeWaiters.forEach((waiter) => waiter.reject(new Error("The Logitech device was closed.")));
+    this.rateChangeWaiters.length = 0;
     if (this.device.opened) {
       await this.device.close();
     }

--- a/src/logitech-hidpp.ts
+++ b/src/logitech-hidpp.ts
@@ -93,6 +93,7 @@ export class LogitechHidppClient {
   private readonly waiters: Array<{
     featureIndex: number;
     functionId: number;
+    timer: number;
     resolve: (report: Uint8Array) => void;
     reject: (reason: Error) => void;
   }> = [];
@@ -195,7 +196,10 @@ export class LogitechHidppClient {
 
   async close(): Promise<void> {
     this.device.removeEventListener("inputreport", this.onInputReport);
-    this.waiters.forEach((waiter) => waiter.reject(new Error("The Logitech device was closed.")));
+    this.waiters.forEach((waiter) => {
+      window.clearTimeout(waiter.timer);
+      waiter.reject(new Error("The Logitech device was closed."));
+    });
     this.waiters.length = 0;
     this.rateChangeWaiters.forEach((waiter) => waiter.reject(new Error("The Logitech device was closed.")));
     this.rateChangeWaiters.length = 0;
@@ -584,6 +588,7 @@ export class LogitechHidppClient {
       this.waiters.push({
         featureIndex,
         functionId,
+        timer: timeout,
         resolve: (report) => {
           window.clearTimeout(timeout);
           resolve(report);

--- a/src/pulsar-pro-hid.ts
+++ b/src/pulsar-pro-hid.ts
@@ -164,6 +164,9 @@ export class PulsarProHidClient {
   }
 
   async setPollingRate(value: number): Promise<number> {
+    if (!Number.isInteger(value) || ![125, 250, 500, 1000, 2000, 4000, 8000].includes(value)) {
+      throw new Error("Unsupported Pulsar Pro polling rate.");
+    }
     await this.setValue(COMMAND.polling, new Uint8Array([value & 0xff, value >> 8]));
     const confirmed = this.readUint16LE(await this.query(COMMAND.polling), 2);
     if (confirmed !== value) throw new Error(`The mouse kept ${confirmed} Hz instead of ${value} Hz.`);
@@ -230,6 +233,9 @@ export class PulsarProHidClient {
   }
 
   async setDebounceTime(value: number): Promise<number> {
+    if (!Number.isInteger(value) || value < 0 || value > 255) {
+      throw new Error("Pulsar Pro debounce time must be between 0 and 255 ms.");
+    }
     await this.setValue(COMMAND.debounce, new Uint8Array([value]));
     return (await this.query(COMMAND.debounce))[2];
   }

--- a/src/pulsar-pro-hid.ts
+++ b/src/pulsar-pro-hid.ts
@@ -164,8 +164,8 @@ export class PulsarProHidClient {
   }
 
   async setPollingRate(value: number): Promise<number> {
-    if (!Number.isInteger(value) || ![125, 250, 500, 1000, 2000, 4000, 8000].includes(value)) {
-      throw new Error("Unsupported Pulsar Pro polling rate.");
+    if (!Number.isInteger(value) || value <= 0) {
+      throw new Error("Polling rate must be a positive integer.");
     }
     await this.setValue(COMMAND.polling, new Uint8Array([value & 0xff, value >> 8]));
     const confirmed = this.readUint16LE(await this.query(COMMAND.polling), 2);
@@ -233,8 +233,8 @@ export class PulsarProHidClient {
   }
 
   async setDebounceTime(value: number): Promise<number> {
-    if (!Number.isInteger(value) || value < 0 || value > 255) {
-      throw new Error("Pulsar Pro debounce time must be between 0 and 255 ms.");
+    if (!Number.isInteger(value) || value < 0 || value > 20) {
+      throw new Error("Pulsar Pro debounce time must be between 0 and 20 ms.");
     }
     await this.setValue(COMMAND.debounce, new Uint8Array([value]));
     return (await this.query(COMMAND.debounce))[2];


### PR DESCRIPTION
## Summary
This PR makes HID more reliable. It adds Pulsar Pro input checks and makes sure that any pending HID requests are cleaned up when a device is closed or physically disconnected.

# Changes

# Pulsar Pro validation

-Added validation for the polling‑rate input.

-The polling rate now must be an integer.

-Removed the hardcoded list of polling rates because support for Pulsar Pro hardware could not be verified from the repository.

-Added debounce validation that uses the 0–20 ms range shown in the UI.

-This prevents values, from reaching the HID payload layer.

# Logitech HID++ cleanup

-Updated `close()` in `logitech-hidpp.ts`.

-Pending waiters are now explicitly rejected when the device closes.

-`rateChangeWaiters` are also rejected during shutdown.

-Pending request timers are cleared with `clearTimeout()`.

-Waiter collections are cleared after shutdown.

-Prevents unresolved promises and stale waiter state across disconnect/reconnect cycles.

# Scope

This PR is intentionally limited to

-Pulsar Pro input validation

-HID disconnect handling

-Pending-request cleanup

-Logitech HID++ shutdown handling

No UI or feature changes or protocol changes are included.

# Notes

The Pulsar Pro polling-rate validation does not assume that the standard Pulsar polling-rate list works with the Pro model. The repository does not have hardware evidence specific, to the Pro model to support that claim.
