### PR TITLE
feat: Attack Shark R2 support

### DIFF
--- a/build/check-bundle-size.ts
+++ b/build/check-bundle-size.ts
@@ -54,7 +54,10 @@ const BUDGET_BYTES: Record<string, number> = {
   // initial (English) bundle. Measured aggregate is 1,061.8 kB.
   // Raised to 1,165 kB for Japanese and Korean, same lazy-chunk pattern.
   // Measured aggregate is 1,160.9 kB.
-  ".js": 1_165_000,
+  // Raised to 1,185 kB for Attack Shark R2 support (GearHub-V5 driver,
+  // traits.ts entry, device artwork name-fallback): the measured aggregate
+  // is 1,171.4 kB, leaving ~14 kB of headroom.
+  ".js": 1_185_000,
 };
 
 const ASSETS = join("dist", "assets");

--- a/package-lock.json
+++ b/package-lock.json
@@ -481,7 +481,7 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#1414699df47c17d2ee56c73e6e02b1d711fc4d39",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#3e044d06b6bec9f869cbd1fdfdff32c4fbeb5ca4",
       "engines": {
         "node": ">=20"
       }

--- a/public/devices/README.md
+++ b/public/devices/README.md
@@ -112,6 +112,15 @@ a public release package.
 for Zaunkoenig M3K and is also used for the M2K entry. Confirm redistribution
 terms before including it in a public release package.
 
+`attackshark-r2.png` — **needs a maintainer upload.** The name-fallback
+mapping in `src/ui/device-images.ts` is in place (keyed on the reported name
+"Attack Shark R2", since PID 0x402D is shared with the Lingbao M5 Pro) and
+falls back to the placeholder until the file lands. Suggested source: the
+top-down render on Attack Shark's own product page
+(`attackshark.com/products/attack-shark-r2-magnesium-alloy-paw3950-gaming-mouse-8k`)
+or Shopify CDN, keyed out of its backdrop. Vendor product art — treat as a
+request pending licensing review.
+
 `attackshark-r5-ultra.png` is the top-down render of the Attack Shark R5 Ultra
 extracted from Attack Shark's official product gallery
 (`cdn.shopify.com/s/files/1/0823/5050/6282/files/R5ULTRA_C06_3.png`), keyed

