### PR TITLE
fix: move build badge next to the logo in the sidebar

### DIFF
--- a/src/app/Sidebar.tsx
+++ b/src/app/Sidebar.tsx
@@ -114,6 +114,7 @@ export function Sidebar({ snapshot }: { snapshot: ControlSnapshot }): ReactNode 
       <span className="demo-wordmark">
         <img src="/logo.png" alt="" width={181} height={268} />
         OpenMouse
+        <span className="build-badge" title={`OpenMouse ${snapshot.buildLabel}`}>{snapshot.buildLabel}</span>
         <span className="brand-links">
           <a href="https://discord.gg/yxC9jzMdw6" target="_blank" rel="noreferrer" title="Discord" aria-label="OpenMouse on Discord">
             <DiscordIcon />
@@ -263,7 +264,6 @@ export function Sidebar({ snapshot }: { snapshot: ControlSnapshot }): ReactNode 
           <NavIcon path={DEBUG_PATH} />
         </a>
       </nav>
-      <span className="build-badge" title={`OpenMouse ${snapshot.buildLabel}`}>{snapshot.buildLabel}</span>
     </aside>
   );
 }

--- a/src/control.css
+++ b/src/control.css
@@ -540,6 +540,7 @@ button:focus-visible, a:focus-visible, input:focus-visible { outline: 2px solid 
 .demo-wordmark img { width: auto; height: 1.5rem; }
 .sidebar > .build-badge { margin-top: auto; }
 .build-badge { color: var(--ghost); font-family: var(--font-mono); font-size: .62rem; letter-spacing: .06em; white-space: nowrap; }
+.demo-wordmark .build-badge { margin-left: .15rem; font-size: .58rem; }
 .brand-links { display: flex; align-items: center; gap: .7rem; margin-left: auto; }
 .brand-links a { display: flex; color: var(--text-faint); transition: color .18s ease; }
 .brand-links a:hover { color: var(--ui-accent); }
@@ -1024,7 +1025,7 @@ body { height: 100vh; overflow: hidden; }
 .nav-item { width: 1.8rem; height: 1.8rem; border-radius: 5px; }
 .nav-item.has-label { width: auto; padding: 0 .5rem; font-size: .68rem; }
 .nav-item svg { width: .95rem; height: .95rem; }
-.build-badge { margin-top: .6rem !important; font-size: .52rem; }
+.sidebar > .build-badge { margin-top: .6rem !important; font-size: .52rem; }
 
 .control-shell .control-panel {
   display: flex;

--- a/src/control.css
+++ b/src/control.css
@@ -540,7 +540,7 @@ button:focus-visible, a:focus-visible, input:focus-visible { outline: 2px solid 
 .demo-wordmark img { width: auto; height: 1.5rem; }
 .sidebar > .build-badge { margin-top: auto; }
 .build-badge { color: var(--ghost); font-family: var(--font-mono); font-size: .62rem; letter-spacing: .06em; white-space: nowrap; }
-.demo-wordmark .build-badge { margin-left: .15rem; font-size: .58rem; }
+.demo-wordmark .build-badge { margin-left: .15rem; padding: .12rem .45rem; border: 1px solid var(--border-soft); border-radius: 1rem; background: var(--surface-raised); font-size: .56rem; }
 .brand-links { display: flex; align-items: center; gap: .7rem; margin-left: auto; }
 .brand-links a { display: flex; color: var(--text-faint); transition: color .18s ease; }
 .brand-links a:hover { color: var(--ui-accent); }


### PR DESCRIPTION
Move the BETA · vX badge from the sidebar footer into the wordmark header, next to the OpenMouse logo. No behavior change.

before: 
<img width="352" height="979" alt="image" src="https://github.com/user-attachments/assets/44eacadf-50e3-4a82-a2da-a9e2e28de582" />



After: 
<img width="352" height="979" alt="image" src="https://github.com/user-attachments/assets/c29cbb40-8467-421d-b1d0-2fb1e1eae6e3" />
