### PR TITLE
Fix html lang for all supported locales

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -35,7 +35,21 @@ export function App(): ReactNode {
 
   useEffect(() => {
     try {
-      document.documentElement.lang = locale === "pt" ? "pt-BR" : "en";
+      const htmlLang: Record<typeof locale, string> = {
+        pt: "pt-BR",
+        es: "es",
+        fr: "fr",
+        de: "de",
+        zh: "zh-CN",
+        ja: "ja",
+        ko: "ko",
+        ru: "ru",
+        en: "en",
+      };
+      const nextLang = htmlLang[locale] ?? "en";
+      if (document.documentElement.lang !== nextLang) {
+        document.documentElement.lang = nextLang;
+      }
     } catch {
       /* non-DOM environment (tests) */
     }


### PR DESCRIPTION
documentElement.lang only mapped pt->pt-BR and fell back to en, so screen readers mispronounced es/fr/de/zh/ja/ko/ru (WCAG 3.1.1 Language of Page).

This maps every InterfaceLocale to BCP-47 (pt->pt-BR, zh->zh-CN, rest as-is) and only writes when changed to avoid extra renders.

Verified: npm test 105/105 passing, map covers all 9 locales.