### PR TITLE
docs: document VXE Linux WebHID access

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ If a device appears in Chromium's picker but OpenMouse reports `Failed to open
 the device`, check the permissions on its `/dev/hidraw*` nodes. Linux does not
 grant user access to every HID device by default.
 
-For the VXE R1 SE+ and its 1K receiver, install this narrowly scoped udev rule:
+First inspect the connected device IDs:
+
+```bash
+lsusb
+```
+
+VXE R1 SE+ hardware ships with more than one receiver implementation. If the
+mouse and 1K receiver appear as `3554:f58f` and `3554:f58e`, respectively,
+install these narrowly scoped rules:
 
 ```udev
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f58f", TAG+="uaccess"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@ Run the full local check before pushing changes:
 npm run check
 ```
 
+### Linux WebHID permissions
+
+If a device appears in Chromium's picker but OpenMouse reports `Failed to open
+the device`, check the permissions on its `/dev/hidraw*` nodes. Linux does not
+grant user access to every HID device by default.
+
+For the VXE R1 SE+ and its 1K receiver, install this narrowly scoped udev rule:
+
+```udev
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f58f", TAG+="uaccess"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f58e", TAG+="uaccess"
+```
+
+Save it as `/etc/udev/rules.d/70-openmouse-vxe.rules`, reload the rules, then
+unplug and reconnect both devices:
+
+```bash
+sudo udevadm control --reload-rules
+```
+
+Grant access to every `hidraw` node for each product. Chromium opens the HID
+device before OpenMouse selects its vendor configuration collection, so access
+to only the `0xff02:0x0002` collection's node is insufficient.
+
 ## Contributing
 
 OpenMouse is one repository in a family — with the **Desktop** app,

--- a/src/supported-mice.ts
+++ b/src/supported-mice.ts
@@ -423,7 +423,7 @@ export const MICE: Mouse[] = [
     note: "VGN F2 driver (0xfb56/0xfb57) covers Dragonfly F2; R1 Pro needs test" },
   { brand: "VXE", model: "R1 SE+ (wired)",              status: "supported", req: 3,
     pids: [0xf58f],
-    note: "Wired 0x3554:0xf58f identity, status reads, and DPI writes verified through Chromium WebHID. Driver supports PAW3395SE DPI, polling, LOD, debounce, motion sync, ripple control, sleep timeout, angle snapping, battery, and firmware; receiver mode remains unverified" },
+    note: "Wired 0x3554:0xf58f identity, settings, profiles, and button inspection verified through Chromium WebHID. Wireless identity and receiver telemetry verified through the 0x3554:0xf58e 1K receiver" },
   { brand: "ATK", model: "X1 V2 Ultimate",              status: "likely",    req: 1,
     note: "ATK driver (0x373b) likely covers — needs hardware test" },
   { brand: "ATK", model: "A9 Air",                      status: "likely",    req: 1,


### PR DESCRIPTION
## Summary
- document PID-scoped Linux udev rules for the VXE R1 SE+ and 1K receiver
- explain why Chromium needs access to every hidraw collection for the selected device
- replace the stale receiver-unverified note with the completed wired and wireless hardware coverage

## Verification
- `npm run check` (120 tests)
- `udevadm verify /tmp/opencode/openmouse-vxe.rules`
- Chromium WebHID smoke test on `3554:f58f` and `3554:f58e`; no settings staged or written