### PR TITLE
Fix: Improve tab visibility on hover in dark theme

### DIFF
--- a/src/supported.css
+++ b/src/supported.css
@@ -212,6 +212,7 @@
 [data-theme="dark"] .spill-driver    { background: #431407; color: #fdba74; }
 [data-theme="dark"] .spill-unknown   { background: #1e293b; color: #94a3b8; }
 [data-theme="dark"] .search-input    { background: #ffffff; color: #000000; }
+[data-theme="dark"] .ftab:hover      { background: #ffffff; color: #000000; }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) .spill-supported { background: #14532d; color: #86efac; }


### PR DESCRIPTION
### Summary
This PR fixes an accessibility/UI issue in the dark theme where hovering over tabs (`.ftab:hover`) did not provide sufficient visual contrast. 

### Changes Made
- Added a specific CSS rule for `.ftab:hover` under the `[data-theme="dark"]` selector in `src/supported.css`.
- Hovering over a tab in dark mode will now cleanly invert to a white background with black text, matching expected UI feedback.

**Before**
<img width="1917" height="868" alt="image" src="https://github.com/user-attachments/assets/f0bac3a4-fa01-4e9e-90a0-0c07d43cb043" />

**After**
<img width="1877" height="880" alt="image" src="https://github.com/user-attachments/assets/1b495526-cfa9-4421-bb2b-054e73d0aa42" />



### How to Test
1. Switch the application to the dark theme.
2. Hover your mouse over any tab.
3. Verify that the tab background turns white and the text turns black, making it clearly visible.