### PR TITLE
supported: open the tag legend by default

### DIFF
--- a/src/supported.ts
+++ b/src/supported.ts
@@ -189,7 +189,7 @@ app.innerHTML = `
       <div class="result-count" id="result-count"></div>
     </div>
 
-    <details class="tag-legend">
+    <details class="tag-legend" open>
       <summary>What do the tags mean?</summary>
       <ul class="tag-legend-list">
         ${STATUS_LEGEND.map(([key, tip]) => `


### PR DESCRIPTION
Follow-up to #176 — the tag legend should be visible on page load, not collapsed behind a click.