### PR TITLE
chore: bump @openmouse/protocol for DeathAdder V4 Pro spec fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openmouse",
       "version": "0.1.0",
       "dependencies": {
-        "@openmouse/protocol": "github:OpenMouse-Project/mouse-protocol#e75409c7a92ad6b4bdac32a332b37e565f2951ed",
+        "@openmouse/protocol": "github:OpenMouse-Project/mouse-protocol#7bc2d78b9307b446a4b21ac3c03a32cfee11ee3a",
         "preact": "^10.29.8"
       },
       "devDependencies": {
@@ -460,8 +460,8 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#e75409c7a92ad6b4bdac32a332b37e565f2951ed",
-      "integrity": "sha512-mBHhNWxuzbmx51NkPMBQ2RxgRWCI8EPmrA9snIeGPXSiXGaH8Yyo0oCkw+wfqhPCCt6BqXGkqvpiMzpqaPuMng==",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#7bc2d78b9307b446a4b21ac3c03a32cfee11ee3a",
+      "integrity": "sha512-qszIvZv6frluMXdqxLHlUnPdgmwYaZR8x5AUkpP4g+v4CtYe1//8C0Qh74lVpzT3WWnjw0LIidrhMa0lqVN0ow==",
       "engines": {
         "node": ">=20"
       }


### PR DESCRIPTION
Picks up mouse-protocol#40: corrected polling and DPI ceilings for the DeathAdder V4 Pro. It's `nativeOnly` — Chrome/WebHID can't reach its control channel — so this only matters to a native-HID consumer like openmouse-desktop; no web-app behavior changes. Build, bundle-size check, and full test suite (86/86) pass.