### PR TITLE
Add tag legend to Supported Devices page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -481,7 +481,7 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#c46377634bb9a6294a101bb5b799d7737e5b8c40",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#eb9de5d9574b626fbb40a445edeb4aeafbdfe2bf",
       "engines": {
         "node": ">=20"
       }

--- a/src/supported.css
+++ b/src/supported.css
@@ -373,6 +373,45 @@ a:focus-visible, button:focus-visible, input:focus-visible {
 }
 .tag-tip[hidden] { display: none; }
 
+/* ── Tag legend ──────────────────────────────────────────────────────────── */
+.tag-legend {
+  margin: 0.75rem 0;
+  border: 1px solid var(--bg-border);
+  border-radius: 10px;
+  background: var(--bg-surface);
+  padding: 0.1rem 0.9rem;
+}
+.tag-legend summary {
+  cursor: pointer;
+  padding: 0.55rem 0;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  list-style: none;
+}
+.tag-legend summary::-webkit-details-marker { display: none; }
+.tag-legend summary::before { content: "▸ "; }
+.tag-legend[open] summary::before { content: "▾ "; }
+.tag-legend-list {
+  margin: 0;
+  padding: 0 0 0.75rem;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.35rem 1.25rem;
+}
+.tag-legend-list li {
+  font-size: 0.8rem;
+  color: var(--ink-2);
+  line-height: 1.4;
+}
+.tag-legend-list .dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 0.4rem;
+}
+
 /* ── Device list ─────────────────────────────────────────────────────────── */
 .main-content { padding: 1.25rem 0 4rem; }
 

--- a/src/supported.ts
+++ b/src/supported.ts
@@ -189,6 +189,14 @@ app.innerHTML = `
       <div class="result-count" id="result-count"></div>
     </div>
 
+    <details class="tag-legend">
+      <summary>What do the tags mean?</summary>
+      <ul class="tag-legend-list">
+        ${STATUS_LEGEND.map(([key, tip]) => `
+          <li><span class="dot" style="background:${STATUS_DOT[key]}"></span><strong>${STATUS[key].label}</strong> — ${tip}</li>`).join("")}
+      </ul>
+    </details>
+
     <main class="main-content">
       <div id="device-list"></div>
     </main>


### PR DESCRIPTION
## Summary
Adds a small collapsible legend box on the Supported Devices page (`/supported`) explaining what each status tag means, addressing the report that the colored dot/badge tags had no explanation.

- Placed directly below the filter toolbar (brand/tag dropdowns + search) and above the first brand accordion row, per the request.
- Implemented as a `<details>`/`<summary>` element (defaults collapsed) so it stays compact and doesn't push extra vertical space when not needed, while still being always-discoverable.
- Reuses the existing `STATUS_LEGEND` descriptions and `STATUS_DOT` colors already used for the tag-filter dropdown tooltips, so the wording/colors match what's already in the code and can't drift:
  - **Supported** — Confirmed working with a registered driver
  - **PR pending** — Pull request adding the driver is open
  - **Quick Win** — Protocol implemented — only PID/config entry missing
  - **Test Needed** — Driver probably covers it — needs hardware test
  - **Driver Needed** — No driver exists yet
  - **Unknown** — Protocol not yet identified
  - **Needs Bridge** — Not compatible with WebHID — needs the OpenMouse Bridge companion
  - **Requested** — Live community request
- Styling matches the existing dark-theme card/border conventions in `src/supported.css` (`--bg-surface`, `--bg-border`, `--ink-*` tokens).

## Files changed
- `src/supported.ts` — legend markup, inserted between the toolbar and `<main>`
- `src/supported.css` — `.tag-legend` styles
- `package-lock.json` — refreshed after `npm install` (dependency string unchanged, resolved commit hash updated)

## Verification
- `npm run check` — build + all 119 tests pass
- `npm run size` — CSS 143107/195000 (73%), JS 787587/790000 (100%, still within budget, no BUDGET_BYTES change needed)
- `npm audit --audit-level=high` — 0 vulnerabilities
- Verified `package.json` dependency strings still exactly match: `"@openmouse/protocol": "https://github.com/OpenMouse-Project/mouse-protocol.git"`, `"preact": "^10.29.8"` (npm install had normalized the protocol URL to `github:...`; reverted before committing)

https://claude.ai/code/session_014cM8LdYwaPgZKrwYXp9bZe