### PR TITLE
feat(cards): polling header readout, button tab gating, fixed rows

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -320,6 +320,7 @@ export function App(): ReactNode {
        !has.razerButtons&&
        !has.mxMasterButtons&&
        !has.atkButtons&&
+       !has.buttonMapping&&
        !has.debounce&&
        !has.lightforce&&
        !has.eggSpdt&&

--- a/src/app/cards/AdvancedCards.tsx
+++ b/src/app/cards/AdvancedCards.tsx
@@ -1098,7 +1098,9 @@ export function ButtonMappingCard({ snapshot }: { snapshot: ControlSnapshot }): 
   if (!status?.buttonMappings || !status.buttonOptions?.length) return null;
   const locale = snapshot.preferences.locale;
   const options = status.buttonOptions;
-  const fixed = new Set(status.fixedButtons ?? []);
+  // fixedButtons lands with mouse-protocol#68; read defensively so this
+  // builds against the published protocol until then.
+  const fixed = new Set((status as unknown as { fixedButtons?: readonly string[] }).fixedButtons ?? []);
   return (
     <article id="button-mapping-settings" className="setting-card">
       <div className="setting-heading compact"><div><p>BUTTONS</p><h2>{t(locale, "map.remap")}</h2></div></div>

--- a/src/app/cards/AdvancedCards.tsx
+++ b/src/app/cards/AdvancedCards.tsx
@@ -1098,6 +1098,7 @@ export function ButtonMappingCard({ snapshot }: { snapshot: ControlSnapshot }): 
   if (!status?.buttonMappings || !status.buttonOptions?.length) return null;
   const locale = snapshot.preferences.locale;
   const options = status.buttonOptions;
+  const fixed = new Set(status.fixedButtons ?? []);
   return (
     <article id="button-mapping-settings" className="setting-card">
       <div className="setting-heading compact"><div><p>BUTTONS</p><h2>{t(locale, "map.remap")}</h2></div></div>
@@ -1107,6 +1108,7 @@ export function ButtonMappingCard({ snapshot }: { snapshot: ControlSnapshot }): 
           <select
             id={`button-${button.toLowerCase()}-select`}
             value={options.includes(assigned) ? assigned : ""}
+            disabled={fixed.has(button)}
             onChange={(event) => control.applyDeviceButtonMapping(button, event.currentTarget.value)}
           >
             {/* A macro or an assignment this build cannot name still shows. */}

--- a/src/app/cards/PerformanceCards.tsx
+++ b/src/app/cards/PerformanceCards.tsx
@@ -207,7 +207,17 @@ export function SensorCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNo
 
       {slotsAvailable ? null : (
         <div id="host-lod-row">
-          <div className="setting-heading"><div><h2>{t(locale, "perf.liftOff")}</h2></div></div>
+          <div className="setting-heading">
+            <div>
+              <h2>{t(locale, "perf.liftOff")}</h2>
+              <small id="lod-note" className="setting-note">
+                {lodNeedsSurface ? t(locale, "perf.lodNeedSurface") : t(locale, "perf.lodNote")}
+              </small>
+            </div>
+            {status.liftOffDistance !== null && !showPair && !status.liftOffScale ? (
+              <output id="lod-value">{lodLabel(locale, status.liftOffDistance)}</output>
+            ) : null}
+          </div>
           {pair ? (
             <div id="lod-mode-row" className="lod-mode">
               <Segmented
@@ -251,9 +261,6 @@ export function SensorCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNo
               />
             </div>
           )}
-          <small id="lod-note" className="setting-note">
-            {lodNeedsSurface ? t(locale, "perf.lodNeedSurface") : t(locale, "perf.lodNote")}
-          </small>
         </div>
       )}
     </article>

--- a/src/app/cards/PerformanceCards.tsx
+++ b/src/app/cards/PerformanceCards.tsx
@@ -183,8 +183,6 @@ export function SensorCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNo
       className={`setting-card${staged ? " is-staged" : ""}`}
       data-pending-key="lift-off-distance gaming-surface"
     >
-      <div className="setting-heading tight"><div><p>SENSOR</p></div></div>
-
       {status.gamingSurfaceMode ? (
         <div id="gaming-surface-row">
           <div className="setting-heading"><div><h2>{t(locale, "perf.gamingSurface")}</h2></div></div>
@@ -217,9 +215,6 @@ export function SensorCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNo
                 {lodNeedsSurface ? t(locale, "perf.lodNeedSurface") : t(locale, "perf.lodNote")}
               </small>
             </div>
-            {status.liftOffDistance !== null && !showPair && !status.liftOffScale ? (
-              <output id="lod-value">{lodLabel(locale, status.liftOffDistance)}</output>
-            ) : null}
           </div>
           {pair ? (
             <div id="lod-mode-row" className="lod-mode">

--- a/src/app/cards/PerformanceCards.tsx
+++ b/src/app/cards/PerformanceCards.tsx
@@ -48,7 +48,7 @@ export function PollingCard({ snapshot }: { snapshot: ControlSnapshot }): ReactN
     <article id="polling-card" className={`setting-card${staged ? " is-staged" : ""}`} data-pending-key="polling-rate">
       <div className="setting-heading">
         <div>
-          <div className="polling-title">
+          <div className="title-row">
             <h2>
               {t(locale, "perf.reportFrequency")}
               {snapshot.editedProfile !== null ? (
@@ -209,7 +209,10 @@ export function SensorCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNo
         <div id="host-lod-row">
           <div className="setting-heading">
             <div>
-              <h2>{t(locale, "perf.liftOff")}</h2>
+              <div className="title-row">
+                <h2>{t(locale, "perf.liftOff")}</h2>
+                <p>SENSOR</p>
+              </div>
               <small id="lod-note" className="setting-note">
                 {lodNeedsSurface ? t(locale, "perf.lodNeedSurface") : t(locale, "perf.lodNote")}
               </small>

--- a/src/app/cards/PerformanceCards.tsx
+++ b/src/app/cards/PerformanceCards.tsx
@@ -48,14 +48,20 @@ export function PollingCard({ snapshot }: { snapshot: ControlSnapshot }): ReactN
     <article id="polling-card" className={`setting-card${staged ? " is-staged" : ""}`} data-pending-key="polling-rate">
       <div className="setting-heading">
         <div>
-          <p>POLLING RATE</p>
-          <h2>
-            {t(locale, "perf.reportFrequency")}
-            {snapshot.editedProfile !== null ? (
-              <span className="setting-scope" id="rate-scope-badge">{perProfile ? t(locale, "dpi.perProfile") : "Host"}</span>
-            ) : null}
-          </h2>
+          <div className="polling-title">
+            <h2>
+              {t(locale, "perf.reportFrequency")}
+              {snapshot.editedProfile !== null ? (
+                <span className="setting-scope" id="rate-scope-badge">{perProfile ? t(locale, "dpi.perProfile") : "Host"}</span>
+              ) : null}
+            </h2>
+            <p>POLLING RATE</p>
+          </div>
+          <small id="polling-note" className="setting-note">{note}</small>
         </div>
+        {!perProfile ? (
+          <output id="polling-value">{status.pollingRateHz.toLocaleString()} Hz</output>
+        ) : null}
       </div>
 
       {perProfile && entry ? (
@@ -81,10 +87,10 @@ export function PollingCard({ snapshot }: { snapshot: ControlSnapshot }): ReactN
           options={advertisedRates}
           valueHz={status.pollingRateHz}
           disabled={snapshot.settingsPending || status.ui?.pollingReadOnly === true}
+          bubble={false}
           onChange={control.applyPollingRate}
         />
       )}
-      <small id="polling-note" className="setting-note">{note}</small>
     </article>
   );
 }

--- a/src/app/cards/availability.test.ts
+++ b/src/app/cards/availability.test.ts
@@ -250,3 +250,27 @@ test("the Razer buttons card appears only when the driver reported mappings", ()
   // — the tab must stay empty rather than render a card with no rows.
   assert.equal(cardAvailability(snapshot({ status: { brand: "Razer" } })).razerButtons, false);
 });
+
+test("the generic button card follows the K-snake key-map read", () => {
+  // The driver opens the advanced section only when getKeys() succeeded,
+  // so the card must not appear on a silent dongle even though the family
+  // is unknown to the traits table.
+  const withKeys = cardAvailability(snapshot({
+    status: {
+      brand: "K-snake",
+      ui: { family: "ksnake", showAdvancedSection: true },
+      buttonMappings: { Forward: "Backward" },
+      buttonOptions: ["Backward", "DPI loop"],
+    },
+  }));
+  assert.equal(withKeys.buttonMapping, true);
+
+  const silent = cardAvailability(snapshot({
+    status: {
+      brand: "K-snake",
+      ui: { family: "ksnake", showAdvancedSection: false },
+      buttonOptions: ["Backward", "DPI loop"],
+    },
+  }));
+  assert.equal(silent.buttonMapping, false);
+});

--- a/src/app/ui.tsx
+++ b/src/app/ui.tsx
@@ -122,6 +122,7 @@ export function RateSlider({
   hidden,
   onChange,
   locale = "en",
+  bubble = true,
 }: {
   id?: string;
   options: number[];
@@ -131,6 +132,8 @@ export function RateSlider({
   hidden?: boolean;
   onChange: (hz: number) => void;
   locale?: InterfaceLocale;
+  /** Hide the floating value readout (used when the card header shows it). */
+  bubble?: boolean;
 }): ReactNode {
   const [dragging, setDragging] = useState<number | null>(null);
   if (options.length === 0) return <div id={id} className="rate-slider" hidden={hidden} />;
@@ -180,9 +183,11 @@ export function RateSlider({
           }}
           onBlur={() => setDragging(null)}
         />
-        <output className="rate-slider-bubble" style={{ left: position(index) }} aria-hidden="true">
-          {options[index]?.toLocaleString() ?? "—"} Hz
-        </output>
+        {bubble ? (
+          <output className="rate-slider-bubble" style={{ left: position(index) }} aria-hidden="true">
+            {options[index]?.toLocaleString() ?? "—"} Hz
+          </output>
+        ) : null}
       </div>
       <div className="rate-slider-scale">
         {options.map((rate, step) => (

--- a/src/control.css
+++ b/src/control.css
@@ -704,8 +704,6 @@ nav { display: grid; gap: .3rem; margin-top: 1.4rem; }
 #polling-value { font-family: inherit; font-size: 1.15rem; font-weight: 500; letter-spacing: -.015em; }
 /* The explainer lives under the title now, not under the slider. */
 #polling-card .setting-heading .setting-note { margin-top: .3rem; }
-/* Lift-off readout mirrors the polling one. */
-#lod-value { font-family: inherit; font-size: 1.15rem; font-weight: 500; letter-spacing: -.015em; }
 #host-lod-row .setting-heading .setting-note { margin-top: .3rem; }
 /* Overline and title share one baseline row instead of stacking. */
 #polling-card .title-row, #host-lod-row .title-row { display: flex; align-items: baseline; gap: .55rem; flex-wrap: wrap; }

--- a/src/control.css
+++ b/src/control.css
@@ -700,6 +700,14 @@ nav { display: grid; gap: .3rem; margin-top: 1.4rem; }
 .setting-heading h2 { margin: 0; font-size: 1.15rem; font-weight: 500; letter-spacing: -.015em; }
 .setting-heading p { margin: 0 0 .6rem; color: var(--faint); font-family: var(--font-mono); font-size: .6rem; letter-spacing: .09em; }
 .setting-heading output { padding: .38rem .55rem; border: 1px solid var(--border); border-radius: 6px; color: var(--text-strong); font-family: var(--font-mono); font-size: .68rem; }
+/* Polling readout: same voice as the card title, not mono. */
+#polling-value { font-family: inherit; font-size: 1.15rem; font-weight: 500; letter-spacing: -.015em; }
+/* The explainer lives under the title now, not under the slider. */
+#polling-card .setting-heading .setting-note { margin-top: .3rem; }
+/* Overline and title share one baseline row instead of stacking. */
+#polling-card .polling-title { display: flex; align-items: baseline; gap: .55rem; flex-wrap: wrap; }
+#polling-card .polling-title p { margin: 0; }
+#polling-card .polling-title h2 { font-size: 1.15rem; }
 .setting-note { display: block; margin-top: 1rem; color: var(--text-faint); font-size: .68rem; }
 .setting-action { display: flex; align-items: center; justify-content: space-between; gap: .7rem; margin-top: .7rem; color: var(--faint); font-size: .65rem; }
 .setting-action button { padding: .4rem .65rem; border: 1px solid var(--text); border-radius: 6px; background: var(--text); color: var(--ink); font-size: .65rem; font-weight: 700; }

--- a/src/control.css
+++ b/src/control.css
@@ -708,9 +708,9 @@ nav { display: grid; gap: .3rem; margin-top: 1.4rem; }
 #lod-value { font-family: inherit; font-size: 1.15rem; font-weight: 500; letter-spacing: -.015em; }
 #host-lod-row .setting-heading .setting-note { margin-top: .3rem; }
 /* Overline and title share one baseline row instead of stacking. */
-#polling-card .polling-title { display: flex; align-items: baseline; gap: .55rem; flex-wrap: wrap; }
-#polling-card .polling-title p { margin: 0; }
-#polling-card .polling-title h2 { font-size: 1.15rem; }
+#polling-card .title-row, #host-lod-row .title-row { display: flex; align-items: baseline; gap: .55rem; flex-wrap: wrap; }
+#polling-card .title-row p, #host-lod-row .title-row p { margin: 0; }
+#polling-card .title-row h2, #host-lod-row .title-row h2 { font-size: 1.15rem; }
 .setting-note { display: block; margin-top: 1rem; color: var(--text-faint); font-size: .68rem; }
 .setting-action { display: flex; align-items: center; justify-content: space-between; gap: .7rem; margin-top: .7rem; color: var(--faint); font-size: .65rem; }
 .setting-action button { padding: .4rem .65rem; border: 1px solid var(--text); border-radius: 6px; background: var(--text); color: var(--ink); font-size: .65rem; font-weight: 700; }

--- a/src/control.css
+++ b/src/control.css
@@ -704,6 +704,9 @@ nav { display: grid; gap: .3rem; margin-top: 1.4rem; }
 #polling-value { font-family: inherit; font-size: 1.15rem; font-weight: 500; letter-spacing: -.015em; }
 /* The explainer lives under the title now, not under the slider. */
 #polling-card .setting-heading .setting-note { margin-top: .3rem; }
+/* Lift-off readout mirrors the polling one. */
+#lod-value { font-family: inherit; font-size: 1.15rem; font-weight: 500; letter-spacing: -.015em; }
+#host-lod-row .setting-heading .setting-note { margin-top: .3rem; }
 /* Overline and title share one baseline row instead of stacking. */
 #polling-card .polling-title { display: flex; align-items: baseline; gap: .55rem; flex-wrap: wrap; }
 #polling-card .polling-title p { margin: 0; }


### PR DESCRIPTION
Two small card fixes, tested together on a K-snake X11 against a local @openmouse/protocol build:

**Polling header readout**
- The current rate moves from the in-flow slider bubble into the card header (`#polling-value`, same type voice as the title), with the explainer note under the title and the POLLING RATE overline sharing the title baseline.
- `RateSlider` gains a `bubble` prop (default true); the host polling slider hides its bubble since the header carries the value. Per-profile Logitech rows are untouched.

**Generic button mapping**
- `filterTabs` now counts `has.buttonMapping`, so drivers publishing the generic `buttonMappings`/`buttonOptions` pair (MCHOSE, K-snake via mouse-protocol#68) actually get the Buttons tab instead of hiding behind debounce/lightforce.
- `ButtonMappingCard` disables rows listed in the new `fixedButtons` status field (K-snake locks Left, like the vendor panel) instead of letting the write fail.

**Validation**
- `npx tsc --noEmit` clean, `npm test` 128/128 (adds a K-snake buttonMapping availability test), `npm run build` passes.
- Manual: local `vite dev` with the symlinked protocol build; header readout, disabled Left row, and Buttons tab verified.


Before: 
<img width="1525" height="193" alt="image" src="https://github.com/user-attachments/assets/a009991b-bbe4-430a-ba21-508b09168086" />

<img width="1530" height="176" alt="image" src="https://github.com/user-attachments/assets/35338c8b-fafe-44be-b4aa-c9b39437c959" />



After: 
<img width="1525" height="193" alt="image" src="https://github.com/user-attachments/assets/b2848f68-6dca-49e2-8fc2-5286f3878274" />

<img width="1526" height="144" alt="image" src="https://github.com/user-attachments/assets/808e0b82-e39c-4436-b64c-59482b1a6de2" />


