### PR TITLE
Cache battery samples off the render path

### DIFF
--- a/src/battery-history.test.ts
+++ b/src/battery-history.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { estimateBatteryTime, saveBatterySample } from "./battery-history.ts";
+import { cachedBatterySamples, estimateBatteryTime, recordBatterySample, saveBatterySample } from "./battery-history.ts";
 
 class MemoryStorage implements Storage {
   #values = new Map<string, string>();
@@ -37,4 +37,21 @@ test("battery estimate requires a recent continuous trend", () => {
 
   assert.equal(estimateBatteryTime(samples, 90, "discharging", 60 * 60 * 1000), "~9.0 hr");
   assert.equal(estimateBatteryTime(samples, 90, "discharging", 2 * 60 * 60 * 1000), null);
+});
+
+test("cached battery samples serve renders without storage IO", () => {
+  const storage = new MemoryStorage();
+  recordBatterySample(storage, "RenderMouse", 75, "discharging", 0);
+  storage.getItem = () => { throw new Error("render path must not touch storage"); };
+  const samples = cachedBatterySamples(storage, "RenderMouse", 60_000);
+  assert.equal(samples.length, 1);
+  assert.equal(samples[0]?.percent, 75);
+});
+
+test("cached battery samples load once from storage on cold start", () => {
+  const storage = new MemoryStorage();
+  saveBatterySample(storage, "ColdMouse", 75, "discharging", 0);
+  const samples = cachedBatterySamples(storage, "ColdMouse", 60_000);
+  assert.equal(samples.length, 1);
+  assert.equal(samples[0]?.percent, 75);
 });

--- a/src/battery-history.ts
+++ b/src/battery-history.ts
@@ -24,6 +24,24 @@ function loadHistory(storage: Storage): BatteryHistory {
   }
 }
 
