### PR TITLE
ui: Add Microsoft Intellimouse Classic & Pro integration

### DIFF
--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -142,6 +142,7 @@ import {
 } from "@openmouse/protocol/keychron";
 import { SUPPORTED_HID_FILTERS } from "@openmouse/protocol/drivers/vendors";
 import { WLMouseHidClient } from "@openmouse/protocol/drivers/wlmouse/hid";
+import { MicrosoftHidClient } from "@openmouse/protocol/drivers/microsoft/hid";
 import { parsePreviewMode, previewsEnabled, type PreviewMode } from "../preview-modes";
 import { sleepLabel } from "./options";
 import { traitsFor } from "./traits";
@@ -193,7 +194,7 @@ function activeAs<T>(...classes: ClientClass<T>[]): T | null {
 
 const DM_CLASSES = [WLMouseHidClient, LamzuHidClient, AtkHidClient, NinjutsoHidClient] as const;
 const RAZER_CLASSES = [RazerHidClient, RazerViperMiniHidClient, RazerViperHidClient, RazerCobraHidClient] as const;
-const NEEDS_OPEN = [TeevolutionHidClient, VgnF2HidClient, KeychronNapeHidClient, KeychronM6HidClient, ModdoHidClient, ZaunkoenigHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient, GloriousHidClient, GloriousClassicHidClient, MchoseHidClient, MchoseDockHidClient] as const;
+const NEEDS_OPEN = [TeevolutionHidClient, VgnF2HidClient, KeychronNapeHidClient, KeychronM6HidClient, ModdoHidClient, ZaunkoenigHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient, GloriousHidClient, GloriousClassicHidClient, MchoseHidClient, MchoseDockHidClient, MicrosoftHidClient] as const;
 const PULSAR_CLASSES = [PulsarHidClient, PulsarProHidClient, PulsarXs1HidClient] as const;
 
 const logitechClient = (): LogitechHidppClient | null => activeAs(LogitechHidppClient);

--- a/src/supported-mice.ts
+++ b/src/supported-mice.ts
@@ -523,6 +523,14 @@ export const MICE: Mouse[] = [
     pids: [0x080c],
     note: "PID 0x080c in Orbital driver" },
 
+  // MICROSOFT ───────────────────────────────────────────────────────────
+  { brand: "Microsoft", model: "Pro Intellimouse",      status: "supported", req: 0,
+    pids: [0x082a],
+    note: "For LOD, Low is 2mm, High is 3mm. Calibrated surface 1/2/3 is not supported yet." },
+  { brand: "Microsoft", model: "Classic Intellimouse",  status: "supported", req: 0,
+    pids: [0x0823],
+    note: "" },
+
   // KEYCHRON ────────────────────────────────────────────────────────────
   { brand: "Keychron", model: "Nape Pro",               status: "supported", req: 1,
     pids: [0x0440],

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -142,6 +142,9 @@ const DEVICE_IMAGES: ReadonlyMap<string, string> = new Map([
   // K-snake X11 wired / 2.4 GHz dongle share the same shell.
   ["a8a4:2255", "ksnake-x11.png"],
   ["a8a5:2255", "ksnake-x11.png"],
+  // Microsoft Intellimouse
+  ["045e:0823", "microsoft-classic-intellimouse.png"],
+  ["045e:082a", "microsoft-pro-intellimouse.png"],
 ]);
 
 function deviceKey(device: HIDDevice): string {
@@ -218,6 +221,9 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
   if (/\b(finalmouse|starlight|ulx)\b/i.test(displayName)) return "finalmouse-ulx.png";
   if (/\borbital\b/i.test(displayName)) return "unknown-device.png";
   if (/\bmoddo/i.test(displayName)) return "unknown-device.png";
+  if (/\bintellimouse\s*classic\b/i.test(displayName)) return "microsoft-classic-intellimouse.png";
+  if (/\bpro\s*intellimouse\b/i.test(displayName)) return "microsoft-pro-intellimouse.png";
+  if (/\bintellimouse\b/i.test(displayName)) return "microsoft-classic-intellimouse.png";
   // Pulsar 4K Wireless Receiver ships with the X2 V2 4K dongle kit; the receiver
   // product id is not yet published, so match the name reported by WebHID.
   if (/pulsar/i.test(displayName)) return "pulsar-x2-v2.png";


### PR DESCRIPTION
This PR integrates the Microsoft Intellimouse series into the Openmouse UI.

**Changes:**
* Registered `Microsoft Classic Intellimouse` and `Microsoft Pro Intellimouse` in the supported mouse catalog.
* Added a dedicated UI note for the Pro Intellimouse clarifying the physical measurements for the LOD settings (`For LOD, Low is 2mm, High is 3mm. Calibrated surface 1/2/3 is not supported yet.`).
* Configured the device image mappings so the proper product photos are loaded in the frontend.

**Dependencies:**
* Relies on the protocol driver added in this PR: 
https://github.com/OpenMouse-Project/mouse-protocol/pull/62