### PR TITLE
Preload font CSS and validate staged polling rate

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&family=JetBrains+Mono:wght@400;500&display=swap" />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32" />

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -3108,6 +3108,10 @@ export function setProfileReportRate(link: "wireless" | "wired", hz: number): vo
 
 export function applyPollingRate(rate: number): void {
   if (!hasActiveClient()) return;
+  // The slider only offers device-advertised rates (or RATE_STEPS_HZ); anything
+  // else arrives from an imported profile key, so reject it before staging.
+  const allowed = latestDeviceStatus?.supportedPollingRates ?? RATE_STEPS_HZ;
+  if (!Number.isInteger(rate) || !allowed.includes(rate)) return;
   stageChange({
     key: "polling-rate",
     label: `${rate.toLocaleString()} Hz`,


### PR DESCRIPTION
Resolves conflicts in #225, supersedes it.

#225 also touched `admin.html`, which no longer exists in this repo (it was removed in the landing-site split, commit `01906c9`, before this PR could be merged). This replacement carries forward the two changes that still apply:
- `index.html`: adds a `rel=preload` hint for the Google Fonts CSS alongside the existing stylesheet link.
- `src/device/controller.ts`: `applyPollingRate` now rejects a rate that isn't an integer or isn't in the device's supported/step list, guarding against a bad value arriving from an imported profile key.

`npm run check` passes.

https://claude.ai/code/session_01JfTcrhgBuFh8QiLvbtdJCX