### PR TITLE
chore: bump @openmouse/protocol to current main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -482,7 +482,7 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#3e044d06b6bec9f869cbd1fdfdff32c4fbeb5ca4",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#afe443cbdd1f85fc629b998a4b06141078b91077",
       "engines": {
         "node": ">=20"
       }


### PR DESCRIPTION
## What

One line — bumps the `@openmouse/protocol` pin in `package-lock.json`:

```diff
-      "resolved": "...mouse-protocol.git#3e044d06b6bec9f869cbd1fdfdff32c4fbeb5ca4",
+      "resolved": "...mouse-protocol.git#afe443cbdd1f85fc629b998a4b06141078b91077",
```

`package.json` is unchanged. Regenerated with `npm update @openmouse/protocol`, not hand-edited.

## Why

The lockfile pinned `3e044d0`, which predates several PRs already merged into `mouse-protocol`. Because the dependency is pinned to an exact commit, merging there doesn't reach this app — the pin has to move before any of it is reachable.

The effect is visible in the deployed bundle today. Grepping `control.openmouse.app/assets/main-CtwFaCNt.js`:

| String | Deployed now | After this bump |
| --- | --- | --- |
| `R1 SE+` | 3 | 57 |
| `PAW3395SE` | 1 | present |
| `A9 Mini` | **0** | 2 |
| `F1 Ultimate 2.0` | **0** | 1 |
| `PAW3955Master` | **0** | 4 |

The ATK driver is bundled — the old identities are there — it's just the pre-merge version of it.

## What the bump picks up

Everything between `3e044d0..afe443c`, all already merged and reviewed in `mouse-protocol`:

- **ATK F1 Ultimate 2.0** identity (`1,8`) — names the mouse instead of its shared 8K receiver.
- **ATK A9 Mini +** identities (`1,31`, `1,52`) plus the **PAW3955 Master** DPI codec. This sensor stores DPI in six-byte rows at EEPROM `0x1B00` rather than the shared mode-nibble rows, so before the codec existed a DPI write would appear to apply in the UI without changing the value on the mouse.
- **Continuous 0.7–1.7 mm lift-off** for PAW3950 Ultra and PAW3955 Master, alongside the existing Low/Medium/High control.
- **GearHub** Attack Shark R2 device id 3009, R3 identification, generic fallback, and DPI stage colours.

## Checks

- `npm run check` passes — build clean, 105 tests, 0 failures.
- Built `dist/` and confirmed the three previously-absent strings are present afterwards, which is where the before/after column above comes from.

## Risk

Low, and easy to reason about: no application code changes, and the diff is a single pin. The failure mode worth checking for in a dependency bump — a protocol API change the app doesn't handle — is covered by `tsc --noEmit` and the test suite, both green.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
