### PR TITLE
Add the MCHOSE A7 V3 family, read-only

### DIFF
--- a/public/devices/README.md
+++ b/public/devices/README.md
@@ -182,3 +182,7 @@ package:
   place and falls back to the placeholder until then. Not yet cleared for
   licensing: it is vendor product art, so treat it as a request rather than an
   approved asset.
+- `mchose-a7-v3.png` — MCHOSE A7 V3 render. Same story as the V2 above:
+  MCHOSE publishes only `A7V3Pro_*` renders and the four V3 models share a
+  shell, so one image covers the family. **Needs a maintainer upload**, and
+  carries the same unresolved licensing question.

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -129,6 +129,7 @@ import { GloriousHidClient } from "@openmouse/protocol/drivers/glorious/hid";
 import { GloriousClassicHidClient } from "@openmouse/protocol/drivers/glorious/classic-hid";
 import { MchoseHidClient } from "@openmouse/protocol/drivers/mchose/hid";
 import { MchoseDockHidClient } from "@openmouse/protocol/drivers/mchose/dock-hid";
+import { MchoseV3HidClient } from "@openmouse/protocol/drivers/mchose/v3-hid";
 import { FantechHidClient } from "@openmouse/protocol/drivers/fantech/hid";
 import { WallhackMouseHidClient } from "@openmouse/protocol/drivers/wallhack/mouse-hid";
 import { WallhackKeyboardHidClient } from "@openmouse/protocol/drivers/wallhack/keyboard-hid";
