### PR TITLE
feat(device): wire up the Lamzu Atlantis driver

### DIFF
--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -58,6 +58,7 @@ import {
 } from "@openmouse/protocol/drivers/endgame/egg-we-control";
 import { AtkBitmouseHidClient } from "@openmouse/protocol/drivers/atk/bitmouse-hid";
 import { AtkHidClient } from "@openmouse/protocol/drivers/atk/hid";
+import { LamzuAtlantisHidClient } from "@openmouse/protocol/drivers/lamzu-atlantis/hid";
 import { LamzuHidClient } from "@openmouse/protocol/drivers/lamzu/hid";
 import {
   LogitechHidppClient,
@@ -199,7 +200,7 @@ function activeAs<T>(...classes: ClientClass<T>[]): T | null {
 
 const DM_CLASSES = [WLMouseHidClient, LamzuHidClient, AtkHidClient, AtkBitmouseHidClient, NinjutsoHidClient] as const;
 const RAZER_CLASSES = [RazerHidClient, RazerViperMiniHidClient, RazerViperHidClient, RazerCobraHidClient] as const;
-const NEEDS_OPEN = [TeevolutionHidClient, VgnF2HidClient, KeychronNapeHidClient, KeychronM6HidClient, ModdoHidClient, ZaunkoenigHidClient, CorsairHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient, GloriousHidClient, GloriousClassicHidClient, MchoseHidClient, MchoseDockHidClient, MicrosoftHidClient] as const;
+const NEEDS_OPEN = [LamzuAtlantisHidClient, TeevolutionHidClient, VgnF2HidClient, KeychronNapeHidClient, KeychronM6HidClient, ModdoHidClient, ZaunkoenigHidClient, CorsairHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient, GloriousHidClient, GloriousClassicHidClient, MchoseHidClient, MchoseDockHidClient, MicrosoftHidClient] as const;
 const PULSAR_CLASSES = [PulsarHidClient, PulsarProHidClient, PulsarXs1HidClient] as const;
 
 const logitechClient = (): LogitechHidppClient | null => activeAs(LogitechHidppClient);

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -198,7 +198,7 @@ function activeAs<T>(...classes: ClientClass<T>[]): T | null {
   return null;
 }
 
-const DM_CLASSES = [WLMouseHidClient, LamzuHidClient, AtkHidClient, AtkBitmouseHidClient, NinjutsoHidClient] as const;
+const DM_CLASSES = [WLMouseHidClient, LamzuHidClient, LamzuAtlantisHidClient, AtkHidClient, AtkBitmouseHidClient, NinjutsoHidClient] as const;
 const RAZER_CLASSES = [RazerHidClient, RazerViperMiniHidClient, RazerViperHidClient, RazerCobraHidClient] as const;
 const NEEDS_OPEN = [LamzuAtlantisHidClient, TeevolutionHidClient, VgnF2HidClient, KeychronNapeHidClient, KeychronM6HidClient, ModdoHidClient, ZaunkoenigHidClient, CorsairHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient, GloriousHidClient, GloriousClassicHidClient, MchoseHidClient, MchoseDockHidClient, MicrosoftHidClient] as const;
 const PULSAR_CLASSES = [PulsarHidClient, PulsarProHidClient, PulsarXs1HidClient] as const;
@@ -207,8 +207,8 @@ const logitechClient = (): LogitechHidppClient | null => activeAs(LogitechHidppC
 const eggClient = (): EggOp1HidClient | null => activeAs(EggOp1HidClient);
 const eggWeClient = (): EggWeHidClient | null =>
   active !== null && isEggWeClient(active) ? active : null;
-const dmClient = (): WLMouseHidClient | LamzuHidClient | AtkHidClient | AtkBitmouseHidClient | NinjutsoHidClient | null =>
-  activeAs<WLMouseHidClient | LamzuHidClient | AtkHidClient | AtkBitmouseHidClient | NinjutsoHidClient>(...DM_CLASSES);
+const dmClient = (): WLMouseHidClient | LamzuHidClient | LamzuAtlantisHidClient | AtkHidClient | AtkBitmouseHidClient | NinjutsoHidClient | null =>
+  activeAs<WLMouseHidClient | LamzuHidClient | LamzuAtlantisHidClient | AtkHidClient | AtkBitmouseHidClient | NinjutsoHidClient>(...DM_CLASSES);
 const razerClient = (): RazerHidClient | RazerViperMiniHidClient | RazerViperHidClient | RazerCobraHidClient | null =>
   activeAs<RazerHidClient | RazerViperMiniHidClient | RazerViperHidClient | RazerCobraHidClient>(...RAZER_CLASSES);
 const viperClient = (): RazerViperV4ProHidClient | null => activeAs(RazerViperV4ProHidClient);


### PR DESCRIPTION
Companion to **OpenMouse-Project/mouse-protocol#85**, which adds the Lamzu Atlantis generation (CompX vendor id `0x3554`) as its own driver.

```ts
import { LamzuAtlantisHidClient } from "@openmouse/protocol/drivers/lamzu-atlantis/hid";

const NEEDS_OPEN = [LamzuAtlantisHidClient, TeevolutionHidClient, …] as const;
```

The client's transport is interrupt reports, so it attaches its `inputreport` listener in `open()` — without the `NEEDS_OPEN` entry the first `readStatus()` would sit waiting for a reply that nothing is listening for.

## What the app shows once the protocol PR lands

Read from a Lamzu Atlantis Mini 4K, firmware 1.24, wired:

| Field | Value |
| --- | --- |
| Name / brand | Lamzu Atlantis · Lamzu |
| Firmware | Mouse v1.24 |
| Battery | 100%, 4222 mV, Charging |
| DPI stages | 400 / 800 / **2000** / 3200 / 6400, colours `#ff0000 #00ffff #00ff00 #ffffff #ffff00` |
| Polling | 500 Hz, from 125 / 250 / 500 / 1000 |
| Lift-off · debounce · sleep | Low (1 mm) · 4 ms · 60 s |
| Processing | motion sync on, angle snapping off, ripple off, competition mode on |

Every value matches what Lamzu's own configurator displayed for the same mouse at the same moment.

## Not included

No `ui/device-images.ts` mapping: there is no `3554:*` artwork in the bucket, so the Atlantis resolves to `unknown-device.png` — the same treatment Orbital and moddo get today. Happy to add the mapping once art exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)