### PR TITLE
feat: detect K-snake X11 in Mouse Check (VID 0xA8A4/0xA8A5)

### DIFF
--- a/src/check-scan.ts
+++ b/src/check-scan.ts
@@ -31,6 +31,8 @@ export const BRANDS: Record<number, string> = {
   0x0C45: "Redragon",
   0x1BCF: "Alienware",
   0x3151: "Fantech",
+  0xA8A4: "K-snake",
+  0xA8A5: "K-snake",
 };
 
 const OPENMOUSE_SUPPORTED = new Set([

--- a/src/supported-mice.ts
+++ b/src/supported-mice.ts
@@ -552,6 +552,8 @@ export const MICE: Mouse[] = [
     note: "CM protocol — not implemented" },
   { brand: "Cooler Master", model: "MM711",             status: "driver",    req: 1,
     note: "CM protocol — not implemented" },
+  { brand: "K-snake",     model: "X11",               status: "driver",    req: 1,
+    note: "VID 0xA8A4 (USB) / 0xA8A5 (2.4G) PID 0x2255 — 0x55-framed output-report protocol, vendor panel reverse-engineered, driver in progress in mouse-protocol" },
 
   // UNKNOWNS ────────────────────────────────────────────────────────────
   { brand: "Hitscan",       model: "Hyperlight",        status: "unknown",   req: 5,

--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -200,3 +200,11 @@ test("test-needed and unsupported models are not given new artwork", () => {
   assert.equal(deviceImage(null, "VGN Dragonfly R1 Pro"), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "Razer Viper 8KHz"), CDN + "unknown-device.png");
 });
+
+test("K-snake X11 wired and dongle share the same artwork", () => {
+  const wired = { vendorId: 0xa8a4, productId: 0x2255 } as HIDDevice;
+  const dongle = { vendorId: 0xa8a5, productId: 0x2255 } as HIDDevice;
+  assert.equal(deviceImage(wired), CDN + "ksnake-x11.png");
+  assert.equal(deviceImage(dongle), CDN + "ksnake-x11.png");
+  assert.equal(deviceImage(null, "K-snake X11"), CDN + "ksnake-x11.png");
+});

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -123,6 +123,9 @@ const DEVICE_IMAGES: ReadonlyMap<string, string> = new Map([
   ["1532:00b8", "razer-viper-v3-hyperspeed.png"],
   ["1532:00e5", "razer-viper-v4-pro.png"],
   ["1532:00e6", "razer-viper-v4-pro.png"],
+  // K-snake X11 wired / 2.4 GHz dongle share the same shell.
+  ["a8a4:2255", "ksnake-x11.png"],
+  ["a8a5:2255", "ksnake-x11.png"],
 ]);
 
 function deviceKey(device: HIDDevice): string {
@@ -183,6 +186,8 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
   if (/\bsword\s*x\b/i.test(displayName)) return "wlmouse-sword-x.png";
   if (/\bdragonfly\s*f2\b/i.test(displayName)) return "vgn-dragonfly-f2.png";
   if (/\bmaya\s*x\b/i.test(displayName)) return "lamzu-maya-x.png";
+  if (/\bk-snake\b/i.test(displayName)) return "ksnake-x11.png";
+  if (/\bx11\b/i.test(displayName)) return "ksnake-x11.png";
   if (/\bf1\s*v2\b/i.test(displayName)) return "atk-f1-v2-ultra-max.png";
   if (/\b(finalmouse|starlight|ulx)\b/i.test(displayName)) return "finalmouse-ulx.png";
   if (/\borbital\b/i.test(displayName)) return "unknown-device.png";


### PR DESCRIPTION
Detect K-snake X11 (VID 0xA8A4 USB / 0xA8A5 2.4G, PID 0x2255) in Mouse Check.

- Add 0xA8A4/0xA8A5 to BRANDS so check.html labels the dongle instead of Unknown and SCAN_FILTERS offers the vendor 0xFF01 interface.
- List X11 as driver-needed in supported-mice (no protocol driver yet).

Evidence:
- Vendor WebHID panel https://x1a11.yjx2012.com/ requests [{vendorId:43172,productId:8789,usagePage:65281,usage:16},{vendorId:43173,...}] (0xA8A4/0xA8A5:0x2255, 0xFF01:0x10).
- HID Diagnostic Report from hardware (2.4G dongle): 3x USB Receiver VID_A8A5 PARTIAL, first with Vendor (0xFF01), others FFA5 / FF05+FF06. Output-report protocol (sendReport 0 + 0x55 framing), so PARTIAL is expected.

Full 0x55 codec + WebHID client draft lives locally (readStatus/setDpi/setPollingRate) and will come as a mouse-protocol PR; this PR only unblocks detection/listing.

Checks: npm run check passes (113 tests).