### PR TITLE
supported: list the MX Master 4

### DIFF
--- a/src/supported-mice.ts
+++ b/src/supported-mice.ts
@@ -118,6 +118,8 @@ export const MICE: Mouse[] = [
     note: "Lightspeed dongle — HID++ 2.0 protocol supported; PID 0xc098 (USB cable, direct-connect) also in driver" },
   { brand: "Logitech", model: "MX Vertical",            status: "driver",    req: 9,
     note: "Unifying (HID++ 1.0) / Bluetooth — not implemented" },
+  { brand: "Logitech", model: "MX Master 4",            status: "supported", req: 8,
+    note: "Bluetooth (HID++ on vendor page 0xFF43) and Logi Bolt receiver both in driver" },
   { brand: "Logitech", model: "MX Master 4S",           status: "likely",    req: 8,
     note: "Logi Bolt receiver in driver — needs hardware test" },
   { brand: "Logitech", model: "G304",                   status: "supported", req: 7,


### PR DESCRIPTION
Adds the MX Master 4 to the supported-devices table.

Depends on OpenMouse-Project/mouse-protocol#73, which teaches the Logitech
driver to reach HID++ over Bluetooth (usage page `0xFF43`). Merge that first, or
this row claims coverage the app does not yet have.

No `pids` field: the mouse is matched by usage page rather than product id, so
there is nothing for `supported-mice.test.ts`'s PID check to pin.

Verified with the protocol branch linked into `node_modules`: `npm run build`
and `npm test` (127 pass), and `SUPPORTED_HID_FILTERS` now carries
`{ vendorId: 0x046d, usagePage: 0xff43 }`.