--- a/src/device/traits.ts
+++ b/src/device/traits.ts
@@ -48,6 +48,11 @@ const BY_FAMILY: Readonly<Record<string, Partial<DriverTraits>>> = {
   ninjutso: { ...DIRECT_MODE, ninjutso: true },
   "keychron-nape": { advancedSection: true, sleep: true, directMode: true },
   fantech: { advancedSection: true, sleep: true, directMode: true },
+  // GearHub-V5 (Attack Shark R2, Lingbao M5 Pro): reads debounce, standby time
+  // and the two "move correction" toggles out of its OPTIONPARAM0 block. Not a
+  // CompX direct-mode driver — it publishes its own debounce/sleep option
+  // lists, so it takes the plain flags.
+  gearhub: { advancedSection: true, sleep: true, debounce: true },
   // MCHOSE reads debounce and sleep from its config blob and writes both, but
   // it is not a direct-mode (CompX) driver, so it takes the plain flags.
   mchose: { advancedSection: true, sleep: true, debounce: true },

--- a/src/supported-mice.ts
+++ b/src/supported-mice.ts
@@ -227,8 +227,8 @@ export const MICE: Mouse[] = [
     note: "Not compatible with WebHID — needs the OpenMouse Bridge companion (0x25a7 family)" },
   { brand: "Attack Shark", model: "G3",                 status: "bridge",    req: 1,
     note: "Not compatible with WebHID — needs the OpenMouse Bridge companion (0x25a7 family)" },
-  { brand: "Attack Shark", model: "R2",                 status: "bridge",    req: 1,
-    note: "Not compatible with WebHID — needs the OpenMouse Bridge companion (0x25a7 family)" },
+  { brand: "Attack Shark", model: "R2",                 status: "supported", req: 1,
+    note: "GearHub-V5 ODM mouse on VID 0x3151, PID 0x402D (shared with the Lingbao M5 Pro receiver); the lingbao driver identifies it by its protocol device id 1893. PixArt PAW3950, 42000 DPI, 8000 Hz. DPI and polling read + write verified on hardware over the 2.4 GHz receiver" },
 
   // RAZER ───────────────────────────────────────────────────────────────
   { brand: "Razer", model: "DeathAdder V3 (wired)",     status: "supported", req: 9,

--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -68,6 +68,15 @@ test("Attack Shark R5 Ultra wired and wireless share the same artwork", () => {
   assert.equal(deviceImage(null, "Attack Shark R5 Ultra"), CDN + "attackshark-r5-ultra.png");
 });
 
+test("Attack Shark R2 resolves by name (PID 0x402D is shared with the M5 Pro)", () => {
+  assert.equal(deviceImage(null, "Attack Shark R2"), CDN + "attackshark-r2.png");
+  // The shared receiver PID must NOT resolve to the R2 render.
+  assert.equal(
+    deviceImage({ vendorId: 0x3151, productId: 0x402d } as HIDDevice, "Lingbao M5 Pro"),
+    CDN + "unknown-device.png",
+  );
+});
+
 test("OP1we wired and wireless share the same artwork, distinct from OP1 8K", () => {
   const hid3367 = (productId: number): HIDDevice => ({ vendorId: 0x3367, productId } as HIDDevice);
   assert.equal(deviceImage(hid3367(0x1961)), CDN + "endgame-gear-op1we.png");

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -175,6 +175,9 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
   if (/\bnape\s*pro\b/i.test(displayName)) return "unknown-device.png";
   if (/\bko-one\b/i.test(displayName)) return "crdrako-ko-one.png";
   if (/\br5\s*ultra\b/i.test(displayName)) return "attackshark-r5-ultra.png";
+  // R2 shares PID 0x402D with the Lingbao M5 Pro, so it can only be told apart
+  // by the name the gearhub driver reads back from the device id.
+  if (/\battack\s*shark\s*r2\b/i.test(displayName)) return "attackshark-r2.png";
   if (/\bm[23]k\b/i.test(displayName)) return "zaunkoenig-m3k.png";
   if (/\bmx\s*master\s*3s\b/i.test(displayName)) return "logitech-mx-master-3s.png";
   if (/\bterra\s*pro\b/i.test(displayName)) return "teevolution-terra-pro.png";


### PR DESCRIPTION
Wires up the OpenMouse side of Attack Shark R2 support. The driver itself is
**OpenMouse-Project/mouse-protocol#72** (new `gearhub` family) - that needs
to merge first, and the `@openmouse/protocol` lockfile entry needs a bump
afterward.

## Changes

- **`src/supported-mice.ts`** - R2 row `bridge` → `supported`. It's a
  GearHub-V5 ODM mouse on VID `0x3151` / PID `0x402D` (shared with the
  Lingbao M5 Pro receiver); the `gearhub` driver identifies it by the
  protocol device id `1893`. PixArt PAW3950, 42000 DPI, 8000 Hz.
- **`src/device/traits.ts`** - `gearhub` family entry
  (`advancedSection` + `sleep` + `debounce`), so the shared advanced /
  sleep / debounce cards and the generic button remapper render. Plain
  flags, not direct-mode - the driver publishes its own debounce/sleep
  option lists (`getDebounceOptions` / `getSleepOptions`).
- **`src/ui/device-images.ts`** - name-fallback mapping
  `"Attack Shark R2"` → `attackshark-r2.png`. Can't key on PID `0x402D`
  (shared with the M5 Pro), so it resolves from the reported name. Falls
  back to the placeholder until a maintainer uploads the render to the
  devices bucket; a provenance stub is in `public/devices/README.md`.

## Verified on hardware (retail R2, 2.4 GHz receiver)

DPI stages, polling rate, lift-off distance, debounce, straight + ripple
correction, 2.4 GHz / Bluetooth standby time, and 6-button remapping - all
read back and round-trip. Panel shows "Attack Shark R2" with the correct
PAW3950 / 42000 DPI profile.

## Checks

`npm run check` green (127 tests) against a local build of mouse-protocol#72.


## Picture Link 
**`https://cdn.onyxhq.dev/attackshark-r2.png`**