+function pruneSamples(stored: unknown, cutoff: number): BatterySample[] {
+  if (!Array.isArray(stored)) return [];
+  return stored.filter((sample): sample is BatterySample =>
+    typeof sample === "object"
+    && sample !== null
+    && Number.isFinite((sample as BatterySample).timestamp)
+    && Number.isFinite((sample as BatterySample).percent)
+    && (sample as BatterySample).timestamp >= cutoff
+    && (sample as BatterySample).percent >= 0
+    && (sample as BatterySample).percent <= 100
+    && ((sample as BatterySample).mode === "charging" || (sample as BatterySample).mode === "discharging"));
+}
+
+// In-memory copy of each device's samples. Renders read from here instead of
+// parsing storage on every frame; device updates refresh it via
+// recordBatterySample below.
+const memorySamples = new Map<string, BatterySample[]>();
+
 export function saveBatterySample(
   storage: Storage,
   deviceName: string,
@@ -33,14 +51,9 @@ export function saveBatterySample(
 ): BatterySample[] {
   const history = loadHistory(storage);
   const cutoff = now - MAX_SAMPLE_AGE_MS;
-  const storedSamples = Array.isArray(history[deviceName]) ? history[deviceName] : [];
-  const samples = storedSamples.filter((sample) =>
-    Number.isFinite(sample.timestamp)
-    && Number.isFinite(sample.percent)
-    && sample.timestamp >= cutoff
-    && sample.percent >= 0
-    && sample.percent <= 100
-    && (sample.mode === "charging" || sample.mode === "discharging"));
+  const stored = history[deviceName];
+  const storedCount = Array.isArray(stored) ? stored.length : 0;
+  const samples = pruneSamples(stored, cutoff);
   const previous = samples.at(-1);
   const shouldSave = !previous
     || previous.mode !== mode
@@ -50,7 +63,7 @@ export function saveBatterySample(
   if (shouldSave) samples.push({ timestamp: now, percent, mode });
   const retainedSamples = samples.slice(-MAX_SAMPLES_PER_DEVICE);
   history[deviceName] = retainedSamples;
-  if (shouldSave || retainedSamples.length !== storedSamples.length) {
+  if (shouldSave || retainedSamples.length !== storedCount) {
     try {
       storage.setItem(STORAGE_KEY, JSON.stringify(history));
     } catch {
@@ -58,6 +71,36 @@ export function saveBatterySample(
     }
   }
   return retainedSamples;
+}
+
+/**
+ * Records one sample at device-update cadence (not render cadence) and caches
+ * it for render reads. Call this when a fresh device status arrives.
+ */
+export function recordBatterySample(
+  storage: Storage,
+  deviceName: string,
+  percent: number,
+  mode: BatteryMode,
+  now = Date.now(),
+): void {
+  memorySamples.set(deviceName, saveBatterySample(storage, deviceName, percent, mode, now));
+}
+
+/**
+ * Render-safe read: memory first, a single storage parse on cold start, and
+ * never a write. Renders must call this instead of saveBatterySample.
+ */
+export function cachedBatterySamples(
+  storage: Storage,
+  deviceName: string,
+  now = Date.now(),
+): BatterySample[] {
+  const hit = memorySamples.get(deviceName);
+  if (hit) return hit;
+  const samples = pruneSamples(loadHistory(storage)[deviceName], now - MAX_SAMPLE_AGE_MS);
+  memorySamples.set(deviceName, samples);
+  return samples;
 }
 
 function formatEstimate(milliseconds: number): string {

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -1,4 +1,4 @@
-import { estimateBatteryTime, saveBatterySample, type BatteryMode } from "../battery-history";
+import { cachedBatterySamples, estimateBatteryTime, recordBatterySample, type BatteryMode } from "../battery-history";
 import {
   clientSupportScore,
   createSupportedClient,
@@ -1162,7 +1162,7 @@ export function batteryDetail(status: MouseStatus, locale: InterfaceLocale = "en
   const mode = batteryMode(status.batteryState);
   if (!mode) return withVoltage(batteryStateText(locale, status.batteryState));
   const now = Date.now();
-  const samples = saveBatterySample(localStorage, status.name, status.batteryPercent, mode, now);
+  const samples = cachedBatterySamples(localStorage, status.name, now);
   const estimate = estimateBatteryTime(samples, status.batteryPercent, mode, now);
   const label = mode === "charging" ? t(locale, "bat.untilFull") : t(locale, "bat.remaining");
   const state = batteryStateText(locale, status.batteryState);
@@ -1434,6 +1434,12 @@ function applyStatus(deviceStatus: MouseStatus, statusKey?: string): void {
 function applyStatusInner(deviceStatus: MouseStatus, statusKey?: string): void {
   latestDeviceStatus = deviceStatus;
   latestDiagnosticStatus = deviceStatus;
+  // Battery samples are recorded at device-update cadence; renders read the
+  // cache via batteryDetail instead of touching storage on every frame.
+  const sampleMode = batteryMode(deviceStatus.batteryState);
+  if (deviceStatus.batteryPercent !== null && sampleMode) {
+    recordBatterySample(localStorage, deviceStatus.name, deviceStatus.batteryPercent, sampleMode, Date.now());
+  }
   lastRenderedStatusKey = statusKey ?? JSON.stringify(deviceStatus);
   const status = withPendingChanges(deviceStatus);
   reportMouseUsage(status.name);


### PR DESCRIPTION
batteryDetail parsed and rewrote the full battery history in localStorage on every render. Samples are now recorded at device-update cadence in applyStatusInner, and renders read a memory cache (single storage parse on cold start, never a write). The sample filter was also hardened to ignore malformed entries instead of throwing. Adds 2 tests: render path performs zero storage IO, cold start loads once.

Note: this PR previously also pinned @openmouse/protocol, but that tripped the maintainer-approved dependencies check, so the pin was dropped — floating URL kept as required.

Verified: npm test 107/107 passing.