### PR TITLE
fix: hide unavailable device controls

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 import * as control from "../device/controller";
-import { WORKSPACE_TAB_ORDER, type ControlSnapshot, type WorkspaceTab } from "../device/types";
+import type { ControlSnapshot, WorkspaceTab } from "../device/types";
 import { t, connectLabelText, connectionText, ensureLocale, type I18nKey } from "../i18n";
 import { interfaceThemeSlug } from "../interface-preferences";
 import { CaptureDialog } from "./CaptureDialog";
@@ -42,7 +42,7 @@ import {
   TeevolutionDpiLightingCard,
 } from "./cards/AdvancedCards";
 import { cardAvailability } from "./cards/availability";
-import type { MouseStatus } from "@openmouse/protocol/drivers";
+import { availableWorkspaceTab, availableWorkspaceTabs } from "./workspace-tabs";
 
 function on(tab: WorkspaceTab, tabs: readonly WorkspaceTab[]): boolean {
   return tabs.includes(tab);
@@ -297,10 +297,6 @@ export function App(): ReactNode {
   }, []);
 
   useEffect(() => {
-    panel.current?.scrollTo({ top: 0, behavior: preferences.reducedMotion ? "auto" : "smooth" });
-  }, [snapshot.workspaceTab]);
-
-  useEffect(() => {
     try {
       document.documentElement.lang = locale === "pt" ? "pt-BR" : "en";
     } catch {
@@ -311,24 +307,23 @@ export function App(): ReactNode {
     if (locale !== "en") void ensureLocale(locale).then(() => control.refreshInterface());
   }, [locale]);
 
-  const filterTabs = (status:MouseStatus|null):readonly WorkspaceTab[] => {
-    var tempTabs = WORKSPACE_TAB_ORDER;
-    const has = cardAvailability(snapshot);
-    if(status==null)return tempTabs;
-    if(!has.lighting&&!has.teevolutionDpiLighting)tempTabs=tempTabs.filter(tab=>tab!="lighting")
-    if(!has.eggButtons&&
-       !has.razerButtons&&
-       !has.mxMasterButtons&&
-       !has.atkButtons&&
-       !has.buttonMapping&&
-       !has.debounce&&
-       !has.lightforce&&
-       !has.eggSpdt&&
-       !has.superstrike
-    )tempTabs=tempTabs.filter(tab=>tab!="buttons")
-    return tempTabs;
-  }
-  const tabs = filterTabs(status);
+  const tabs = availableWorkspaceTabs(status !== null, cardAvailability(snapshot));
+  const workspaceTab = availableWorkspaceTab(snapshot.workspaceTab, tabs);
+  const workspaceSnapshot = workspaceTab === snapshot.workspaceTab
+    ? snapshot
+    : { ...snapshot, workspaceTab };
+
+  useEffect(() => {
+    panel.current?.scrollTo({ top: 0, behavior: preferences.reducedMotion ? "auto" : "smooth" });
+  }, [workspaceTab]);
+
+  useEffect(() => {
+    if (workspaceTab === snapshot.workspaceTab) return;
+    control.setWorkspaceTab(workspaceTab);
+    window.requestAnimationFrame(() => {
+      document.querySelector<HTMLButtonElement>(`#workspace-tab-${workspaceTab}`)?.focus();
+    });
+  }, [snapshot.workspaceTab, workspaceTab]);
   const onTabKey = (event: KeyboardEvent<HTMLButtonElement>, current: WorkspaceTab): void => {
     const index = tabs.indexOf(current);
     let next: number;
@@ -433,8 +428,8 @@ export function App(): ReactNode {
                 id={`workspace-tab-${tab}`}
                 type="button"
                 role="tab"
-                aria-selected={snapshot.workspaceTab === tab}
-                tabIndex={snapshot.workspaceTab === tab ? 0 : -1}
+                aria-selected={workspaceTab === tab}
+                tabIndex={workspaceTab === tab ? 0 : -1}
                 onClick={() => control.setWorkspaceTab(tab)}
                 onKeyDown={(event) => onTabKey(event, tab)}
               >
@@ -444,7 +439,7 @@ export function App(): ReactNode {
           </nav>
         ) : null}
 
-        <Workspace snapshot={snapshot} onOpenCapture={() => setCaptureOpen(true)} />
+        <Workspace snapshot={workspaceSnapshot} onOpenCapture={() => setCaptureOpen(true)} />
         <InterfaceSettings snapshot={snapshot} />
       </main>
 

--- a/src/app/cards/AdvancedCards.tsx
+++ b/src/app/cards/AdvancedCards.tsx
@@ -21,7 +21,7 @@ import { teevolutionSensorModeUi } from "@openmouse/protocol/teevolution";
 import { isPulsarProProtocol } from "../../device/traits";
 import * as control from "../../device/controller";
 import { PULSAR_SLEEP_OPTIONS } from "../../device/controller";
-import { selectableValues, sleepLabel, sleepParts, sleepTotalSeconds, KEYCHRON_SLEEP_MAX_HOURS, KEYCHRON_SLEEP_MAX_SECONDS, KEYCHRON_SLEEP_MIN_SECONDS } from "../../device/options";
+import { selectableValues, sleepLabel, sleepParts, sleepTotalSeconds, valuesWithCurrent, KEYCHRON_SLEEP_MAX_HOURS, KEYCHRON_SLEEP_MAX_SECONDS, KEYCHRON_SLEEP_MIN_SECONDS } from "../../device/options";
 import type { ControlSnapshot } from "../../device/types";
 import { t, tp } from "../../i18n";
 import type { InterfaceLocale } from "../../interface-preferences";
@@ -143,7 +143,7 @@ export function DebounceCard({ snapshot }: { snapshot: ControlSnapshot }): React
     : snapshot.capabilities?.teevolutionProfile?.debounce.max ?? 20;
   const offered = snapshot.capabilities?.debounceOptions;
   const options = offered
-    ? selectableValues([...offered], status.debounceMs) ?? offered
+    ? valuesWithCurrent([...offered], status.debounceMs)
     : Array.from({ length: max + 1 }, (_, ms) => ms);
   const staged = snapshot.pending.keys.includes("debounce");
   return (
@@ -155,7 +155,9 @@ export function DebounceCard({ snapshot }: { snapshot: ControlSnapshot }): React
         disabled={status.debounceMs === null || status.debounceMs === undefined}
         onChange={(event) => control.applyPulsarValue("debounce", Number(event.currentTarget.value))}
       >
-        {options.map((ms) => <option key={ms} value={ms}>{ms} ms</option>)}
+        {options.map((ms) => (
+          <option key={ms} value={ms} disabled={offered != null && !offered.includes(ms)}>{ms} ms</option>
+        ))}
       </select>
     </article>
   );
@@ -397,15 +399,17 @@ export function ProcessingCard({ snapshot }: { snapshot: ControlSnapshot }): Rea
       {angleTuning != null ? (
         <label className="field-label spaced">
           {t(locale, "adv.angleTune")}
-          <select
-            id="angle-tune-select"
-            value={angleTuning}
-            onChange={(event) => control.applyAngleTuning(Number(event.currentTarget.value))}
-          >
-            {Array.from({ length: 61 }, (_, index) => index - 30).map((angle) => (
-              <option key={angle} value={angle}>{angle}°</option>
-            ))}
-          </select>
+          {capabilities?.angleTuningWritable ? (
+            <select
+              id="angle-tune-select"
+              value={angleTuning}
+              onChange={(event) => control.applyAngleTuning(Number(event.currentTarget.value))}
+            >
+              {Array.from({ length: 61 }, (_, index) => index - 30).map((angle) => (
+                <option key={angle} value={angle}>{angle}°</option>
+              ))}
+            </select>
+          ) : <output id="angle-tune-value">{angleTuning}°</output>}
         </label>
       ) : null}
 
@@ -1126,44 +1130,23 @@ export function ButtonMappingCard({ snapshot }: { snapshot: ControlSnapshot }): 
   );
 }
 
-/**
- * A device's named power/performance modes, plus sensor angle tuning where it
- * offers one. Driven entirely by what the driver reports, so it stays
- * brand-agnostic.
- */
+/** A device's named power/performance modes. */
 export function PowerModeCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNode {
   const status = snapshot.status;
   if (!status) return null;
   const locale = snapshot.preferences.locale;
   const modes = status.powerModes;
-  const tuning = status.angleTuning;
-  if (!modes?.length && tuning == null) return null;
+  if (!modes?.length) return null;
   return (
     <article id="power-mode-settings" className="setting-card">
       <div className="setting-heading compact"><div><p>SENSOR</p><h2>{t(locale, "pow.mode")}</h2></div></div>
-      {modes?.length ? (
-        <Segmented
-          className={modes.length === 3 ? "three" : undefined}
-          ariaLabel={t(locale, "pow.perfMode")}
-          options={modes.map((mode) => ({ value: mode, label: mode }))}
-          value={status.powerMode ?? modes[0]!}
-          onChange={(next) => control.applyPowerMode(String(next))}
-        />
-      ) : null}
-      {tuning != null ? (
-        <label className="field-label spaced">
-          {t(locale, "adv.angleTuning")}
-          <select
-            id="angle-tuning-select"
-            value={tuning}
-            onChange={(event) => control.applyAngleTuning(Number(event.currentTarget.value))}
-          >
-            {Array.from({ length: 61 }, (_, index) => index - 30).map((angle) => (
-              <option key={angle} value={angle}>{angle}°</option>
-            ))}
-          </select>
-        </label>
-      ) : null}
+      <Segmented
+        className={modes.length === 3 ? "three" : undefined}
+        ariaLabel={t(locale, "pow.perfMode")}
+        options={modes.map((mode) => ({ value: mode, label: mode }))}
+        value={status.powerMode ?? modes[0]!}
+        onChange={(next) => control.applyPowerMode(String(next))}
+      />
     </article>
   );
 }

--- a/src/app/cards/availability.test.ts
+++ b/src/app/cards/availability.test.ts
@@ -124,6 +124,19 @@ test("ATK exposes its processing and DPI-lighting cards from reported controls",
   assert.equal(has.teevolutionDpiLighting, true);
 });
 
