### PR TITLE
fix: K-snake artwork fallback and supported status for the X11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -481,7 +481,7 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#541f39eeb5b2cf5761bb1239e8d825a7052004fe",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#1414699df47c17d2ee56c73e6e02b1d711fc4d39",
       "engines": {
         "node": ">=20"
       }

--- a/src/supported-mice.test.ts
+++ b/src/supported-mice.test.ts
@@ -26,6 +26,7 @@ import { RAZER_PRODUCTS } from "@openmouse/protocol/razer-devices";
 import { TEEVOLUTION_PRODUCT_IDS } from "@openmouse/protocol/teevolution";
 import { ZAUNKOENIG_PRODUCT_IDS } from "@openmouse/protocol/zaunkoenig";
 import { CORSAIR_PRODUCT_IDS } from "@openmouse/protocol/corsair";
+import { KSNAKE_PRODUCTS } from "@openmouse/protocol/ksnake";
 
 import { MICE, STATUS, type Mouse, type Status } from "./supported-mice.ts";
 
@@ -155,6 +156,8 @@ const PID_UNIVERSE = new Set<number>([
   ...GLORIOUS_PRODUCTS.keys(),
   ...GLORIOUS_CLASSIC_PRODUCTS.keys(),
   ...MICROSOFT_PRODUCTS,
+  // K-snake X11 wired + 2.4 GHz dongle share PID 0x2255 (src/ksnake).
+  ...KSNAKE_PRODUCTS.keys(),
 ]);
 test("every pinned PID on a coverage claim exists in the protocol registry", () => {
   const withPids: Array<Mouse & { pids: readonly number[] }> = MICE.filter(

--- a/src/supported-mice.ts
+++ b/src/supported-mice.ts
@@ -567,8 +567,9 @@ export const MICE: Mouse[] = [
     note: "CM protocol — not implemented" },
   { brand: "Cooler Master", model: "MM711",             status: "driver",    req: 1,
     note: "CM protocol — not implemented" },
-  { brand: "K-snake",     model: "X11",               status: "driver",    req: 1,
-    note: "VID 0xA8A4 (USB) / 0xA8A5 (2.4G) PID 0x2255 — 0x55-framed output-report protocol, vendor panel reverse-engineered, driver in progress in mouse-protocol" },
+  { brand: "K-snake",     model: "X11",               status: "supported", req: 1,
+    pids: [0x2255],
+    note: "VID 0xA8A4 (USB) / 0xA8A5 (2.4G) PID 0x2255 — 0x55-framed output-report protocol, verified on retail dongle hardware (FW 2.1.7)" },
 
   // UNKNOWNS ────────────────────────────────────────────────────────────
   { brand: "Hitscan",       model: "Hyperlight",        status: "unknown",   req: 5,

--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -223,3 +223,8 @@ test("K-snake X11 wired and dongle share the same artwork", () => {
   assert.equal(deviceImage(dongle), CDN + "ksnake-x11.png");
   assert.equal(deviceImage(null, "K-snake X11"), CDN + "ksnake-x11.png");
 });
+
+test("Attack Shark X11 does not inherit K-snake artwork", () => {
+  assert.equal(deviceImage(null, "Attack Shark X11"), CDN + "unknown-device.png");
+  assert.equal(deviceImage(null, "Attack Shark X11 SE"), CDN + "unknown-device.png");
+});

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -219,8 +219,7 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
   if (/\bsword\s*x\b/i.test(displayName)) return "wlmouse-sword-x.png";
   if (/\bdragonfly\s*f2\b/i.test(displayName)) return "vgn-dragonfly-f2.png";
   if (/\bmaya\s*x\b/i.test(displayName)) return "lamzu-maya-x.png";
-  if (/\bk-snake\b/i.test(displayName)) return "ksnake-x11.png";
-  if (/\bx11\b/i.test(displayName)) return "ksnake-x11.png";
+  if (/k[\s-]*snake/i.test(displayName)) return "ksnake-x11.png";
   if (/\bf1\s*v2\b/i.test(displayName)) return "atk-f1-v2-ultra-max.png";
   // Catches any A7 V2 variant whose product id is not pinned above.
   if (/\ba7\s*v2\b/i.test(displayName)) return "mchose-a7-v2.png";


### PR DESCRIPTION
Clean merge of #198 onto current control-panel — no conflicts, all checks pass. Closes #198.