### PR TITLE
Add Keychron M6 device artwork mapping

### DIFF
--- a/public/devices/README.md
+++ b/public/devices/README.md
@@ -178,7 +178,15 @@ package:
   (`https://cdn.mchose.com.cn/configCenter/assets/img/mouse/A7V2Pro_white.png`).
   MCHOSE only publishes `A7V2Pro_*` renders and the Pro / Pro+ / Ultra / Ultra+
   are one shell, so this single image covers the whole A7 V2 family. **Needs a
-  maintainer upload** — the mapping in `src/ui/device-images.ts` is already in
+  maintainer upload**, the mapping in `src/ui/device-images.ts` is already in
   place and falls back to the placeholder until then. Not yet cleared for
   licensing: it is vendor product art, so treat it as a request rather than an
   approved asset.
+- `keychron-m6.png`: Keychron M6 (1K, PixArt 3395; PID 0x3434:0xd060, receiver
+  0x3434:0xd029) render, from Keychron Launcher's own product catalogue
+  (`https://sysmgr.keychron.cn/api/upload/cover/25/1751522970525.png`; a second
+  angled view is at `.../1751522970560.png`). Transparent 2560×2560 PNG, needs
+  the usual crop/downscale to the ~340 px panel size. **Needs a maintainer
+  upload**, the mapping in `src/ui/device-images.ts` is in place and falls back
+  to the placeholder until then. Vendor product art, not yet cleared for
+  licensing, so treat it as a request rather than an approved asset.

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -162,6 +162,9 @@ const DEVICE_IMAGES: ReadonlyMap<string, string> = new Map([
   ["03f0:0f8f", "hyperx-pulsefire-haste.png"],
   ["03f0:048e", "hyperx-pulsefire-haste.png"],
   ["03f0:028e", "hyperx-pulsefire-haste.png"],
+  // Keychron M6 (1K, PixArt 3395) wired and its Link-KM receiver share one shell.
+  ["3434:d060", "keychron-m6.png"],
+  ["3434:d029", "keychron-m6.png"],
 ]);
 
 function deviceKey(device: HIDDevice): string {


### PR DESCRIPTION
Maps the Keychron M6 wired transport (0x3434:0xd060) and its Link-KM receiver (0x3434:0xd029) to `keychron-m6.png`, and records the source in `public/devices/README.md`.

The render comes from Keychron Launcher's own product catalogue (transparent 2560x2560 PNG):

- https://sysmgr.keychron.cn/api/upload/cover/25/1751522970525.png (primary, top-down)
- https://sysmgr.keychron.cn/api/upload/cover/25/1751522970560.png (angled side view)

Per the artwork workflow the image itself is not committed; a maintainer needs to normalize and upload it to the R2 bucket. Until then the mapping falls back to the placeholder at load time, so nothing breaks. Companion artwork request issue linked below.