### PR TITLE
gwolves: surface the full model lineup on the supported-devices page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openmouse",
       "version": "0.1.0",
       "dependencies": {
-        "@openmouse/protocol": "github:OpenMouse-Project/mouse-protocol#f52003a4310cde6a29a188a458ac3b62c95cbea6",
+        "@openmouse/protocol": "github:OpenMouse-Project/mouse-protocol#c8289b9e3b4e941f189b7ec34ee343712e14e405",
         "preact": "^10.29.8"
       },
       "devDependencies": {
@@ -460,8 +460,8 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#f52003a4310cde6a29a188a458ac3b62c95cbea6",
-      "integrity": "sha512-wvvCGrWtcRBTKxnIpMiIKhPaghA/1uoML3baMicupvy4n2X9fNF8IzKpDilptqXuRbfA2J3eaS9cV1jwM8I7Gw==",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#c8289b9e3b4e941f189b7ec34ee343712e14e405",
+      "integrity": "sha512-MHXBqWvPQ7nx4YopeGE7R0g6+4inrzPKGtpe6sFUXjCYsBqQjDggL2rm8aS0Y/SzXs1Olg2/QrFKfQGqoOr4JA==",
       "engines": {
         "node": ">=20"
       }

--- a/src/supported-live.ts
+++ b/src/supported-live.ts
@@ -3,6 +3,7 @@ import { LAMZU_PRODUCTS } from "@openmouse/protocol/lamzu";
 import { KEYCHRON_NAPE_PRODUCTS } from "@openmouse/protocol/keychron";
 import { ORBITAL_DEVICES } from "@openmouse/protocol/orbital";
 import { FANTECH_PRODUCTS } from "@openmouse/protocol/fantech";
+import { GWOLVES_PRODUCTS } from "@openmouse/protocol/drivers/gwolves/products";
 
 import { MICE, type Mouse } from "./supported-mice.ts";
 import { listSupportRequests, type SupportRequest } from "./support-requests.ts";
@@ -139,6 +140,10 @@ export function registrySupportedModels(): Mouse[] {
   }
   for (const [pid, info] of FANTECH_PRODUCTS) {
     rows.push({ brand: "Fantech", model: info.model, status: "supported", req: 0, note: "", pids: [pid] });
+  }
+  for (const [pid, info] of GWOLVES_PRODUCTS) {
+    if (info.wireless) continue;
+    rows.push({ brand: "G-Wolves", model: info.model, status: "supported", req: 0, note: "", pids: [pid] });
   }
 
   const seen = new Set<string>();


### PR DESCRIPTION
Bumps @openmouse/protocol for mouse-protocol#42 (21 new G-Wolves models transcribed from their own web-driver config, all unverified but sharing HTX Ultra's already-verified protocol) and wires `GWOLVES_PRODUCTS` into `registrySupportedModels()` the same way WLMouse/Lamzu/Keychron Nape/Orbital/Fantech already are, rather than hand-listing 22 static rows — G-Wolves models weren't in that live overlay at all before, so even the existing verified HTX Ultra never showed up on the page.

Build, bundle-size check, and full test suite (86/86) pass.