### PR TITLE
Preload font CSS and validate staged polling rate

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -10,6 +10,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+    />
+    <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
     />

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&family=JetBrains+Mono:wght@400;500&display=swap" />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32" />

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -3055,6 +3055,10 @@ export function setProfileReportRate(link: "wireless" | "wired", hz: number): vo
 
 export function applyPollingRate(rate: number): void {
   if (!hasActiveClient()) return;
+  // The slider only offers device-advertised rates (or RATE_STEPS_HZ); anything
+  // else arrives from an imported profile key, so reject it before staging.
+  const allowed = latestDeviceStatus?.supportedPollingRates ?? RATE_STEPS_HZ;
+  if (!Number.isInteger(rate) || !allowed.includes(rate)) return;
   stageChange({
     key: "polling-rate",
     label: `${rate.toLocaleString()} Hz`,


### PR DESCRIPTION
Two tiny independent hardening fixes:

- Add rel=preload (byte-identical URL, no double fetch) for the Google Fonts stylesheet on index and admin pages, so first paint isn't stuck behind late font CSS discovery.
- applyPollingRate now rejects anything outside the device-advertised rates (or RATE_STEPS_HZ fallback) before staging, so a malicious OMK1 profile key can't push garbage like 999999 Hz to the HID write. The slider only ever offers values from that same list.

Verified: npm test 105/105 passing.