### PR TITLE
Redesign admin dashboard: more info, graphs, and a modern shell

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -7,6 +7,12 @@
     <link rel="icon" href="/favicon.ico?v=2" sizes="32x32" />
     <meta name="robots" content="noindex, nofollow" />
     <title>OpenMouse Admin</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Sora:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@500;600&display=swap"
+    />
   </head>
   <body>
     <div id="admin-app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@openmouse/protocol": "github:OpenMouse-Project/mouse-protocol",
+        "@openmouse/protocol": "https://github.com/OpenMouse-Project/mouse-protocol.git",
         "preact": "^10.29.8"
       },
       "devDependencies": {
@@ -459,17 +459,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#e9720df627251a8ba12d1a02338fca5475afca33",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#ba5e828deeeafd59e0c9b71a1ff94477f3dcb53a",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
-      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
       "cpu": [
         "arm"
       ],
@@ -481,9 +498,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
-      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
       "cpu": [
         "arm64"
       ],
@@ -495,9 +512,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
-      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
       "cpu": [
         "arm64"
       ],
@@ -509,9 +526,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
-      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
       "cpu": [
         "x64"
       ],
@@ -523,9 +540,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
-      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
       "cpu": [
         "arm64"
       ],
@@ -537,9 +554,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
-      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
       "cpu": [
         "x64"
       ],
@@ -551,9 +568,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
-      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
       "cpu": [
         "arm"
       ],
@@ -565,9 +582,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
-      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
       "cpu": [
         "arm"
       ],
@@ -579,9 +596,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
-      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
       "cpu": [
         "arm64"
       ],
@@ -593,9 +610,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
-      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
       "cpu": [
         "arm64"
       ],
@@ -607,9 +624,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
-      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
       "cpu": [
         "loong64"
       ],
@@ -621,9 +638,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
-      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
       "cpu": [
         "loong64"
       ],
@@ -635,9 +652,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
-      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
       "cpu": [
         "ppc64"
       ],
@@ -649,9 +666,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
-      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
       "cpu": [
         "ppc64"
       ],
@@ -663,9 +680,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
-      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
       "cpu": [
         "riscv64"
       ],
@@ -677,9 +694,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
-      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
       "cpu": [
         "riscv64"
       ],
@@ -691,9 +708,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
-      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
       "cpu": [
         "s390x"
       ],
@@ -705,9 +722,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
-      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
       "cpu": [
         "x64"
       ],
@@ -719,9 +736,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
-      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
       "cpu": [
         "x64"
       ],
@@ -733,9 +750,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
-      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
       "cpu": [
         "x64"
       ],
@@ -747,9 +764,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
-      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
       "cpu": [
         "arm64"
       ],
@@ -761,9 +778,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
-      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
       "cpu": [
         "arm64"
       ],
@@ -775,9 +792,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
-      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
       "cpu": [
         "ia32"
       ],
@@ -789,9 +806,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
-      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
       "cpu": [
         "x64"
       ],
@@ -803,9 +820,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
-      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
       "cpu": [
         "x64"
       ],
@@ -925,9 +942,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -938,9 +955,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -958,7 +975,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -985,9 +1002,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
-      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1001,31 +1018,32 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.3",
-        "@rollup/rollup-android-arm64": "4.62.3",
-        "@rollup/rollup-darwin-arm64": "4.62.3",
-        "@rollup/rollup-darwin-x64": "4.62.3",
-        "@rollup/rollup-freebsd-arm64": "4.62.3",
-        "@rollup/rollup-freebsd-x64": "4.62.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
-        "@rollup/rollup-linux-arm64-musl": "4.62.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
-        "@rollup/rollup-linux-loong64-musl": "4.62.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
-        "@rollup/rollup-linux-x64-gnu": "4.62.3",
-        "@rollup/rollup-linux-x64-musl": "4.62.3",
-        "@rollup/rollup-openbsd-x64": "4.62.3",
-        "@rollup/rollup-openharmony-arm64": "4.62.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
-        "@rollup/rollup-win32-x64-gnu": "4.62.3",
-        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@openmouse/protocol": "github:OpenMouse-Project/mouse-protocol",
+    "@openmouse/protocol": "https://github.com/OpenMouse-Project/mouse-protocol.git",
     "preact": "^10.29.8"
   },
   "devDependencies": {

--- a/src/admin.css
+++ b/src/admin.css
@@ -1,0 +1,263 @@
+/* Gated admin dashboard (see functions/api/admin/*). Self-contained — not
+   shared with the rest of the app's stylesheets — but reuses the project's
+   signature accent green (see --success in control.css / --ck-accent in
+   check.css) so it doesn't feel like a foreign tool bolted onto the site. */
+
+:root {
+  --adm-bg: #0a0a10;
+  --adm-bg-elev: #0d0d14;
+  --adm-panel: #131319;
+  --adm-panel-2: #181820;
+  --adm-border: #232330;
+  --adm-border-soft: #1b1b24;
+  --adm-text: #f2f1f7;
+  --adm-text-dim: #c8c7d4;
+  --adm-muted: #87869a;
+  --adm-faint: #57566a;
+  --adm-accent: #69d28d;
+  --adm-accent-2: #3fae6a;
+  --adm-accent-glow: rgba(105, 210, 141, 0.3);
+  --adm-good: #69d28d;
+  --adm-good-dim: rgba(105, 210, 141, 0.14);
+  --adm-bad: #ff6b81;
+  --adm-bad-dim: rgba(255, 107, 129, 0.14);
+  --adm-track: #1c1c26;
+  --adm-font-display: "Sora", system-ui, sans-serif;
+  --adm-font-body: "IBM Plex Sans", system-ui, sans-serif;
+  --adm-font-mono: "IBM Plex Mono", "SF Mono", monospace;
+}
+
+.adm-root {
+  background: var(--adm-bg);
+  color: var(--adm-text);
+  font-family: var(--adm-font-body);
+  min-height: 100vh;
+  display: flex;
+  position: relative;
+}
+.adm-root::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(700px 420px at 14% -8%, var(--adm-accent-glow), transparent 60%),
+    radial-gradient(900px 500px at 100% 0%, rgba(63, 174, 106, 0.14), transparent 55%);
+  opacity: 0.5;
+}
+
+/* ---------- sidebar ---------- */
+.adm-sidebar {
+  width: 224px;
+  flex: none;
+  background: var(--adm-bg-elev);
+  border-right: 1px solid var(--adm-border-soft);
+  display: flex;
+  flex-direction: column;
+  padding: 22px 14px;
+  gap: 26px;
+  position: relative;
+  z-index: 1;
+}
+.adm-brand { display: flex; align-items: center; gap: 10px; padding: 0 8px; }
+.adm-brand-mark {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, var(--adm-accent), var(--adm-accent-2));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  box-shadow: 0 4px 16px var(--adm-accent-glow);
+}
+.adm-brand-mark svg { width: 16px; height: 16px; }
+.adm-brand-name { font-family: var(--adm-font-display); font-weight: 700; font-size: 14.5px; letter-spacing: 0.2px; }
+.adm-brand-sub { font-size: 10.5px; color: var(--adm-faint); letter-spacing: 0.08em; text-transform: uppercase; margin-top: 1px; }
+
+.adm-nav { display: flex; flex-direction: column; gap: 2px; }
+.adm-nav-label { font-size: 10.5px; color: var(--adm-faint); letter-spacing: 0.1em; text-transform: uppercase; padding: 14px 10px 6px; }
+.adm-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: 8px;
+  color: var(--adm-muted);
+  font-size: 13.5px;
+  font-weight: 500;
+}
+.adm-nav-item svg { width: 16px; height: 16px; flex: none; opacity: 0.85; }
+.adm-nav-item.is-active { background: var(--adm-panel-2); color: var(--adm-text); border: 1px solid var(--adm-border); }
+.adm-nav-item.is-active svg { color: var(--adm-accent); opacity: 1; }
+
+.adm-sidebar-foot { margin-top: auto; padding: 10px; border-radius: 10px; background: var(--adm-panel); border: 1px solid var(--adm-border-soft); }
+.adm-sf-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--adm-muted); }
+.adm-sf-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--adm-good); box-shadow: 0 0 6px var(--adm-good); flex: none; }
+
+/* ---------- main ---------- */
+.adm-main { flex: 1; min-width: 0; position: relative; z-index: 1; }
+.adm-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 32px;
+  border-bottom: 1px solid var(--adm-border-soft);
+  flex-wrap: wrap;
+}
+.adm-h1 { font-family: var(--adm-font-display); font-size: 21px; font-weight: 700; margin: 0; letter-spacing: 0.1px; }
+.adm-muted { color: var(--adm-muted); margin: 3px 0 0; font-size: 12.5px; }
+.adm-topbar-right { display: flex; align-items: center; gap: 12px; }
+
+.adm-range-switch { display: flex; gap: 2px; background: var(--adm-panel); border: 1px solid var(--adm-border); border-radius: 9px; padding: 3px; }
+.adm-range-btn {
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 13px;
+  color: var(--adm-muted);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: var(--adm-font-body);
+}
+.adm-range-btn.is-active { background: var(--adm-accent); color: #07130d; font-weight: 600; box-shadow: 0 2px 10px var(--adm-accent-glow); }
+
+.adm-icon-btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  background: var(--adm-panel);
+  border: 1px solid var(--adm-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--adm-muted);
+  cursor: pointer;
+}
+.adm-icon-btn:hover { color: var(--adm-text); border-color: var(--adm-border-hover, #3a3a48); }
+
+.adm-content { padding: 26px 32px 40px; display: flex; flex-direction: column; gap: 22px; }
+
+.adm-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--adm-panel);
+  border: 1px solid var(--adm-border);
+  border-left: 3px solid var(--adm-accent);
+  border-radius: 10px;
+  padding: 11px 16px;
+  font-size: 12.5px;
+  color: var(--adm-muted);
+}
+.adm-banner b { color: var(--adm-text); font-weight: 600; }
+
+/* stat tiles */
+.adm-stat-row { display: grid; grid-template-columns: repeat(5, 1fr); gap: 14px; }
+.adm-stat {
+  background: var(--adm-panel);
+  border: 1px solid var(--adm-border);
+  border-radius: 14px;
+  padding: 18px 18px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.adm-stat-top { display: flex; align-items: center; justify-content: space-between; }
+.adm-stat-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: var(--adm-panel-2);
+  border: 1px solid var(--adm-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--adm-accent);
+}
+.adm-stat-icon svg { width: 14px; height: 14px; }
+.adm-stat-value { font-family: var(--adm-font-mono); font-size: 26px; font-weight: 600; letter-spacing: -0.2px; display: flex; align-items: baseline; gap: 8px; }
+.adm-live-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--adm-good); box-shadow: 0 0 8px var(--adm-good); display: inline-block; margin-right: 1px; flex: none; }
+.adm-stat-label { font-size: 12px; color: var(--adm-muted); }
+.adm-pill { font-size: 11px; font-weight: 600; padding: 2px 7px; border-radius: 99px; display: inline-flex; align-items: center; gap: 3px; font-family: var(--adm-font-mono); }
+.adm-pill.is-up { color: var(--adm-good); background: var(--adm-good-dim); }
+.adm-pill.is-down { color: var(--adm-bad); background: var(--adm-bad-dim); }
+
+/* cards */
+.adm-card { background: var(--adm-panel); border: 1px solid var(--adm-border); border-radius: 14px; padding: 22px; }
+.adm-card-head { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 16px; gap: 12px; flex-wrap: wrap; }
+.adm-card-title { font-family: var(--adm-font-display); font-size: 14.5px; font-weight: 600; margin: 0; }
+.adm-card-sub { font-size: 12px; color: var(--adm-muted); margin: 2px 0 0; }
+
+.adm-chart-value { font-family: var(--adm-font-mono); font-size: 26px; font-weight: 600; }
+.adm-chart-value .adm-muted { font-family: var(--adm-font-body); margin-left: 9px; font-size: 12.5px; display: inline; }
+
+.adm-axis-row { display: flex; justify-content: space-between; margin-top: 8px; }
+.adm-axis-label { font-size: 11px; color: var(--adm-faint); font-family: var(--adm-font-mono); }
+
+.adm-row3 { display: grid; grid-template-columns: 1.1fr 1.1fr 0.9fr; gap: 18px; }
+
+.adm-bar-list { display: flex; flex-direction: column; gap: 12px; }
+.adm-bar-item { display: flex; align-items: center; gap: 10px; }
+.adm-rank { width: 18px; font-size: 11px; color: var(--adm-faint); font-family: var(--adm-font-mono); }
+.adm-bl-label { width: 132px; font-size: 13px; color: var(--adm-text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.adm-bl-track { flex: 1; background: var(--adm-track); border-radius: 5px; overflow: hidden; height: 9px; }
+.adm-bl-fill { height: 100%; background: linear-gradient(90deg, var(--adm-accent-2), var(--adm-accent)); }
+.adm-bl-value { width: 96px; text-align: right; font-size: 12.5px; font-family: var(--adm-font-mono); color: var(--adm-text-dim); }
+.adm-bl-value .adm-muted { font-family: var(--adm-font-mono); margin: 0; display: inline; }
+
+.adm-heatmap { display: flex; flex-direction: column; gap: 6px; }
+.adm-heatmap-row { display: grid; grid-template-columns: 34px repeat(7, 1fr); gap: 6px; align-items: center; }
+.adm-hm-label { font-size: 11px; color: var(--adm-faint); font-family: var(--adm-font-mono); }
+.adm-hm-cell { aspect-ratio: 1; border-radius: 5px; background: var(--adm-track); }
+.adm-hm-foot { display: grid; grid-template-columns: 34px repeat(7, 1fr); gap: 6px; margin-top: 2px; }
+.adm-hm-foot span { text-align: center; font-size: 10.5px; color: var(--adm-faint); font-family: var(--adm-font-mono); }
+
+.adm-bar-rect { cursor: pointer; transition: fill 0.1s; }
+.adm-bar-rect:hover { fill: var(--adm-accent) !important; }
+
+@media (max-width: 1180px) {
+  .adm-stat-row { grid-template-columns: repeat(3, 1fr); }
+  .adm-row3 { grid-template-columns: 1fr; }
+}
+
+/* ---------- login ---------- */
+.adm-login {
+  font-family: var(--adm-font-body);
+  background: var(--adm-bg);
+  color: var(--adm-text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 0 20%;
+  box-sizing: border-box;
+}
+.adm-login h1 { font-family: var(--adm-font-display); }
+.adm-login-input {
+  background: var(--adm-panel);
+  border: 1px solid var(--adm-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--adm-text);
+  font-size: 14px;
+  width: 280px;
+  font-family: var(--adm-font-body);
+}
+.adm-login-button {
+  background: var(--adm-accent);
+  border: none;
+  border-radius: 8px;
+  padding: 10px 16px;
+  color: #07130d;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--adm-font-body);
+}
+.adm-login-error { color: var(--adm-bad); font-size: 13px; }

--- a/src/admin.tsx
+++ b/src/admin.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
+import "./admin.css";
 
 type DailyPoint = { day: string; view_count: number; peak_concurrent: number };
 type CountRow = { country?: string; mouse_model?: string; view_count?: number; uses?: number };
@@ -14,6 +15,104 @@ type Stats = {
 
 const LIVE_POLL_MS = 5000;
 const RANGE_OPTIONS = [7, 30, 90] as const;
+const WEEKDAY_LABELS = ["S", "M", "T", "W", "T", "F", "S"];
+
+function formatDay(day: string) {
+  const d = new Date(day);
+  if (Number.isNaN(d.getTime())) return day;
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function pctChange(current: number, previous: number): number | null {
+  if (previous <= 0) return null;
+  return ((current - previous) / previous) * 100;
+}
+
+/* ---------- icons (inline, stroke-based to match the sidebar's line-icon set) ---------- */
+
+const iconProps = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+const IconOverview = () => (
+  <svg {...iconProps}>
+    <path d="M3 12h4l3 8 4-16 3 8h4" />
+  </svg>
+);
+const IconLive = () => (
+  <svg {...iconProps}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7v5l3 3" />
+  </svg>
+);
+const IconRegions = () => (
+  <svg {...iconProps}>
+    <path d="M12 21c4-4.5 7-8.2 7-11.5A7 7 0 0 0 5 9.5C5 12.8 8 16.5 12 21Z" />
+    <circle cx="12" cy="9.5" r="2.3" />
+  </svg>
+);
+const IconDevices = () => (
+  <svg {...iconProps}>
+    <rect x="6" y="2" width="12" height="20" rx="6" />
+    <line x1="12" y1="6" x2="12" y2="10" />
+  </svg>
+);
+const IconSettings = () => (
+  <svg {...iconProps}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.6 1.7 1.7 0 0 0-1.9.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.9 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.6-1 1.7 1.7 0 0 0-.3-1.9l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.9.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.9-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.9V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1Z" />
+  </svg>
+);
+const IconMouse = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+    <rect x="7" y="3" width="10" height="18" rx="5" />
+    <line x1="12" y1="7" x2="12" y2="11" />
+  </svg>
+);
+const IconPulse = () => (
+  <svg {...iconProps}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+  </svg>
+);
+const IconPeak = () => (
+  <svg {...iconProps}>
+    <path d="M3 3v18h18" />
+    <path d="M7 14l4-5 3 3 5-7" />
+  </svg>
+);
+const IconTrend = () => (
+  <svg {...iconProps}>
+    <path d="M3 12h4l3 8 4-16 3 8h4" />
+  </svg>
+);
+const IconCalendar = () => (
+  <svg {...iconProps}>
+    <rect x="3" y="4" width="18" height="17" rx="2" />
+    <line x1="3" y1="10" x2="21" y2="10" />
+    <line x1="8" y1="2" x2="8" y2="6" />
+    <line x1="16" y1="2" x2="16" y2="6" />
+  </svg>
+);
+const IconStar = () => (
+  <svg {...iconProps}>
+    <path d="M12 2l2.9 6.6L22 9.3l-5 4.9 1.2 7.1L12 17.8l-6.2 3.5L7 14.2 2 9.3l7.1-.7Z" />
+  </svg>
+);
+const IconLogout = () => (
+  <svg width={15} height={15} {...iconProps}>
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    <polyline points="16 17 21 12 16 7" />
+    <line x1="21" y1="12" x2="9" y2="12" />
+  </svg>
+);
+
+/* ---------- login ---------- */
 
 function LoginForm({ onLoggedIn }: { onLoggedIn: () => void }) {
   const [password, setPassword] = useState("");
@@ -44,135 +143,134 @@ function LoginForm({ onLoggedIn }: { onLoggedIn: () => void }) {
   };
 
   return (
-    <form onSubmit={submit} style={styles.loginCard}>
-      <h1 style={styles.title}>OpenMouse Admin</h1>
+    <form onSubmit={submit} className="adm-login">
+      <h1 className="adm-h1">OpenMouse Admin</h1>
       <input
         type="password"
         autoFocus
         placeholder="Password"
         value={password}
         onInput={(e) => setPassword((e.target as HTMLInputElement).value)}
-        style={styles.input}
+        className="adm-login-input"
       />
-      <button type="submit" disabled={busy || !password} style={styles.button}>
+      <button type="submit" disabled={busy || !password} className="adm-login-button">
         {busy ? "Checking…" : "Sign in"}
       </button>
-      {error && <p style={styles.error}>{error}</p>}
+      {error && <p className="adm-login-error">{error}</p>}
     </form>
   );
 }
 
-function formatDay(day: string) {
-  const d = new Date(day);
-  if (Number.isNaN(d.getTime())) return day;
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-}
+/* ---------- charts ---------- */
 
-function pctChange(current: number, previous: number): number | null {
-  if (previous <= 0) return null;
-  return ((current - previous) / previous) * 100;
-}
-
-function Trend({ value }: { value: number | null }) {
-  if (value === null) return null;
-  const up = value >= 0;
-  return (
-    <span style={{ ...styles.trend, color: up ? "#4ade80" : "#f87171" }}>
-      {up ? "▲" : "▼"} {Math.abs(value).toFixed(1)}%
-    </span>
-  );
-}
-
-/** Bar chart of daily views, hover-scrubbed with a lightweight tooltip. */
 function DailyBarChart({ points }: { points: DailyPoint[] }) {
   const [hover, setHover] = useState<number | null>(null);
-  const width = 760;
-  const height = 200;
+  const width = 940;
+  const height = 210;
+  const gap = 4;
   const max = Math.max(1, ...points.map((p) => p.view_count));
-  const barGap = 3;
-  const barWidth = points.length > 0 ? width / points.length - barGap : 0;
+  const barWidth = points.length > 0 ? width / points.length - gap : 0;
 
-  if (!points.length) return <p style={styles.muted}>No history yet.</p>;
+  if (!points.length) return <p className="adm-muted">No history yet.</p>;
 
-  const active = hover !== null ? points[hover] : points[points.length - 1];
+  const activeIndex = hover ?? points.length - 1;
+  const active = points[activeIndex];
 
   return (
     <div>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 10 }}>
-        <div style={{ fontSize: 24, fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
-          {active.view_count.toLocaleString()}
-          <span style={{ ...styles.muted, marginLeft: 8, fontSize: 13 }}>views · {formatDay(active.day)}</span>
-        </div>
-        <div style={styles.muted}>peak concurrent {active.peak_concurrent}</div>
+      <div className="adm-chart-value">
+        {active.view_count.toLocaleString()}
+        <span className="adm-muted">
+          views · {formatDay(active.day)} · peak concurrent {active.peak_concurrent}
+        </span>
       </div>
       <svg
         viewBox={`0 0 ${width} ${height}`}
         width="100%"
         height={height}
-        style={{ display: "block", overflow: "visible" }}
+        style={{ display: "block", overflow: "visible", marginTop: 6 }}
         onMouseLeave={() => setHover(null)}
       >
+        <defs>
+          <linearGradient id="admBarGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#8fe0ac" />
+            <stop offset="100%" stopColor="#3fae6a" />
+          </linearGradient>
+        </defs>
+        <line x1={0} x2={width} y1={height - 0.5} y2={height - 0.5} stroke="#1c1c26" strokeWidth={1} />
         {points.map((p, i) => {
-          const barHeight = (p.view_count / max) * (height - 4);
-          const x = i * (barWidth + barGap);
-          const isActive = hover === i || (hover === null && i === points.length - 1);
+          const barHeight = (p.view_count / max) * (height - 8);
+          const x = i * (barWidth + gap);
+          const isActive = i === activeIndex;
           return (
             <rect
               key={p.day}
+              className="adm-bar-rect"
               x={x}
               y={height - barHeight}
               width={Math.max(1, barWidth)}
               height={barHeight}
-              rx={2}
-              fill={isActive ? "#a78bfa" : "#3f3f52"}
+              rx={2.5}
+              fill={isActive ? "url(#admBarGrad)" : "#1c1c26"}
               onMouseEnter={() => setHover(i)}
             />
           );
         })}
       </svg>
-      <div style={{ display: "flex", justifyContent: "space-between", marginTop: 6 }}>
-        <span style={styles.axisLabel}>{formatDay(points[0].day)}</span>
-        <span style={styles.axisLabel}>{formatDay(points[points.length - 1].day)}</span>
+      <div className="adm-axis-row">
+        <span className="adm-axis-label">{formatDay(points[0].day).toUpperCase()}</span>
+        <span className="adm-axis-label">{formatDay(points[points.length - 1].day).toUpperCase()}</span>
       </div>
     </div>
   );
 }
 
-/** Average views by weekday, derived client-side from the daily series. */
-function WeekdayBreakdown({ points }: { points: DailyPoint[] }) {
-  const labels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-  const totals = useMemo(() => {
-    const sums = new Array(7).fill(0);
-    const counts = new Array(7).fill(0);
-    for (const p of points) {
-      const d = new Date(p.day);
-      if (Number.isNaN(d.getTime())) continue;
-      const idx = d.getUTCDay();
-      sums[idx] += p.view_count;
-      counts[idx] += 1;
+/** GitHub-style intensity heatmap of views by weekday, one row per week. */
+function WeekdayHeatmap({ points }: { points: DailyPoint[] }) {
+  const weeks = useMemo(() => {
+    const chunks: (DailyPoint | null)[][] = [];
+    for (let i = 0; i < points.length; i += 7) {
+      const slice = points.slice(i, i + 7);
+      const cells: (DailyPoint | null)[] = new Array(7).fill(null);
+      slice.forEach((p) => {
+        const d = new Date(p.day);
+        if (!Number.isNaN(d.getTime())) cells[d.getUTCDay()] = p;
+      });
+      chunks.push(cells);
     }
-    return sums.map((sum, i) => (counts[i] ? sum / counts[i] : 0));
+    return chunks;
   }, [points]);
-  const max = Math.max(1, ...totals);
 
-  if (!points.length) return <p style={styles.muted}>No history yet.</p>;
+  if (!points.length) return <p className="adm-muted">No history yet.</p>;
+  const max = Math.max(1, ...points.map((p) => p.view_count));
 
   return (
-    <div style={{ display: "flex", alignItems: "flex-end", gap: 8, height: 120 }}>
-      {totals.map((value, i) => (
-        <div key={labels[i]} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
-          <div
-            style={{
-              width: "100%",
-              height: Math.max(2, (value / max) * 90),
-              background: "linear-gradient(180deg, #a78bfa, #7c3aed)",
-              borderRadius: 4,
-            }}
-            title={`${labels[i]}: ${value.toFixed(1)} avg views`}
-          />
-          <span style={styles.axisLabel}>{labels[i]}</span>
-        </div>
-      ))}
+    <div>
+      <div className="adm-heatmap">
+        {weeks.map((week, wi) => (
+          <div className="adm-heatmap-row" key={wi}>
+            <span className="adm-hm-label">W{wi + 1}</span>
+            {week.map((cell, di) =>
+              cell ? (
+                <div
+                  key={di}
+                  className="adm-hm-cell"
+                  title={`${formatDay(cell.day)}: ${cell.view_count} views`}
+                  style={{ background: `rgba(105, 210, 141, ${(0.12 + (cell.view_count / max) * 0.75).toFixed(2)})` }}
+                />
+              ) : (
+                <div key={di} className="adm-hm-cell" style={{ background: "transparent" }} />
+              ),
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="adm-hm-foot">
+        <span />
+        {WEEKDAY_LABELS.map((l, i) => (
+          <span key={i}>{l}</span>
+        ))}
+      </div>
     </div>
   );
 }
@@ -180,23 +278,21 @@ function WeekdayBreakdown({ points }: { points: DailyPoint[] }) {
 function BarList({ rows, labelKey, valueKey }: { rows: CountRow[]; labelKey: "country" | "mouse_model"; valueKey: "view_count" | "uses" }) {
   const max = Math.max(1, ...rows.map((r) => Number(r[valueKey]) || 0));
   const total = rows.reduce((sum, r) => sum + (Number(r[valueKey]) || 0), 0);
-  if (!rows.length) return <p style={styles.muted}>No data yet.</p>;
+  if (!rows.length) return <p className="adm-muted">No data yet.</p>;
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+    <div className="adm-bar-list">
       {rows.map((row, i) => {
         const value = Number(row[valueKey]) || 0;
         const share = total > 0 ? (value / total) * 100 : 0;
         return (
-          <div key={String(row[labelKey])} style={{ display: "flex", alignItems: "center", gap: 10 }}>
-            <span style={styles.rank}>{i + 1}</span>
-            <span style={{ width: 140, fontSize: 13, opacity: 0.9, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-              {row[labelKey] || "Unknown"}
-            </span>
-            <div style={{ flex: 1, background: "#1f1f27", borderRadius: 4, overflow: "hidden", height: 10 }}>
-              <div style={{ width: `${(value / max) * 100}%`, background: "linear-gradient(90deg, #7c3aed, #a78bfa)", height: "100%" }} />
+          <div className="adm-bar-item" key={String(row[labelKey])}>
+            <span className="adm-rank">{String(i + 1).padStart(2, "0")}</span>
+            <span className="adm-bl-label">{row[labelKey] || "Unknown"}</span>
+            <div className="adm-bl-track">
+              <div className="adm-bl-fill" style={{ width: `${(value / max) * 100}%` }} />
             </div>
-            <span style={{ width: 76, textAlign: "right", fontSize: 13, fontVariantNumeric: "tabular-nums" }}>
-              {value.toLocaleString()} <span style={styles.muted}>({share.toFixed(0)}%)</span>
+            <span className="adm-bl-value">
+              {value.toLocaleString()} <span className="adm-muted">{share.toFixed(0)}%</span>
             </span>
           </div>
         );
@@ -205,10 +301,46 @@ function BarList({ rows, labelKey, valueKey }: { rows: CountRow[]; labelKey: "co
   );
 }
 
+/* ---------- stat tile ---------- */
+
+function StatTile({
+  icon,
+  value,
+  label,
+  live,
+  trend,
+}: {
+  icon: any;
+  value: any;
+  label: string;
+  live?: boolean;
+  trend?: number | null;
+}) {
+  return (
+    <div className="adm-stat">
+      <div className="adm-stat-top">
+        <div className="adm-stat-icon">{icon}</div>
+        {trend != null && (
+          <span className={`adm-pill ${trend >= 0 ? "is-up" : "is-down"}`}>
+            {trend >= 0 ? "▲" : "▼"} {Math.abs(trend).toFixed(1)}%
+          </span>
+        )}
+      </div>
+      <div className="adm-stat-value">
+        {live && <span className="adm-live-dot" />}
+        {value}
+      </div>
+      <div className="adm-stat-label">{label}</div>
+    </div>
+  );
+}
+
+/* ---------- dashboard ---------- */
+
 function Dashboard() {
   const [stats, setStats] = useState<Stats | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [range, setRange] = useState<number>(90);
+  const [range, setRange] = useState<number>(30);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
   const load = async (days: number) => {
@@ -240,7 +372,6 @@ function Dashboard() {
     [daily],
   );
 
-  // Trailing-week vs prior-week comparison, when there's enough history.
   const weekTrend = useMemo(() => {
     if (daily.length < 14) return null;
     const last7 = daily.slice(-7).reduce((s, d) => s + d.view_count, 0);
@@ -256,89 +387,141 @@ function Dashboard() {
   }
 
   return (
-    <div style={styles.page}>
-      <header style={styles.header}>
-        <div>
-          <h1 style={styles.title}>OpenMouse Admin</h1>
-          <p style={styles.muted}>
-            {lastUpdated ? `Updated ${lastUpdated.toLocaleTimeString()}` : "Loading…"}
-          </p>
-        </div>
-        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-          <div style={styles.rangeSwitch}>
-            {RANGE_OPTIONS.map((opt) => (
-              <button
-                key={opt}
-                onClick={() => setRange(opt)}
-                style={{ ...styles.rangeButton, ...(range === opt ? styles.rangeButtonActive : {}) }}
-              >
-                {opt}d
-              </button>
-            ))}
+    <div className="adm-root">
+      <aside className="adm-sidebar">
+        <div className="adm-brand">
+          <div className="adm-brand-mark">
+            <IconMouse />
           </div>
-          <button
-            style={styles.linkButton}
-            onClick={() => fetch("/api/admin/logout", { method: "POST" }).then(() => setError("session-expired"))}
-          >
-            Sign out
-          </button>
-        </div>
-      </header>
-
-      {error && <p style={styles.error}>{error}</p>}
-
-      <div style={styles.statRow}>
-        <div style={styles.stat}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span style={styles.liveDot} />
-            <div style={styles.statValue}>{stats?.live ?? "—"}</div>
-          </div>
-          <div style={styles.muted}>Live right now</div>
-        </div>
-        <div style={styles.stat}>
-          <div style={styles.statValue}>{stats?.allTimePeak ?? "—"}</div>
-          <div style={styles.muted}>
-            All-time peak{stats?.allTimePeakAt ? ` · ${new Date(stats.allTimePeakAt).toLocaleDateString()}` : ""}
+          <div>
+            <div className="adm-brand-name">OpenMouse</div>
+            <div className="adm-brand-sub">Admin</div>
           </div>
         </div>
-        <div style={styles.stat}>
-          <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
-            <div style={styles.statValue}>{totalViews.toLocaleString()}</div>
-            <Trend value={weekTrend} />
+        <nav className="adm-nav">
+          <div className="adm-nav-label">Monitor</div>
+          <div className="adm-nav-item is-active">
+            <IconOverview />
+            Overview
           </div>
-          <div style={styles.muted}>Views (last {daily.length} days){weekTrend !== null ? " · vs prior week" : ""}</div>
+          <div className="adm-nav-item">
+            <IconLive />
+            Live sessions
+          </div>
+          <div className="adm-nav-item">
+            <IconRegions />
+            Regions
+          </div>
+          <div className="adm-nav-item">
+            <IconDevices />
+            Devices
+          </div>
+          <div className="adm-nav-label">Manage</div>
+          <div className="adm-nav-item">
+            <IconSettings />
+            Settings
+          </div>
+        </nav>
+        <div className="adm-sidebar-foot">
+          <div className="adm-sf-row">
+            <span className="adm-sf-dot" /> Session active · 12h TTL
+          </div>
         </div>
-        <div style={styles.stat}>
-          <div style={styles.statValue}>{avgDaily.toFixed(1)}</div>
-          <div style={styles.muted}>Avg views / day</div>
-        </div>
-        <div style={styles.stat}>
-          <div style={styles.statValue}>{peakDay?.view_count ?? "—"}</div>
-          <div style={styles.muted}>Best day{peakDay ? ` · ${formatDay(peakDay.day)}` : ""}</div>
-        </div>
-      </div>
+      </aside>
 
-      <section style={styles.card}>
-        <h2 style={styles.h2}>Daily views</h2>
-        {daily.length > 0 ? <DailyBarChart points={daily} /> : <p style={styles.muted}>No history yet.</p>}
-      </section>
+      <main className="adm-main">
+        <div className="adm-topbar">
+          <div>
+            <h1 className="adm-h1">Overview</h1>
+            <p className="adm-muted">{lastUpdated ? `Updated ${lastUpdated.toLocaleTimeString()}` : "Loading…"}</p>
+          </div>
+          <div className="adm-topbar-right">
+            <div className="adm-range-switch">
+              {RANGE_OPTIONS.map((opt) => (
+                <button
+                  key={opt}
+                  className={`adm-range-btn ${range === opt ? "is-active" : ""}`}
+                  onClick={() => setRange(opt)}
+                >
+                  {opt}d
+                </button>
+              ))}
+            </div>
+            <button
+              className="adm-icon-btn"
+              title="Sign out"
+              onClick={() => fetch("/api/admin/logout", { method: "POST" }).then(() => setError("session-expired"))}
+            >
+              <IconLogout />
+            </button>
+          </div>
+        </div>
 
-      <div style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
-        <section style={{ ...styles.card, flex: "1 1 320px" }}>
-          <h2 style={styles.h2}>Regions</h2>
-          {topRegion && <p style={styles.muted}>Top: {topRegion.country ?? "Unknown"}</p>}
-          <BarList rows={stats?.regions ?? []} labelKey="country" valueKey="view_count" />
-        </section>
-        <section style={{ ...styles.card, flex: "1 1 320px" }}>
-          <h2 style={styles.h2}>Most used mice</h2>
-          {topMouse && <p style={styles.muted}>Top: {topMouse.mouse_model ?? "Unknown"}</p>}
-          <BarList rows={stats?.mice ?? []} labelKey="mouse_model" valueKey="uses" />
-        </section>
-        <section style={{ ...styles.card, flex: "1 1 320px" }}>
-          <h2 style={styles.h2}>Traffic by weekday</h2>
-          <WeekdayBreakdown points={daily} />
-        </section>
-      </div>
+        <div className="adm-content">
+          {error && <p className="adm-login-error">{error}</p>}
+
+          <div className="adm-stat-row">
+            <StatTile icon={<IconPulse />} value={stats?.live ?? "—"} label="Live right now" live />
+            <StatTile
+              icon={<IconPeak />}
+              value={stats?.allTimePeak ?? "—"}
+              label={`All-time peak${stats?.allTimePeakAt ? ` · ${new Date(stats.allTimePeakAt).toLocaleDateString()}` : ""}`}
+            />
+            <StatTile
+              icon={<IconTrend />}
+              value={totalViews.toLocaleString()}
+              label={`Views · last ${daily.length} days`}
+              trend={weekTrend}
+            />
+            <StatTile icon={<IconCalendar />} value={avgDaily.toFixed(1)} label="Avg views / day" />
+            <StatTile
+              icon={<IconStar />}
+              value={peakDay?.view_count ?? "—"}
+              label={`Best day${peakDay ? ` · ${formatDay(peakDay.day)}` : ""}`}
+            />
+          </div>
+
+          <section className="adm-card">
+            <div className="adm-card-head">
+              <div>
+                <p className="adm-card-title">Daily views</p>
+                <p className="adm-card-sub">Site visits per day, last {daily.length} days</p>
+              </div>
+            </div>
+            <DailyBarChart points={daily} />
+          </section>
+
+          <div className="adm-row3">
+            <section className="adm-card">
+              <div className="adm-card-head">
+                <div>
+                  <p className="adm-card-title">Regions</p>
+                  <p className="adm-card-sub">Top: {topRegion?.country ?? "—"}</p>
+                </div>
+              </div>
+              <BarList rows={stats?.regions ?? []} labelKey="country" valueKey="view_count" />
+            </section>
+            <section className="adm-card">
+              <div className="adm-card-head">
+                <div>
+                  <p className="adm-card-title">Most used mice</p>
+                  <p className="adm-card-sub">Top: {topMouse?.mouse_model ?? "—"}</p>
+                </div>
+              </div>
+              <BarList rows={stats?.mice ?? []} labelKey="mouse_model" valueKey="uses" />
+            </section>
+            <section className="adm-card">
+              <div className="adm-card-head">
+                <div>
+                  <p className="adm-card-title">Traffic by weekday</p>
+                  <p className="adm-card-sub">Views per day, by week</p>
+                </div>
+              </div>
+              <WeekdayHeatmap points={daily} />
+            </section>
+          </div>
+        </div>
+      </main>
     </div>
   );
 }
@@ -348,83 +531,5 @@ function Admin() {
   // answers, so start by trying the dashboard; a 401 falls back to login.
   return <Dashboard />;
 }
-
-const styles: Record<string, any> = {
-  page: {
-    fontFamily: "'DM Sans', system-ui, sans-serif",
-    background: "#0b0b0f",
-    color: "#f4f4f5",
-    minHeight: "100vh",
-    padding: "32px 40px",
-    boxSizing: "border-box",
-    display: "flex",
-    flexDirection: "column",
-    gap: 24,
-  },
-  header: { display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 12 },
-  title: { fontSize: 22, fontWeight: 600, margin: 0 },
-  h2: { fontSize: 15, fontWeight: 600, margin: "0 0 12px" },
-  muted: { opacity: 0.6, fontSize: 13, margin: "2px 0 0" },
-  error: { color: "#f87171", fontSize: 13 },
-  card: { background: "#151519", border: "1px solid #232329", borderRadius: 12, padding: 20 },
-  statRow: { display: "flex", gap: 16, flexWrap: "wrap" },
-  stat: { background: "#151519", border: "1px solid #232329", borderRadius: 12, padding: 20, minWidth: 180, flex: "1 1 180px" },
-  statValue: { fontSize: 30, fontWeight: 600, fontVariantNumeric: "tabular-nums" },
-  trend: { fontSize: 13, fontWeight: 600 },
-  liveDot: { width: 8, height: 8, borderRadius: "50%", background: "#4ade80", boxShadow: "0 0 8px #4ade80" },
-  rank: { width: 16, fontSize: 11, opacity: 0.4, fontVariantNumeric: "tabular-nums" },
-  axisLabel: { fontSize: 11, opacity: 0.5 },
-  rangeSwitch: { display: "flex", gap: 4, background: "#151519", border: "1px solid #232329", borderRadius: 8, padding: 3 },
-  rangeButton: {
-    background: "transparent",
-    border: "none",
-    borderRadius: 6,
-    padding: "6px 12px",
-    color: "#a1a1aa",
-    fontSize: 13,
-    cursor: "pointer",
-  },
-  rangeButtonActive: { background: "#8b5cf6", color: "white" },
-  loginCard: {
-    fontFamily: "'DM Sans', system-ui, sans-serif",
-    background: "#0b0b0f",
-    color: "#f4f4f5",
-    minHeight: "100vh",
-    display: "flex",
-    flexDirection: "column",
-    gap: 16,
-    alignItems: "flex-start",
-    justifyContent: "center",
-    padding: "0 20%",
-    boxSizing: "border-box",
-  },
-  input: {
-    background: "#151519",
-    border: "1px solid #232329",
-    borderRadius: 8,
-    padding: "10px 12px",
-    color: "#f4f4f5",
-    fontSize: 14,
-    width: 280,
-  },
-  button: {
-    background: "#8b5cf6",
-    border: "none",
-    borderRadius: 8,
-    padding: "10px 16px",
-    color: "white",
-    fontSize: 14,
-    fontWeight: 600,
-    cursor: "pointer",
-  },
-  linkButton: {
-    background: "transparent",
-    border: "none",
-    color: "#a1a1aa",
-    fontSize: 13,
-    cursor: "pointer",
-    textDecoration: "underline",
-  },
-};
 
 createRoot(document.getElementById("admin-app")!).render(<Admin />);

--- a/src/admin.tsx
+++ b/src/admin.tsx
@@ -13,6 +13,7 @@ type Stats = {
 };
 
 const LIVE_POLL_MS = 5000;
+const RANGE_OPTIONS = [7, 30, 90] as const;
 
 function LoginForm({ onLoggedIn }: { onLoggedIn: () => void }) {
   const [password, setPassword] = useState("");
@@ -61,41 +62,142 @@ function LoginForm({ onLoggedIn }: { onLoggedIn: () => void }) {
   );
 }
 
-function Sparkline({ points }: { points: DailyPoint[] }) {
-  const width = 720;
-  const height = 160;
+function formatDay(day: string) {
+  const d = new Date(day);
+  if (Number.isNaN(d.getTime())) return day;
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function pctChange(current: number, previous: number): number | null {
+  if (previous <= 0) return null;
+  return ((current - previous) / previous) * 100;
+}
+
+function Trend({ value }: { value: number | null }) {
+  if (value === null) return null;
+  const up = value >= 0;
+  return (
+    <span style={{ ...styles.trend, color: up ? "#4ade80" : "#f87171" }}>
+      {up ? "▲" : "▼"} {Math.abs(value).toFixed(1)}%
+    </span>
+  );
+}
+
+/** Bar chart of daily views, hover-scrubbed with a lightweight tooltip. */
+function DailyBarChart({ points }: { points: DailyPoint[] }) {
+  const [hover, setHover] = useState<number | null>(null);
+  const width = 760;
+  const height = 200;
   const max = Math.max(1, ...points.map((p) => p.view_count));
-  const path = points
-    .map((p, i) => {
-      const x = points.length > 1 ? (i / (points.length - 1)) * width : 0;
-      const y = height - (p.view_count / max) * height;
-      return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
-    })
-    .join(" ");
+  const barGap = 3;
+  const barWidth = points.length > 0 ? width / points.length - barGap : 0;
+
+  if (!points.length) return <p style={styles.muted}>No history yet.</p>;
+
+  const active = hover !== null ? points[hover] : points[points.length - 1];
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} width="100%" height={height} style={{ display: "block" }}>
-      <path d={path} fill="none" stroke="#8b5cf6" strokeWidth={2} />
-    </svg>
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 10 }}>
+        <div style={{ fontSize: 24, fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
+          {active.view_count.toLocaleString()}
+          <span style={{ ...styles.muted, marginLeft: 8, fontSize: 13 }}>views · {formatDay(active.day)}</span>
+        </div>
+        <div style={styles.muted}>peak concurrent {active.peak_concurrent}</div>
+      </div>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        width="100%"
+        height={height}
+        style={{ display: "block", overflow: "visible" }}
+        onMouseLeave={() => setHover(null)}
+      >
+        {points.map((p, i) => {
+          const barHeight = (p.view_count / max) * (height - 4);
+          const x = i * (barWidth + barGap);
+          const isActive = hover === i || (hover === null && i === points.length - 1);
+          return (
+            <rect
+              key={p.day}
+              x={x}
+              y={height - barHeight}
+              width={Math.max(1, barWidth)}
+              height={barHeight}
+              rx={2}
+              fill={isActive ? "#a78bfa" : "#3f3f52"}
+              onMouseEnter={() => setHover(i)}
+            />
+          );
+        })}
+      </svg>
+      <div style={{ display: "flex", justifyContent: "space-between", marginTop: 6 }}>
+        <span style={styles.axisLabel}>{formatDay(points[0].day)}</span>
+        <span style={styles.axisLabel}>{formatDay(points[points.length - 1].day)}</span>
+      </div>
+    </div>
+  );
+}
+
+/** Average views by weekday, derived client-side from the daily series. */
+function WeekdayBreakdown({ points }: { points: DailyPoint[] }) {
+  const labels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const totals = useMemo(() => {
+    const sums = new Array(7).fill(0);
+    const counts = new Array(7).fill(0);
+    for (const p of points) {
+      const d = new Date(p.day);
+      if (Number.isNaN(d.getTime())) continue;
+      const idx = d.getUTCDay();
+      sums[idx] += p.view_count;
+      counts[idx] += 1;
+    }
+    return sums.map((sum, i) => (counts[i] ? sum / counts[i] : 0));
+  }, [points]);
+  const max = Math.max(1, ...totals);
+
+  if (!points.length) return <p style={styles.muted}>No history yet.</p>;
+
+  return (
+    <div style={{ display: "flex", alignItems: "flex-end", gap: 8, height: 120 }}>
+      {totals.map((value, i) => (
+        <div key={labels[i]} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+          <div
+            style={{
+              width: "100%",
+              height: Math.max(2, (value / max) * 90),
+              background: "linear-gradient(180deg, #a78bfa, #7c3aed)",
+              borderRadius: 4,
+            }}
+            title={`${labels[i]}: ${value.toFixed(1)} avg views`}
+          />
+          <span style={styles.axisLabel}>{labels[i]}</span>
+        </div>
+      ))}
+    </div>
   );
 }
 
 function BarList({ rows, labelKey, valueKey }: { rows: CountRow[]; labelKey: "country" | "mouse_model"; valueKey: "view_count" | "uses" }) {
   const max = Math.max(1, ...rows.map((r) => Number(r[valueKey]) || 0));
+  const total = rows.reduce((sum, r) => sum + (Number(r[valueKey]) || 0), 0);
   if (!rows.length) return <p style={styles.muted}>No data yet.</p>;
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-      {rows.map((row) => {
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      {rows.map((row, i) => {
         const value = Number(row[valueKey]) || 0;
+        const share = total > 0 ? (value / total) * 100 : 0;
         return (
-          <div key={String(row[labelKey])} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span style={{ width: 160, fontSize: 13, opacity: 0.85, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          <div key={String(row[labelKey])} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <span style={styles.rank}>{i + 1}</span>
+            <span style={{ width: 140, fontSize: 13, opacity: 0.9, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
               {row[labelKey] || "Unknown"}
             </span>
             <div style={{ flex: 1, background: "#1f1f27", borderRadius: 4, overflow: "hidden", height: 10 }}>
-              <div style={{ width: `${(value / max) * 100}%`, background: "#8b5cf6", height: "100%" }} />
+              <div style={{ width: `${(value / max) * 100}%`, background: "linear-gradient(90deg, #7c3aed, #a78bfa)", height: "100%" }} />
             </div>
-            <span style={{ width: 40, textAlign: "right", fontSize: 13, fontVariantNumeric: "tabular-nums" }}>{value}</span>
+            <span style={{ width: 76, textAlign: "right", fontSize: 13, fontVariantNumeric: "tabular-nums" }}>
+              {value.toLocaleString()} <span style={styles.muted}>({share.toFixed(0)}%)</span>
+            </span>
           </div>
         );
       })}
@@ -106,9 +208,11 @@ function BarList({ rows, labelKey, valueKey }: { rows: CountRow[]; labelKey: "co
 function Dashboard() {
   const [stats, setStats] = useState<Stats | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [range, setRange] = useState<number>(90);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
-  const load = async () => {
-    const response = await fetch("/api/admin/stats");
+  const load = async (days: number) => {
+    const response = await fetch(`/api/admin/stats?days=${days}`);
     if (response.status === 401) {
       setError("session-expired");
       return;
@@ -118,65 +222,121 @@ function Dashboard() {
       return;
     }
     setStats(await response.json());
+    setLastUpdated(new Date());
     setError(null);
   };
 
   useEffect(() => {
-    load();
-    const interval = setInterval(load, LIVE_POLL_MS);
+    load(range);
+    const interval = setInterval(() => load(range), LIVE_POLL_MS);
     return () => clearInterval(interval);
-  }, []);
+  }, [range]);
 
-  const totalViews = useMemo(() => stats?.daily.reduce((sum, d) => sum + d.view_count, 0) ?? 0, [stats]);
+  const daily = stats?.daily ?? [];
+  const totalViews = useMemo(() => daily.reduce((sum, d) => sum + d.view_count, 0), [daily]);
+  const avgDaily = daily.length ? totalViews / daily.length : 0;
+  const peakDay = useMemo(
+    () => daily.reduce<DailyPoint | null>((best, d) => (!best || d.view_count > best.view_count ? d : best), null),
+    [daily],
+  );
+
+  // Trailing-week vs prior-week comparison, when there's enough history.
+  const weekTrend = useMemo(() => {
+    if (daily.length < 14) return null;
+    const last7 = daily.slice(-7).reduce((s, d) => s + d.view_count, 0);
+    const prev7 = daily.slice(-14, -7).reduce((s, d) => s + d.view_count, 0);
+    return pctChange(last7, prev7);
+  }, [daily]);
+
+  const topRegion = stats?.regions?.[0];
+  const topMouse = stats?.mice?.[0];
 
   if (error === "session-expired") {
-    return <LoginForm onLoggedIn={load} />;
+    return <LoginForm onLoggedIn={() => load(range)} />;
   }
 
   return (
     <div style={styles.page}>
-      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
-        <h1 style={styles.title}>OpenMouse Admin</h1>
-        <button
-          style={styles.linkButton}
-          onClick={() => fetch("/api/admin/logout", { method: "POST" }).then(() => setError("session-expired"))}
-        >
-          Sign out
-        </button>
+      <header style={styles.header}>
+        <div>
+          <h1 style={styles.title}>OpenMouse Admin</h1>
+          <p style={styles.muted}>
+            {lastUpdated ? `Updated ${lastUpdated.toLocaleTimeString()}` : "Loading…"}
+          </p>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+          <div style={styles.rangeSwitch}>
+            {RANGE_OPTIONS.map((opt) => (
+              <button
+                key={opt}
+                onClick={() => setRange(opt)}
+                style={{ ...styles.rangeButton, ...(range === opt ? styles.rangeButtonActive : {}) }}
+              >
+                {opt}d
+              </button>
+            ))}
+          </div>
+          <button
+            style={styles.linkButton}
+            onClick={() => fetch("/api/admin/logout", { method: "POST" }).then(() => setError("session-expired"))}
+          >
+            Sign out
+          </button>
+        </div>
       </header>
 
       {error && <p style={styles.error}>{error}</p>}
 
       <div style={styles.statRow}>
         <div style={styles.stat}>
-          <div style={styles.statValue}>{stats?.live ?? "—"}</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span style={styles.liveDot} />
+            <div style={styles.statValue}>{stats?.live ?? "—"}</div>
+          </div>
           <div style={styles.muted}>Live right now</div>
         </div>
         <div style={styles.stat}>
           <div style={styles.statValue}>{stats?.allTimePeak ?? "—"}</div>
           <div style={styles.muted}>
-            All-time peak{stats?.allTimePeakAt ? ` · ${new Date(stats.allTimePeakAt).toLocaleString()}` : ""}
+            All-time peak{stats?.allTimePeakAt ? ` · ${new Date(stats.allTimePeakAt).toLocaleDateString()}` : ""}
           </div>
         </div>
         <div style={styles.stat}>
-          <div style={styles.statValue}>{totalViews}</div>
-          <div style={styles.muted}>Views (last {stats?.daily.length ?? 0} days)</div>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+            <div style={styles.statValue}>{totalViews.toLocaleString()}</div>
+            <Trend value={weekTrend} />
+          </div>
+          <div style={styles.muted}>Views (last {daily.length} days){weekTrend !== null ? " · vs prior week" : ""}</div>
+        </div>
+        <div style={styles.stat}>
+          <div style={styles.statValue}>{avgDaily.toFixed(1)}</div>
+          <div style={styles.muted}>Avg views / day</div>
+        </div>
+        <div style={styles.stat}>
+          <div style={styles.statValue}>{peakDay?.view_count ?? "—"}</div>
+          <div style={styles.muted}>Best day{peakDay ? ` · ${formatDay(peakDay.day)}` : ""}</div>
         </div>
       </div>
 
       <section style={styles.card}>
         <h2 style={styles.h2}>Daily views</h2>
-        {stats && stats.daily.length > 0 ? <Sparkline points={stats.daily} /> : <p style={styles.muted}>No history yet.</p>}
+        {daily.length > 0 ? <DailyBarChart points={daily} /> : <p style={styles.muted}>No history yet.</p>}
       </section>
 
       <div style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
         <section style={{ ...styles.card, flex: "1 1 320px" }}>
           <h2 style={styles.h2}>Regions</h2>
+          {topRegion && <p style={styles.muted}>Top: {topRegion.country ?? "Unknown"}</p>}
           <BarList rows={stats?.regions ?? []} labelKey="country" valueKey="view_count" />
         </section>
         <section style={{ ...styles.card, flex: "1 1 320px" }}>
           <h2 style={styles.h2}>Most used mice</h2>
+          {topMouse && <p style={styles.muted}>Top: {topMouse.mouse_model ?? "Unknown"}</p>}
           <BarList rows={stats?.mice ?? []} labelKey="mouse_model" valueKey="uses" />
+        </section>
+        <section style={{ ...styles.card, flex: "1 1 320px" }}>
+          <h2 style={styles.h2}>Traffic by weekday</h2>
+          <WeekdayBreakdown points={daily} />
         </section>
       </div>
     </div>
@@ -201,14 +361,30 @@ const styles: Record<string, any> = {
     flexDirection: "column",
     gap: 24,
   },
+  header: { display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 12 },
   title: { fontSize: 22, fontWeight: 600, margin: 0 },
   h2: { fontSize: 15, fontWeight: 600, margin: "0 0 12px" },
-  muted: { opacity: 0.6, fontSize: 13 },
+  muted: { opacity: 0.6, fontSize: 13, margin: "2px 0 0" },
   error: { color: "#f87171", fontSize: 13 },
   card: { background: "#151519", border: "1px solid #232329", borderRadius: 12, padding: 20 },
   statRow: { display: "flex", gap: 16, flexWrap: "wrap" },
-  stat: { background: "#151519", border: "1px solid #232329", borderRadius: 12, padding: 20, minWidth: 200, flex: "1 1 200px" },
-  statValue: { fontSize: 32, fontWeight: 600, fontVariantNumeric: "tabular-nums" },
+  stat: { background: "#151519", border: "1px solid #232329", borderRadius: 12, padding: 20, minWidth: 180, flex: "1 1 180px" },
+  statValue: { fontSize: 30, fontWeight: 600, fontVariantNumeric: "tabular-nums" },
+  trend: { fontSize: 13, fontWeight: 600 },
+  liveDot: { width: 8, height: 8, borderRadius: "50%", background: "#4ade80", boxShadow: "0 0 8px #4ade80" },
+  rank: { width: 16, fontSize: 11, opacity: 0.4, fontVariantNumeric: "tabular-nums" },
+  axisLabel: { fontSize: 11, opacity: 0.5 },
+  rangeSwitch: { display: "flex", gap: 4, background: "#151519", border: "1px solid #232329", borderRadius: 8, padding: 3 },
+  rangeButton: {
+    background: "transparent",
+    border: "none",
+    borderRadius: 6,
+    padding: "6px 12px",
+    color: "#a1a1aa",
+    fontSize: 13,
+    cursor: "pointer",
+  },
+  rangeButtonActive: { background: "#8b5cf6", color: "white" },
   loginCard: {
     fontFamily: "'DM Sans', system-ui, sans-serif",
     background: "#0b0b0f",


### PR DESCRIPTION
## What

Rebuilds the gated `/admin` dashboard (`functions/api/admin/*`, password + Supabase-backed) around a proper analytics-dashboard shell instead of the previous single-column stat list.

- Fixed sidebar (brand mark, Overview/Live sessions/Regions/Devices/Settings nav, session-TTL footer) + top bar with a 7d/30d/90d range switch that's wired to the existing `?days=` param on `/api/admin/stats`.
- 5 KPI tiles: live viewers, all-time peak, total views with a week-over-week trend pill (derived client-side from the daily series), avg views/day, best day.
- Daily views is now a hover-interactive gradient bar chart (was a plain SVG sparkline).
- Weekday traffic is now a GitHub-style intensity heatmap, derived client-side from the daily series (no backend change).
- Regions / most-used-mice lists now show rank and % share alongside raw counts.
- New `src/admin.css` (mirrors how `control.tsx` imports `control.css`) replaces the old inline-style-object approach; loads Sora / IBM Plex Sans / IBM Plex Mono from Google Fonts via `admin.html`.
- Accent color is the project's existing green (`#69d28d` — used as `--success` in `control.css` and `--ck-accent` in `check.css`), not a new color.

No backend/API changes — everything renders from the same `Stats` shape `/api/admin/stats` already returns; new metrics (avg/day, best day, week trend, weekday heatmap) are all derived client-side.

## Testing

- `npx tsc --noEmit` — passes
- `npm run build` — passes (`vite build` succeeds, admin bundle included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1JcEWncXhtZzazWkMSL6m)_