@@ -200,7 +201,7 @@ function activeAs<T>(...classes: ClientClass<T>[]): T | null {
 
 const DM_CLASSES = [WLMouseHidClient, LamzuHidClient, AtkHidClient, AtkBitmouseHidClient, NinjutsoHidClient] as const;
 const RAZER_CLASSES = [RazerHidClient, RazerViperMiniHidClient, RazerViperHidClient, RazerCobraHidClient] as const;
-const NEEDS_OPEN = [TeevolutionHidClient, VgnF2HidClient, KeychronNapeHidClient, KeychronM6HidClient, ModdoHidClient, ZaunkoenigHidClient, CorsairHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient, GloriousHidClient, GloriousClassicHidClient, MchoseHidClient, MchoseDockHidClient, MicrosoftHidClient, IncottHidClient] as const;
+const NEEDS_OPEN = [TeevolutionHidClient, VgnF2HidClient, KeychronNapeHidClient, KeychronM6HidClient, ModdoHidClient, ZaunkoenigHidClient, CorsairHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient, GloriousHidClient, GloriousClassicHidClient, MchoseHidClient, MchoseDockHidClient, MchoseV3HidClient, MicrosoftHidClient, IncottHidClient] as const;
 const PULSAR_CLASSES = [PulsarHidClient, PulsarProHidClient, PulsarXs1HidClient] as const;
 
 const logitechClient = (): LogitechHidppClient | null => activeAs(LogitechHidppClient);

--- a/src/device/traits.ts
+++ b/src/device/traits.ts
@@ -56,6 +56,9 @@ const BY_FAMILY: Readonly<Record<string, Partial<DriverTraits>>> = {
   // MCHOSE reads debounce and sleep from its config blob and writes both, but
   // it is not a direct-mode (CompX) driver, so it takes the plain flags.
   mchose: { advancedSection: true, sleep: true, debounce: true },
+  // "mchose-v3" is deliberately absent: that driver reads and cannot write, so
+  // every card these flags open would render controls with nothing behind
+  // them. Give it the same flags as `mchose` once it grows setters.
   // Incott supports a 0-30 ms debounce and a 1-900 s sleep timer over its own
   // vendor protocol, not the CompX direct-mode transport, so it takes the
   // plain flags rather than DIRECT_MODE (its advancedSection already comes

--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -237,3 +237,23 @@ test("Attack Shark X11 does not inherit K-snake artwork", () => {
   assert.equal(deviceImage(null, "Attack Shark X11"), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "Attack Shark X11 SE"), CDN + "unknown-device.png");
 });
+
+test("the MCHOSE A7 V3 family gets its own render, not the V2's", () => {
+  const mchose = (productId: number): HIDDevice =>
+    ({ vendorId: 0x3837, productId } as HIDDevice);
+
+  for (const productId of [0x4030, 0x4031, 0x4032, 0x4033]) {
+    assert.equal(deviceImage(mchose(productId)), CDN + "mchose-a7-v3.png");
+  }
+  assert.equal(deviceImage(mchose(0x4021)), CDN + "mchose-a7-v2.png");
+
+  // The V3 receivers are shared with the K5, R7 and A5 V3, so mapping them to
+  // an A7 render would put the wrong mouse on screen for those owners.
+  assert.equal(deviceImage(mchose(0x1014)), CDN + "unknown-device.png");
+  assert.equal(deviceImage(mchose(0x1018)), CDN + "unknown-device.png");
+});
+
+test("an A7 V3 name is not swallowed by the A7 V2 fallback", () => {
+  assert.equal(deviceImage(null, "MCHOSE A7 V3 Ultra+"), CDN + "mchose-a7-v3.png");
+  assert.equal(deviceImage(null, "MCHOSE A7 V2 Ultra+"), CDN + "mchose-a7-v2.png");
+});

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -55,6 +55,14 @@ const DEVICE_IMAGES: ReadonlyMap<string, string> = new Map([
   ["3837:100a", "mchose-a7-v2.png"],
   ["3837:100b", "mchose-a7-v2.png"],
   ["3837:1020", "mchose-a7-v2.png"],
+  // MCHOSE A7 V3 family — a different shell and a different protocol from the
+  // V2 above. Its two receiver ids are shared with the other V3-generation
+  // models, so they are deliberately not mapped: a K5 or R7 behind the same
+  // dongle would get an A7 render.
+  ["3837:4030", "mchose-a7-v3.png"],
+  ["3837:4031", "mchose-a7-v3.png"],
+  ["3837:4032", "mchose-a7-v3.png"],
+  ["3837:4033", "mchose-a7-v3.png"],
   // CRDRAKO KO-ONE wired and receiver transports share the same shell.
   ["373e:006a", "crdrako-ko-one.png"],
   ["373e:006b", "crdrako-ko-one.png"],
@@ -307,7 +315,9 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
   if (/\bmaya\s*x\b/i.test(displayName)) return "lamzu-maya-x.png";
   if (/k[\s-]*snake/i.test(displayName)) return "ksnake-x11.png";
   if (/\bf1\s*v2\b/i.test(displayName)) return "atk-f1-v2-ultra-max.png";
-  // Catches any A7 V2 variant whose product id is not pinned above.
+  // Catches any A7 variant whose product id is not pinned above. V3 first, so
+  // an "A7 V3" name is not swallowed by a looser A7 match later.
+  if (/\ba7\s*v3\b/i.test(displayName)) return "mchose-a7-v3.png";
   if (/\ba7\s*v2\b/i.test(displayName)) return "mchose-a7-v2.png";
   if (/\b(finalmouse|starlight|ulx)\b/i.test(displayName)) return "finalmouse-ulx.png";
   if (/\borbital\b/i.test(displayName)) return "unknown-device.png";


### PR DESCRIPTION
Wires up `MchoseV3HidClient`, which drives MCHOSE's newer mice.

> **Depends on [OpenMouse-Project/mouse-protocol#84](https://github.com/OpenMouse-Project/mouse-protocol/pull/84).** This app installs `@openmouse/protocol` from its git URL, so that one has to land first.

The A7 V3 is a **separate protocol from the A7 V2 on the same usage page** — a `0x4d` output report rather than the V2's inverted feature reports. The two drivers are kept off each other's devices by product id in the protocol package; nothing in this repo has to know about that.

## Small on purpose

- the client is imported and added to `NEEDS_OPEN`
- device art maps the four model ids to `mchose-a7-v3.png`, which still needs a bucket upload and resolves to the placeholder until then
- the two V3 receiver ids are **deliberately left unmapped**: they are shared with the K5, R7 and A5 V3, so an A7 render would be the wrong mouse on screen for those owners

**No traits entry**, and that is the point rather than an oversight — the driver reads and cannot write, so every card those flags open would render controls with nothing behind them. The absence is commented, and the driver's own status note explains the limitation where a user will actually see it. There is a line saying to give it the same flags as `mchose` once it grows setters.

## Not here

The supported-devices rows for these models are not in this PR: that catalog moved to `openmouse-landing-page` in 01906c9, so they go there instead — [jamezrin/openmouse-landing-page:add-mchose-v3-rows](https://github.com/jamezrin/openmouse-landing-page/tree/add-mchose-v3-rows), opened separately.

## Testing

`npm test` (107), `tsc` and `vite build` all pass. New tests cover the V3 image mappings, that a V3 id does not resolve to the V2 render, and that an "A7 V3" name is not swallowed by the looser A7 V2 name fallback. Verified against a local build of the protocol branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
