### PR TITLE
keychron: show the M6's sleep, debounce and sensor cards

### DIFF
--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -218,6 +218,7 @@ const finalmouseClient = (): FinalmouseHidClient | null => activeAs(FinalmouseHi
 const orbitalClient = (): OrbitalHidClient | null => activeAs(OrbitalHidClient);
 const vgnClient = (): VgnF2HidClient | null => activeAs(VgnF2HidClient);
 const keychronNapeClient = (): KeychronNapeHidClient | null => activeAs(KeychronNapeHidClient);
+const keychronM6Client = (): KeychronM6HidClient | null => activeAs(KeychronM6HidClient);
 const wallhackMouseClient = (): WallhackMouseHidClient | null => activeAs(WallhackMouseHidClient);
 const incottClient = (): IncottHidClient | null => activeAs(IncottHidClient);
 /** Pulsar is the only family with the collection-explorer onboarding path. */
@@ -3239,7 +3240,7 @@ export function applyPulsarToggle(setting: PulsarToggleSetting, enabled: boolean
 
 export function applyPulsarValue(setting: "debounce" | "sleep", value: number): void {
   if (!(pulsarClient() ?? dmClient() ?? orbitalClient() ?? razerClient()
-    ?? viperClient() ?? teevolutionClient() ?? vgnClient() ?? keychronNapeClient() ?? wallhackMouseClient()
+    ?? viperClient() ?? teevolutionClient() ?? vgnClient() ?? keychronNapeClient() ?? keychronM6Client() ?? wallhackMouseClient()
     ?? incottClient())) return;
   const asleep = value !== WLMOUSE_SLEEP_NEVER;
   stageChange({

--- a/src/device/traits.ts
+++ b/src/device/traits.ts
@@ -47,6 +47,9 @@ const BY_FAMILY: Readonly<Record<string, Partial<DriverTraits>>> = {
   "atk-bitmouse": DIRECT_MODE,
   ninjutso: { ...DIRECT_MODE, ninjutso: true },
   "keychron-nape": { advancedSection: true, sleep: true, directMode: true },
+  // The M6 reads debounce and sleep from its 0x06 status report and publishes
+  // its own option lists, so it takes the plain flags rather than DIRECT_MODE.
+  "keychron-m6": { advancedSection: true, sleep: true, debounce: true },
   fantech: { advancedSection: true, sleep: true, directMode: true },
   // GearHub-V5 (Attack Shark R2, Lingbao M5 Pro): reads debounce, standby time
   // and the two "move correction" toggles out of its OPTIONPARAM0 block. Not a


### PR DESCRIPTION
## Summary

Companion to the mouse-protocol change that decodes the Keychron M6's full Launcher protocol (lift-off, motion sync, angle snapping, ripple control, debounce, sleep, onboard profiles, firmware string). The sensor, processing, profile and firmware UI already render from the new status fields. Two things needed wiring:

- `src/device/traits.ts`: a `keychron-m6` family entry with `advancedSection`, `sleep` and `debounce`, so the sleep and debounce cards render. Plain flags rather than `DIRECT_MODE`, because the driver publishes its own `getSleepOptions()` and `getDebounceOptions()`.
- `src/device/controller.ts`: `applyPulsarValue` only stages a sleep or debounce change when the active client is on its allow-list; the M6 client is added there via a `keychronM6Client()` accessor next to the Nape one.

The driver also drops its `hideProcessingCard` and `hideSleepCard` hints, so no other app change is needed.

## Depends on

OpenMouse-Project/mouse-protocol PR "keychron: decode the M6's full 8k protocol". The app tracks mouse-protocol `main`, so this should merge after that one.

## Verified

Typechecks against the new protocol build; the driver itself was exercised on an M6 (firmware 1.0.3, USB) for every field and setter it exposes.