+test("angle tuning belongs to processing rather than creating a second power-mode card", () => {
+  const angleOnly = cardAvailability(snapshot({
+    status: { brand: "VXE", ui: { family: "atk" }, angleTuning: 0 },
+  }));
+  assert.equal(angleOnly.processing, true);
+  assert.equal(angleOnly.powerMode, false);
+
+  const namedModes = cardAvailability(snapshot({
+    status: { brand: "MCHOSE", ui: { family: "mchose" }, powerModes: ["Eco", "Performance"] },
+  }));
+  assert.equal(namedModes.powerMode, true);
+});
+
 test("ATK inspection cards require data actually read from the device", () => {
   const empty = cardAvailability(snapshot({ status: { brand: "VXE", ui: { family: "atk" } } }));
   assert.equal(empty.atkButtons, false);

--- a/src/app/cards/availability.ts
+++ b/src/app/cards/availability.ts
@@ -120,7 +120,7 @@ export function cardAvailability(snapshot: ControlSnapshot): CardAvailability {
     lightingAdvanced: host && Boolean(status.lighting || status.lightingZones?.length),
     onboardProfiles: (status.profileCount ?? 0) > 1 && status.activeProfile != null,
     buttonMapping: host && Boolean(status.buttonMappings) && Boolean(status.buttonOptions?.length),
-    powerMode: host && (Boolean(status.powerModes?.length) || status.angleTuning != null),
+    powerMode: host && Boolean(status.powerModes?.length),
     profiles: traits.logitech
       && status.deviceMode !== undefined && status.deviceMode !== "Unknown",
     keychronNapeLayers: status.napeLayerCount != null && status.napeLayerCount >= 1,

--- a/src/app/workspace-tabs.test.ts
+++ b/src/app/workspace-tabs.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CardAvailability } from "./cards/availability.ts";
+import { availableWorkspaceTab, availableWorkspaceTabs } from "./workspace-tabs.ts";
+
+function availability(enabled: Partial<CardAvailability>): CardAvailability {
+  return new Proxy(enabled, { get: (target, property) => Reflect.get(target, property) ?? false }) as CardAvailability;
+}
+
+test("a connected mouse exposes only tabs backed by available controls", () => {
+  assert.deepEqual(availableWorkspaceTabs(true, availability({})), ["overview", "performance", "advanced"]);
+  assert.deepEqual(availableWorkspaceTabs(true, availability({ debounce: true })), [
+    "overview", "performance", "buttons", "advanced",
+  ]);
+});
+
+test("every profile surface retains the profiles tab", () => {
+  for (const surface of ["profiles", "keychronNapeLayers", "atkProfile", "onboardProfiles", "pulsarPro"] as const) {
+    assert.equal(availableWorkspaceTabs(true, availability({ [surface]: true })).includes("profiles"), true, surface);
+  }
+});
+
+test("an unavailable selected tab falls back to overview", () => {
+  const tabs = availableWorkspaceTabs(true, availability({}));
+  assert.equal(availableWorkspaceTab("profiles", tabs), "overview");
+  assert.equal(availableWorkspaceTab("performance", tabs), "performance");
+});
+
+test("the disconnected state keeps every navigation tab", () => {
+  assert.equal(availableWorkspaceTabs(false, availability({})).length, 6);
+});

--- a/src/app/workspace-tabs.ts
+++ b/src/app/workspace-tabs.ts
@@ -1,0 +1,26 @@
+import { WORKSPACE_TAB_ORDER, type WorkspaceTab } from "../device/types.ts";
+import type { CardAvailability } from "./cards/availability.ts";
+
+export function availableWorkspaceTabs(
+  connected: boolean,
+  has: CardAvailability,
+): readonly WorkspaceTab[] {
+  if (!connected) return WORKSPACE_TAB_ORDER;
+  const hasButtons = has.eggButtons || has.razerButtons || has.mxMasterButtons || has.atkButtons
+    || has.buttonMapping || has.debounce || has.lightforce || has.eggSpdt || has.superstrike;
+  const hasProfiles = has.profiles || has.keychronNapeLayers || has.atkProfile
+    || has.onboardProfiles || has.pulsarPro;
+  return WORKSPACE_TAB_ORDER.filter((tab) => {
+    if (tab === "lighting") return has.lighting || has.teevolutionDpiLighting;
+    if (tab === "buttons") return hasButtons;
+    if (tab === "profiles") return hasProfiles;
+    return true;
+  });
+}
+
+export function availableWorkspaceTab(
+  current: WorkspaceTab,
+  tabs: readonly WorkspaceTab[],
+): WorkspaceTab {
+  return tabs.includes(current) ? current : "overview";
+}

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -543,6 +543,11 @@ function clientNumberList(method: string): number[] | null {
   return Array.isArray(value) && value.every((entry) => typeof entry === "number") ? value : null;
 }
 
+function clientHasMethod(method: string): boolean {
+  const client = active as unknown as Record<string, unknown> | null;
+  return typeof client?.[method] === "function";
+}
+
 function requireClientMethod<K extends string>(
   method: K,
   setting: string,
@@ -558,6 +563,7 @@ function readCapabilities(): DeviceCapabilities {
   const keychron = keychronNapeClient();
   return {
     canDisableSleep: dm?.canDisableSleep === true,
+    angleTuningWritable: clientHasMethod("setAngleTuning"),
     // Any client may publish these; the two named drivers are just the ones
     // that predate the generic lookup below.
     sleepOptions: dm

--- a/src/device/options.test.ts
+++ b/src/device/options.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { valuesWithCurrent } from "./options.ts";
+
+test("a current value outside the writable range remains visible", () => {
+  assert.deepEqual(valuesWithCurrent([1, 2, 3], 0), [0, 1, 2, 3]);
+  assert.deepEqual(valuesWithCurrent([1, 2, 3], 4), [1, 2, 3, 4]);
+});
+
+test("a writable current value is not duplicated", () => {
+  const offered = [1, 2, 3];
+  assert.equal(valuesWithCurrent(offered, 2), offered);
+  assert.equal(valuesWithCurrent(offered, null), offered);
+  assert.equal(valuesWithCurrent(offered, undefined), offered);
+});

--- a/src/device/options.ts
+++ b/src/device/options.ts
@@ -46,3 +46,9 @@ export function selectableValues(offered: number[], current: number | null | und
   if (current < offered[0] || current > offered[offered.length - 1]) return null;
   return offered.includes(current) ? offered : [...offered, current].sort((left, right) => left - right);
 }
+
+/** Keep an unwritable firmware value visible without adding it to the offered set. */
+export function valuesWithCurrent(offered: number[], current: number | null | undefined): number[] {
+  if (current === null || current === undefined || offered.includes(current)) return offered;
+  return [...offered, current].sort((left, right) => left - right);
+}

--- a/src/device/types.ts
+++ b/src/device/types.ts
@@ -42,6 +42,7 @@ export interface TeevolutionProfile {
 
 export interface DeviceCapabilities {
   canDisableSleep: boolean;
+  angleTuningWritable: boolean;
   sleepOptions: number[] | null;
   debounceMaxMs: number | null;
   debounceOptions?: number[] | null;


### PR DESCRIPTION
## Summary
- hide workspace tabs that have no available control surface
- keep unsupported current debounce values visible but unwritable
- render angle tuning once and expose it as read-only when the driver has no setter
- restore Overview and keyboard focus when a selected tab becomes unavailable

## Verification
- `npm run check`
- `npm run size`
- `git diff --check`