### PR TITLE
Add VXE R1 Pro Max app integration

### DIFF
--- a/public/devices/README.md
+++ b/public/devices/README.md
@@ -182,3 +182,11 @@ package:
   place and falls back to the placeholder until then. Not yet cleared for
   licensing: it is vendor product art, so treat it as a request rather than an
   approved asset.
+
+`vxe-r1-series.png` ? **needs a maintainer upload.** It is shared by the
+VXE R1 family (R1, R1 SE, R1 SE+, R1 Pro, and R1 Pro Max), which use the same
+external shell. The render was extracted from ATK Hub, ATK/VXE's official device
+configurator, and normalized as a transparent PNG for the device panel. The
+mapping is already in place and falls back cleanly until the file is uploaded.
+Vendor product artwork ? confirm redistribution terms before including it in a
+public release package.

--- a/src/app/cards/AdvancedCards.tsx
+++ b/src/app/cards/AdvancedCards.tsx
@@ -431,7 +431,13 @@ export function ProcessingCard({ snapshot }: { snapshot: ControlSnapshot }): Rea
 export function TeevolutionDpiLightingCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNode {
   const status = snapshot.status;
   const profile = snapshot.capabilities?.teevolutionProfile;
-  if (!status || !profile) return null;
+  const hint = status?.ui?.dpiLighting;
+  if (!status || (!hint && !profile)) return null;
+  const modes = hint?.modes ?? profile!.dpiLighting.modes;
+  const brightnessMin = hint?.brightness.at(0) ?? profile!.dpiLighting.brightness.min;
+  const brightnessMax = hint?.brightness.at(-1) ?? profile!.dpiLighting.brightness.max;
+  const speedMin = hint?.speed.at(0) ?? profile!.dpiLighting.speed.min;
+  const speedMax = hint?.speed.at(-1) ?? profile!.dpiLighting.speed.max;
   const locale = snapshot.preferences.locale;
   const lightMode = status.dpiLedMode ?? 0;
   const staged = snapshot.pending.keys.some((key) => key.startsWith("teevolution-dpi-light-"));
@@ -450,7 +456,7 @@ export function TeevolutionDpiLightingCard({ snapshot }: { snapshot: ControlSnap
           onChange={(event) => control.applyTeevolutionDpiLighting("mode", Number(event.currentTarget.value))}
         >
           {([[0, "adv.ledOff"], [1, "adv.ledSteady"], [2, "adv.ledBreathing"]] as const)
-            .filter(([value]) => profile.dpiLighting.modes.includes(value))
+            .filter(([value]) => modes.includes(value))
             .map(([value, label]) => <option key={value} value={value}>{t(locale, label)}</option>)}
         </select>
       </label>
@@ -464,14 +470,14 @@ export function TeevolutionDpiLightingCard({ snapshot }: { snapshot: ControlSnap
             <input
               id="teevolution-dpi-light-brightness"
               type="range"
-              min={profile.dpiLighting.brightness.min}
-              max={profile.dpiLighting.brightness.max}
+              min={brightnessMin}
+              max={brightnessMax}
               step={1}
-              value={status.dpiLedBrightness ?? profile.dpiLighting.brightness.min}
+              value={status.dpiLedBrightness ?? brightnessMin}
               disabled={lightMode !== 1 || status.dpiLedBrightness == null}
               style={{
-                "--fill": `${((status.dpiLedBrightness ?? profile.dpiLighting.brightness.min) - profile.dpiLighting.brightness.min)
-                  / Math.max(1, profile.dpiLighting.brightness.max - profile.dpiLighting.brightness.min) * 100}%`,
+                "--fill": `${((status.dpiLedBrightness ?? brightnessMin) - brightnessMin)
+                  / Math.max(1, brightnessMax - brightnessMin) * 100}%`,
               }}
               onChange={(event) => control.applyTeevolutionDpiLighting("brightness", Number(event.currentTarget.value))}
             />
@@ -486,14 +492,14 @@ export function TeevolutionDpiLightingCard({ snapshot }: { snapshot: ControlSnap
             <input
               id="teevolution-dpi-light-speed"
               type="range"
-              min={profile.dpiLighting.speed.min}
-              max={profile.dpiLighting.speed.max}
+              min={speedMin}
+              max={speedMax}
               step={1}
-              value={status.dpiLedSpeed ?? profile.dpiLighting.speed.min}
+              value={status.dpiLedSpeed ?? speedMin}
               disabled={lightMode !== 2 || status.dpiLedSpeed == null}
               style={{
-                "--fill": `${((status.dpiLedSpeed ?? profile.dpiLighting.speed.min) - profile.dpiLighting.speed.min)
-                  / Math.max(1, profile.dpiLighting.speed.max - profile.dpiLighting.speed.min) * 100}%`,
+                "--fill": `${((status.dpiLedSpeed ?? speedMin) - speedMin)
+                  / Math.max(1, speedMax - speedMin) * 100}%`,
               }}
               onChange={(event) => control.applyTeevolutionDpiLighting("speed", Number(event.currentTarget.value))}
             />

--- a/src/device/atk.test.ts
+++ b/src/device/atk.test.ts
@@ -1,11 +1,27 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { isVxeR1SePlusReceiver, receiverPairingSucceeded } from "./atk.ts";
+import {
+  isVxeR1ProMaxReceiver,
+  isVxeR1ProMaxWired,
+  isVxeR1SePlusReceiver,
+  receiverPairingSucceeded,
+} from "./atk.ts";
 
 test("R1 SE+ pairing controls require the exact verified receiver", () => {
   assert.equal(isVxeR1SePlusReceiver({ vendorId: 0x3554, productId: 0xf58e }), true);
   assert.equal(isVxeR1SePlusReceiver({ vendorId: 0x373b, productId: 0x1085 }), false);
+  assert.equal(isVxeR1SePlusReceiver({ vendorId: 0x3554, productId: 0xf58a }), false);
   assert.equal(isVxeR1SePlusReceiver(null), false);
+});
+
+test("R1 Pro Max identities distinguish receiver and wired transports", () => {
+  assert.equal(isVxeR1ProMaxReceiver({ vendorId: 0x3554, productId: 0xf58a }), true);
+  assert.equal(isVxeR1ProMaxReceiver({ vendorId: 0x3554, productId: 0xf58c }), false);
+  assert.equal(isVxeR1ProMaxReceiver({ vendorId: 0x373b, productId: 0xf58a }), false);
+
+  assert.equal(isVxeR1ProMaxWired({ vendorId: 0x3554, productId: 0xf58c }), true);
+  assert.equal(isVxeR1ProMaxWired({ vendorId: 0x3554, productId: 0xf58a }), false);
+  assert.equal(isVxeR1ProMaxWired(null), false);
 });
 
 test("pairing requires terminal status and online telemetry", () => {

--- a/src/device/atk.ts
+++ b/src/device/atk.ts
@@ -1,11 +1,35 @@
 import type { AtkReceiverInfo } from "@openmouse/protocol/drivers/mouse-types";
 
+export const VXE_R1_PRO_MAX_RECEIVER = {
+  vendorId: 0x3554,
+  productId: 0xf58a,
+  cid: 0x02,
+  mid: 0x1b,
+} as const;
+
+export const VXE_R1_PRO_MAX_WIRED = {
+  vendorId: 0x3554,
+  productId: 0xf58c,
+  cid: 0x02,
+  mid: 0x1b,
+} as const;
+
 export const VXE_R1_SE_PLUS_RECEIVER = {
   vendorId: 0x3554,
   productId: 0xf58e,
   cid: 0x02,
   mid: 0x20,
 } as const;
+
+export function isVxeR1ProMaxReceiver(device: Pick<HIDDevice, "vendorId" | "productId"> | null): boolean {
+  return device?.vendorId === VXE_R1_PRO_MAX_RECEIVER.vendorId
+    && device.productId === VXE_R1_PRO_MAX_RECEIVER.productId;
+}
+
+export function isVxeR1ProMaxWired(device: Pick<HIDDevice, "vendorId" | "productId"> | null): boolean {
+  return device?.vendorId === VXE_R1_PRO_MAX_WIRED.vendorId
+    && device.productId === VXE_R1_PRO_MAX_WIRED.productId;
+}
 
 export function isVxeR1SePlusReceiver(device: Pick<HIDDevice, "vendorId" | "productId"> | null): boolean {
   return device?.vendorId === VXE_R1_SE_PLUS_RECEIVER.vendorId

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -214,6 +214,8 @@ const razerClient = (): RazerHidClient | RazerViperMiniHidClient | RazerViperHid
 const viperClient = (): RazerViperV4ProHidClient | null => activeAs(RazerViperV4ProHidClient);
 
 const teevolutionClient = (): TeevolutionHidClient | null => activeAs(TeevolutionHidClient);
+const dpiLightingClient = (): TeevolutionHidClient | AtkHidClient | null =>
+  activeAs<TeevolutionHidClient | AtkHidClient>(TeevolutionHidClient, AtkHidClient);
 const finalmouseClient = (): FinalmouseHidClient | null => activeAs(FinalmouseHidClient);
 const orbitalClient = (): OrbitalHidClient | null => activeAs(OrbitalHidClient);
 const vgnClient = (): VgnF2HidClient | null => activeAs(VgnF2HidClient);
@@ -3492,20 +3494,21 @@ export function applyTeevolutionPerformanceDuration(duration: number): void {
 const TEEVOLUTION_DPI_LIGHT_GROUP = "teevolution-dpi-lighting";
 
 async function writeStagedTeevolutionDpiLighting(): Promise<void> {
-  const client = teevolutionClient();
+  const client = dpiLightingClient();
   if (!client || !latestDeviceStatus) {
-    throw new Error(st("ctl.teeGone"));
+    throw new Error("The DPI-lighting device is no longer connected.");
   }
   const status = withPendingChanges(latestDeviceStatus);
+  const hint = status.ui?.dpiLighting;
   await client.setDpiLighting(
-    status.dpiLedMode ?? 0,
-    status.dpiLedBrightness ?? 5,
-    status.dpiLedSpeed ?? 3,
+    status.dpiLedMode ?? hint?.modes[0] ?? 0,
+    status.dpiLedBrightness ?? hint?.brightness[0] ?? 5,
+    status.dpiLedSpeed ?? hint?.speed[0] ?? 3,
   );
 }
 
 export function applyTeevolutionDpiLighting(setting: "mode" | "brightness" | "speed", value: number): void {
-  if (!teevolutionClient()) return;
+  if (!dpiLightingClient()) return;
   const names = { mode: "effect", brightness: "brightness", speed: "speed" } as const;
   const display = setting === "mode" ? (["Off", "Steady", "Breathing"][value] ?? `${value}`) : `${value}`;
   stageChange({

--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -61,6 +61,23 @@ test("Pulsar 4K receiver artwork follows the reported mouse name", () => {
   assert.equal(deviceImage(null, "Pulsar X2 V2 Pro"), CDN + "pulsar-x2-v2.png");
 });
 
+test("VXE R1 family transports and names share one shell render", () => {
+  const vxe = (vendorId: number, productId: number): HIDDevice =>
+    ({ vendorId, productId } as HIDDevice);
+
+  assert.equal(deviceImage(vxe(0x3554, 0xf58a)), CDN + "vxe-r1-series.png");
+  assert.equal(deviceImage(vxe(0x3554, 0xf58c)), CDN + "vxe-r1-series.png");
+  assert.equal(deviceImage(vxe(0x3554, 0xf58e)), CDN + "vxe-r1-series.png");
+  assert.equal(deviceImage(vxe(0x3554, 0xf58f)), CDN + "vxe-r1-series.png");
+  assert.equal(deviceImage(vxe(0x373b, 0x1085)), CDN + "vxe-r1-series.png");
+
+  assert.equal(deviceImage(null, "VXE R1"), CDN + "vxe-r1-series.png");
+  assert.equal(deviceImage(null, "VXE R1 SE"), CDN + "vxe-r1-series.png");
+  assert.equal(deviceImage(null, "VXE R1 SE+"), CDN + "vxe-r1-series.png");
+  assert.equal(deviceImage(null, "VXE R1 Pro"), CDN + "vxe-r1-series.png");
+  assert.equal(deviceImage(null, "VXE R1 Pro Max"), CDN + "vxe-r1-series.png");
+});
+
 test("Attack Shark R5 Ultra wired and wireless share the same artwork", () => {
   const hid373e = (productId: number): HIDDevice => ({ vendorId: 0x373e, productId } as HIDDevice);
   assert.equal(deviceImage(hid373e(0x0046)), CDN + "attackshark-r5-ultra.png");

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -97,6 +97,13 @@ const DEVICE_IMAGES: ReadonlyMap<string, string> = new Map([
   // Beast Max wired / 4K8K receiver transports share the same shell.
   ["36a7:a881", "wlmouse-beast-max.png"],
   ["36a7:a880", "wlmouse-beast-max.png"],
+  // VXE R1 family. R1, R1 SE/SE+, R1 Pro, and R1 Pro Max share the same shell.
+  // Known wired / receiver transports therefore reuse one family render.
+  ["3554:f58a", "vxe-r1-series.png"],
+  ["3554:f58c", "vxe-r1-series.png"],
+  ["3554:f58e", "vxe-r1-series.png"],
+  ["3554:f58f", "vxe-r1-series.png"],
+  ["373b:1085", "vxe-r1-series.png"],
   // Teevolution Terra Pro wired / receiver Compx transports.
   ["3554:f520", "teevolution-terra-pro.png"],
   ["3554:f522", "teevolution-terra-pro.png"],
@@ -257,6 +264,9 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
   if (/\bcobra\b/i.test(displayName)) return "razer-cobra.webp";
   if (/\bnape\s*pro\b/i.test(displayName)) return "unknown-device.png";
   if (/\bko-one\b/i.test(displayName)) return "crdrako-ko-one.png";
+  if (/\bvxe\s+r1(?:\s+(?:se\+?|pro(?:\s+max)?))?\b/i.test(displayName)) {
+    return "vxe-r1-series.png";
+  }
   if (/\br5\s*ultra\b/i.test(displayName)) return "attackshark-r5-ultra.png";
   // R2 shares PID 0x402D with the Lingbao M5 Pro, so it can only be told apart
   // by the name the gearhub driver reads back from the device id.


### PR DESCRIPTION
Adds OpenMouse integration for the VXE R1 Pro Max over both F58A receiver and F58C wired transports, including DPI lighting, stage controls, advanced/performance settings, Long Range, profiles, stored button-mapping display, and shared VXE R1-family artwork mapping.

The app was hardware smoke-tested on both transports. All 107 tests pass, along with the production build and git diff --check. The device artwork mapping is included, while the PNG itself still needs a maintainer upload to the OpenMouse R2 bucket.

Depends on the corresponding mouse-protocol PR.