### PR TITLE
Add FAQ page with a shared header for the landing page

### DIFF
--- a/build/pwa-vite-plugin.ts
+++ b/build/pwa-vite-plugin.ts
@@ -23,7 +23,7 @@ const STATIC_PRECACHE = [
  */
 const TARGET_PAGES: Record<string, string[]> = {
   app: ["index.html"],
-  landing: ["landing.html", "check.html", "supported.html", "donate.html"],
+  landing: ["landing.html", "check.html", "supported.html", "donate.html", "faq.html"],
 };
 
 export const ROOT_PAGE: Record<string, string> = {

--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#09090b" />
+    <meta name="robots" content="index, follow" />
+    <title>FAQ — OpenMouse</title>
+    <meta
+      name="description"
+      content="Frequently asked questions about OpenMouse — the free, open source mouse configurator that runs entirely in your browser over WebHID."
+    />
+    <link rel="icon" href="/favicon.ico" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="canonical" href="https://openmouse.app/faq.html" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="OpenMouse" />
+    <meta property="og:url" content="https://openmouse.app/faq.html" />
+    <meta property="og:title" content="FAQ — OpenMouse" />
+    <meta property="og:description" content="Frequently asked questions about OpenMouse — the free, open source mouse configurator that runs entirely in your browser over WebHID." />
+    <meta property="og:image" content="https://openmouse.app/og-image.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="faq-app"></div>
+    <script type="module" src="/src/faq.tsx"></script>
+  </body>
+</html>

--- a/src/app/site-chrome.tsx
+++ b/src/app/site-chrome.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import {
+  DiscordIcon,
+  DISCORD_URL,
+  formatCount,
+  GitHubIcon,
+  GITHUB_URL,
+  StarIcon,
+  TwitterIcon,
+  TWITTER_URL,
+  useGitHubStars,
+} from "./social-links";
+
+// The control app lives on its own subdomain — dev.openmouse.app is
+// retired, openmouse.app is this marketing page, control.openmouse.app is
+// the actual configurator.
+export const APP_URL = "https://control.openmouse.app/";
+
+// Shared header/footer for the marketing pages (openmouse.app) — landing.tsx
+// and faq.tsx both render these so the two pages look coherent.
+export function SiteNav(): ReactNode {
+  return (
+    <header className="land-nav">
+      <a className="land-brand" href="/">
+        <img src="/logo.png" alt="" width={22} height={32} />
+        OpenMouse
+      </a>
+      <nav className="land-nav-links">
+        <a href="/supported.html">Supported mice</a>
+        <a href="/faq.html">FAQ</a>
+        <a href="https://docs.openmouse.app">Contribute</a>
+        <a href="/donate.html">Donate</a>
+        <a href={GITHUB_URL} target="_blank" rel="noreferrer">GitHub</a>
+      </nav>
+      <a className="land-nav-cta" href={APP_URL}>Open the app</a>
+    </header>
+  );
+}
+
+export function SiteFooter(): ReactNode {
+  const stars = useGitHubStars();
+
+  return (
+    <footer className="land-footer">
+      <a href={DISCORD_URL} target="_blank" rel="noreferrer" title="Discord" aria-label="OpenMouse on Discord">
+        <DiscordIcon />
+      </a>
+      <a href={TWITTER_URL} target="_blank" rel="noreferrer" title="Twitter" aria-label="OpenMouse on Twitter">
+        <TwitterIcon />
+      </a>
+      <a
+        className="land-footer-stars"
+        href={GITHUB_URL}
+        target="_blank"
+        rel="noreferrer"
+        title="GitHub"
+        aria-label="OpenMouse on GitHub"
+      >
+        <GitHubIcon />
+        {stars !== null && (
+          <span className="land-star-count">
+            <StarIcon />
+            {formatCount(stars)}
+          </span>
+        )}
+      </a>
+      <a href="/donate.html">Donate</a>
+    </footer>
+  );
+}

--- a/src/faq.tsx
+++ b/src/faq.tsx
@@ -1,0 +1,112 @@
+import type { ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+// FAQ shares landing.css so the header/footer render identically to the
+// landing page — see src/app/site-chrome.tsx for the shared components.
+import "./landing.css";
+import { mountOfflineBanner } from "./offline-banner";
+import { registerServiceWorker } from "./register-sw";
+import { SiteFooter, SiteNav } from "./app/site-chrome";
+import { DISCORD_URL, GITHUB_URL } from "./app/social-links";
+
+interface FaqEntry {
+  question: string;
+  answer: ReactNode;
+}
+
+const FAQS: FaqEntry[] = [
+  {
+    question: "Is OpenMouse free?",
+    answer:
+      "Yes. OpenMouse is free and open source, with no accounts, subscriptions, or paid tiers.",
+  },
+  {
+    question: "Does OpenMouse send any of my data anywhere?",
+    answer:
+      "No. OpenMouse runs entirely in your browser over WebHID — there's no telemetry, no background service, and nothing phones home. You can read exactly what it does, since every driver is open source.",
+  },
+  {
+    question: "Which mice are supported?",
+    answer: (
+      <>
+        Dozens of gaming mice across several brands. Check the{" "}
+        <a href="/supported.html">supported mice list</a> for the current
+        set — support depends on what the community has reverse-engineered
+        and tested so far.
+      </>
+    ),
+  },
+  {
+    question: "What browsers work with OpenMouse?",
+    answer:
+      "OpenMouse needs a browser with WebHID support, so Chrome, Edge, and other Chromium-based browsers work. Firefox and Safari don't currently support WebHID.",
+  },
+  {
+    question: "My mouse isn't listed — can I add support for it?",
+    answer: (
+      <>
+        Yes. The{" "}
+        <a href="https://docs.openmouse.app">contribution guide</a> walks
+        through safe reverse-engineering practices and how the driver repos
+        fit together.
+      </>
+    ),
+  },
+  {
+    question: "Do I need to install anything?",
+    answer:
+      "No installer, no driver, no background app. Plug in your mouse, open the page in a supported browser, and it's there.",
+  },
+  {
+    question: "Is my configuration stored anywhere?",
+    answer:
+      "Your settings are only stored locally, in your browser — there's no account and no cloud sync.",
+  },
+  {
+    question: "How can I support the project?",
+    answer: (
+      <>
+        Star the project on <a href={GITHUB_URL} target="_blank" rel="noreferrer">GitHub</a>,
+        join the <a href={DISCORD_URL} target="_blank" rel="noreferrer">Discord</a>, or{" "}
+        <a href="/donate.html">donate</a> to help fund testing hardware and
+        development.
+      </>
+    ),
+  },
+];
+
+function Faq(): ReactNode {
+  return (
+    <section className="land-faq">
+      <h1>Frequently asked questions</h1>
+      <dl className="land-faq-list">
+        {FAQS.map(({ question, answer }) => (
+          <div className="land-faq-item" key={question}>
+            <dt>{question}</dt>
+            <dd>{answer}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function FaqPage(): ReactNode {
+  return (
+    <div className="land-shell">
+      <SiteNav />
+      <Faq />
+      <SiteFooter />
+    </div>
+  );
+}
+
+const faqApp = document.querySelector<HTMLDivElement>("#faq-app");
+
+if (!faqApp) {
+  throw new Error("OpenMouse could not find the FAQ page root.");
+}
+
+createRoot(faqApp).render(<FaqPage />);
+
+registerServiceWorker();
+mountOfflineBanner();

--- a/src/landing.css
+++ b/src/landing.css
@@ -263,3 +263,50 @@ body {
   height: 13px;
   color: #69d28d;
 }
+
+/* ── FAQ ───────────────────────────────────────────────────────────────── */
+.land-faq {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: clamp(2.5rem, 8vw, 4rem) 1.5rem clamp(3rem, 6vw, 4.5rem);
+}
+
+.land-faq h1 {
+  margin: 0 0 2rem;
+  font-size: clamp(1.8rem, 5vw, 2.6rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  text-align: center;
+}
+
+.land-faq-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+}
+
+.land-faq-item {
+  padding: 1.4rem 1.6rem;
+  border: 1px solid color-mix(in srgb, #69d28d 12%, #232527);
+  border-radius: 14px;
+  background: color-mix(in srgb, #14161a 88%, transparent);
+}
+
+.land-faq-item dt {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.land-faq-item dd {
+  margin: 0.5rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #7a9498;
+}
+
+.land-faq-item dd a {
+  color: #69d28d;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}

--- a/src/landing.tsx
+++ b/src/landing.tsx
@@ -3,40 +3,7 @@ import { createRoot } from "react-dom/client";
 import "./landing.css";
 import { mountOfflineBanner } from "./offline-banner";
 import { registerServiceWorker } from "./register-sw";
-import {
-  DiscordIcon,
-  DISCORD_URL,
-  formatCount,
-  GitHubIcon,
-  GITHUB_URL,
-  StarIcon,
-  TwitterIcon,
-  TWITTER_URL,
-  useGitHubStars,
-} from "./app/social-links";
-
-// The control app lives on its own subdomain — dev.openmouse.app is
-// retired, openmouse.app is this marketing page, control.openmouse.app is
-// the actual configurator.
-const APP_URL = "https://control.openmouse.app/";
-
-function Nav(): ReactNode {
-  return (
-    <header className="land-nav">
-      <a className="land-brand" href="/">
-        <img src="/logo.png" alt="" width={22} height={32} />
-        OpenMouse
-      </a>
-      <nav className="land-nav-links">
-        <a href="/supported.html">Supported mice</a>
-        <a href="https://docs.openmouse.app">Contribute</a>
-        <a href="/donate.html">Donate</a>
-        <a href={GITHUB_URL} target="_blank" rel="noreferrer">GitHub</a>
-      </nav>
-      <a className="land-nav-cta" href={APP_URL}>Open the app</a>
-    </header>
-  );
-}
+import { APP_URL, SiteFooter, SiteNav } from "./app/site-chrome";
 
 function Hero(): ReactNode {
   return (
@@ -99,46 +66,14 @@ function Contribute(): ReactNode {
   );
 }
 
-function Footer(): ReactNode {
-  const stars = useGitHubStars();
-
-  return (
-    <footer className="land-footer">
-      <a href={DISCORD_URL} target="_blank" rel="noreferrer" title="Discord" aria-label="OpenMouse on Discord">
-        <DiscordIcon />
-      </a>
-      <a href={TWITTER_URL} target="_blank" rel="noreferrer" title="Twitter" aria-label="OpenMouse on Twitter">
-        <TwitterIcon />
-      </a>
-      <a
-        className="land-footer-stars"
-        href={GITHUB_URL}
-        target="_blank"
-        rel="noreferrer"
-        title="GitHub"
-        aria-label="OpenMouse on GitHub"
-      >
-        <GitHubIcon />
-        {stars !== null && (
-          <span className="land-star-count">
-            <StarIcon />
-            {formatCount(stars)}
-          </span>
-        )}
-      </a>
-      <a href="/donate.html">Donate</a>
-    </footer>
-  );
-}
-
 function Landing(): ReactNode {
   return (
     <div className="land-shell">
-      <Nav />
+      <SiteNav />
       <Hero />
       <Features />
       <Contribute />
-      <Footer />
+      <SiteFooter />
     </div>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
               // contribute.html was retired in favor of docs.openmouse.app
               // (see sites-vite-plugin.ts for the redirect).
               landing: resolve(__dirname, "landing.html"),
+              faq: resolve(__dirname, "faq.html"),
               check: resolve(__dirname, "check.html"),
               supported: resolve(__dirname, "supported.html"),
               donate: resolve(__dirname, "donate.html"),


### PR DESCRIPTION
## Summary
- Adds a new FAQ page (`faq.html` / `src/faq.tsx`) covering cost, privacy/telemetry, supported mice, browser support, contributing a driver, whether an install is needed, local-only storage, and how to support the project.
- Extracts the landing page's nav and footer into `src/app/site-chrome.tsx` so the landing page and the FAQ page render an identical header/footer, and adds a "FAQ" link to that shared nav.
- Registers `faq.html` in the landing build target (`vite.config.ts`) and its offline precache list (`build/pwa-vite-plugin.ts`).

## Testing
- `tsc --noEmit && vite build` (landing target) — passes
- `npm test` — 120/120 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMTo1msWZCnq3434edNJTx)_