### PR TITLE
Re-derive Attack Shark X11 native polling (supersedes #222)

### DIFF
--- a/src/app/cards/PerformanceCards.tsx
+++ b/src/app/cards/PerformanceCards.tsx
@@ -6,7 +6,7 @@ import {
   reportRatesFor,
 } from "@openmouse/protocol/drivers/logitech/onboard-profiles";
 import * as control from "../../device/controller";
-import { RATE_STEPS_HZ } from "../../device/controller";
+import { isNativeAttackSharkX11, RATE_STEPS_HZ } from "../../device/controller";
 import type { ControlSnapshot, LiftOffLevel } from "../../device/types";
 import { t, tp } from "../../i18n";
 import type { InterfaceLocale } from "../../interface-preferences";
@@ -28,6 +28,7 @@ export function PollingCard({ snapshot }: { snapshot: ControlSnapshot }): ReactN
   const perProfile = entry !== null && rates !== null;
   const locked = snapshot.profileFormat?.writable !== true;
   const shared = (snapshot.profileFormat?.id ?? 6) < 6;
+  const nativeX11 = isNativeAttackSharkX11(status);
 
   const advertisedRates = (status.supportedPollingRates ?? RATE_STEPS_HZ)
     .filter((rate) => !(snapshot.traits.eggControls && rate < 1000))
@@ -86,7 +87,7 @@ export function PollingCard({ snapshot }: { snapshot: ControlSnapshot }): ReactN
           locale={locale}
           options={advertisedRates}
           valueHz={status.pollingRateHz}
-          disabled={snapshot.settingsPending || status.ui?.pollingReadOnly === true}
+          disabled={(snapshot.settingsPending && !nativeX11) || status.ui?.pollingReadOnly === true}
           bubble={false}
           onChange={control.applyPollingRate}
         />

--- a/src/app/cards/availability.ts
+++ b/src/app/cards/availability.ts
@@ -112,7 +112,14 @@ export function cardAvailability(snapshot: ControlSnapshot): CardAvailability {
 
   return {
     dpi: ready,
-    polling: ready,
+    // The Attack Shark X11's settings channel is native-only (settingsReady
+    // stays false), but its polling rate is still controllable through
+    // OpenMouse Bridge — see isNativeAttackSharkX11 in device/controller.ts.
+    polling: ready || (
+      status.brand === "Attack Shark"
+      && status.name === "Attack Shark X11"
+      && status.ui?.settingsReady === false
+    ),
     sensor: sensor && ready,
     lightforce: Boolean(status.lightforceSwitchMode),
     superstrike: traits.logitech && status.analogButtonTuning?.buttons.length === 2,

--- a/src/bridge.test.ts
+++ b/src/bridge.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { applyBridgeNativeSettings } from "./bridge.ts";
+
+test("native settings are sent to the Bridge as JSON", async () => {
+  const originalFetch = globalThis.fetch;
+  let request: { url: string; method?: string; body?: BodyInit | null } | null = null;
+  globalThis.fetch = async (input, init) => {
+    request = { url: String(input), method: init?.method, body: init?.body };
+    return Response.json({ ok: true });
+  };
+
+  try {
+    await applyBridgeNativeSettings({ brand: "Attack Shark", pollingRateHz: 500 });
+    assert.deepEqual(request, {
+      url: "http://127.0.0.1:17846/v1/native/settings",
+      method: "PUT",
+      body: JSON.stringify({ brand: "Attack Shark", pollingRateHz: 500 }),
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,5 +1,9 @@
 const BRIDGE_URL = "http://127.0.0.1:17846";
 const BRIDGE_TIMEOUT_MS = 1_500;
+// Native settings writes go through a real hardware channel Bridge alone can
+// reach (e.g. a libusb claim on an interface WebHID cannot see), so they get
+// a much longer budget than the plain REST calls above.
+const BRIDGE_NATIVE_TIMEOUT_MS = 12_000;
 
 export interface BridgeStatus {
   version: string;
@@ -94,8 +98,33 @@ export async function saveBridgeBattery(
   }, signal);
 }
 
-async function bridgeRequest<T>(path: string, init?: RequestInit, signal?: AbortSignal): Promise<T> {
-  const timeout = AbortSignal.timeout(BRIDGE_TIMEOUT_MS);
+/**
+ * Ask Bridge to apply settings on a device it controls natively, bypassing
+ * WebHID entirely (e.g. the Attack Shark X11 family, whose config channel is
+ * an interface a browser is never allowed to open — see
+ * `attackSharkNativeOnlyMessage` in @openmouse/protocol). Bridge itself claims
+ * the hardware and applies the change, which can take longer than a normal
+ * status round-trip.
+ */
+export async function applyBridgeNativeSettings(settings: {
+  brand: string;
+  dpi?: number;
+  pollingRateHz?: number;
+}): Promise<void> {
+  await bridgeRequest("/v1/native/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(settings),
+  }, undefined, BRIDGE_NATIVE_TIMEOUT_MS);
+}
+
+async function bridgeRequest<T>(
+  path: string,
+  init?: RequestInit,
+  signal?: AbortSignal,
+  timeoutMs = BRIDGE_TIMEOUT_MS,
+): Promise<T> {
+  const timeout = AbortSignal.timeout(timeoutMs);
   const combined = signal ? AbortSignal.any([signal, timeout]) : timeout;
   const response = await fetch(`${BRIDGE_URL}${path}`, {
     headers: { Accept: "application/json" },

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -1,4 +1,5 @@
 import { cachedBatterySamples, estimateBatteryTime, recordBatterySample, type BatteryMode } from "../battery-history";
+import { applyBridgeNativeSettings } from "../bridge";
 import {
   clientSupportScore,
   createSupportedClient,
@@ -178,6 +179,15 @@ const DEFAULT_TITLE = typeof document === "undefined" ? "OpenMouse Control" : do
 const ACTIVE_DEVICE_STORAGE_KEY = "openmouse.active-device";
 const WLMOUSE_SLEEP_NEVER = 0xffff;
 export const RATE_STEPS_HZ = [125, 250, 500, 1000, 2000, 4000, 8000];
+// Real Attack Shark X11 hardware exposes no HID feature reports the browser
+// can reach (see attackSharkNativeOnlyMessage in @openmouse/protocol); the
+// driver reports it with `ui.settingsReady: false`. Polling rate can still be
+// set through OpenMouse Bridge, which claims the native interface directly,
+// so this app-side allowlist of rates and a small local cache of the last
+// value we told Bridge to apply (the firmware exposes no read-back command)
+// stand in for what the driver would normally advertise.
+export const X11_POLLING_RATES_HZ = [125, 250, 500, 1000];
+const X11_POLLING_STORAGE_KEY = "openmouse.attack-shark-x11.polling-rate";
 export const PULSAR_SLEEP_OPTIONS: ReadonlyArray<readonly [number, string]> = [
   [1, "10 seconds"], [3, "30 seconds"], [6, "1 minute"], [12, "2 minutes"],
   [30, "5 minutes"], [60, "10 minutes"], [180, "30 minutes"],
@@ -196,6 +206,17 @@ const previewMode = previewModeEnabled
 const isAnyPreview = previewMode !== null;
 
 let active: SupportedClient | null = null;
+let x11PollingRateHz = (() => {
+  const saved = Number(window.localStorage.getItem(X11_POLLING_STORAGE_KEY));
+  return X11_POLLING_RATES_HZ.includes(saved) ? saved : 1000;
+})();
+
+/** True for the specific Attack Shark X11 units whose settings channel is native-only. */
+export function isNativeAttackSharkX11(status: MouseStatus | null | undefined): boolean {
+  return status?.brand === "Attack Shark"
+    && status.name === "Attack Shark X11"
+    && status.ui?.settingsReady === false;
+}
 
 type ClientClass<T> = abstract new (...args: never[]) => T;
 
@@ -1485,6 +1506,20 @@ function applyStatus(deviceStatus: MouseStatus, statusKey?: string): void {
 }
 
 function applyStatusInner(deviceStatus: MouseStatus, statusKey?: string): void {
+  if (isNativeAttackSharkX11(deviceStatus)) {
+    // The firmware has no read-back command for polling rate, so show the
+    // last value this app told Bridge to apply instead of the driver's 0.
+    deviceStatus = {
+      ...deviceStatus,
+      pollingRateHz: x11PollingRateHz,
+      supportedPollingRates: X11_POLLING_RATES_HZ,
+      ui: {
+        ...deviceStatus.ui,
+        pollingNote: "Native control through OpenMouse Bridge. The displayed rate is the "
+          + "last value applied here; this firmware does not expose a readable current-rate command.",
+      },
+    };
+  }
   latestDeviceStatus = deviceStatus;
   latestDiagnosticStatus = deviceStatus;
   // Battery samples are recorded at device-update cadence; renders read the
@@ -3117,6 +3152,7 @@ export function applyPollingRate(rate: number): void {
   // else arrives from an imported profile key, so reject it before staging.
   const allowed = latestDeviceStatus?.supportedPollingRates ?? RATE_STEPS_HZ;
   if (!Number.isInteger(rate) || !allowed.includes(rate)) return;
+  const nativeX11 = isNativeAttackSharkX11(latestDeviceStatus);
   stageChange({
     key: "polling-rate",
     label: `${rate.toLocaleString()} Hz`,
@@ -3126,7 +3162,13 @@ export function applyPollingRate(rate: number): void {
       status.pollingRateHz = rate;
     },
     apply: async () => {
-      await requireClientMethod("setPollingRate", "the polling rate").setPollingRate(rate);
+      if (nativeX11) {
+        await applyBridgeNativeSettings({ brand: "Attack Shark", pollingRateHz: rate });
+        x11PollingRateHz = rate;
+        window.localStorage.setItem(X11_POLLING_STORAGE_KEY, String(rate));
+      } else {
+        await requireClientMethod("setPollingRate", "the polling rate").setPollingRate(rate);
+      }
     },
   });
 }


### PR DESCRIPTION
Re-derives #222 against current main (predates the `src/bridge.ts` / settings-page refactor), supersedes it.

## Summary

The original PR added app-side support for the Attack Shark X11's polling rate, which is native-only (real X11 hardware exposes no HID feature reports a browser can reach). Since #222 was opened, `@openmouse/protocol`'s Attack Shark driver has been built out to detect this itself (`ui.settingsReady: false`, plus a `statusNote` pointing users at OpenMouse Bridge), and `src/bridge.ts` has grown well beyond the "coming soon" REST stub the original PR patched.

This PR re-implements the same intent against that current structure:

- `src/bridge.ts`: `applyBridgeNativeSettings()` PUTs to `/v1/native/settings` so Bridge can apply settings on hardware it controls natively (bypassing WebHID), with a longer timeout than the other Bridge REST calls, plus a unit test.
- `src/device/controller.ts`: `isNativeAttackSharkX11()` detects the unreachable X11 units by brand/name/settingsReady; `applyStatusInner()` fills in a cached last-applied polling rate (the firmware has no read-back command) and a `pollingNote` explaining Bridge control; `applyPollingRate()` routes through `applyBridgeNativeSettings()` for these units instead of the normal WebHID `setPollingRate()`.
- `src/app/cards/availability.ts`: the polling card stays visible for this specific native-only case instead of being hidden by the generic `settingsReady` gate.
- `src/app/cards/PerformanceCards.tsx`: the polling slider stays interactive for native X11 units even while `settingsPending` is otherwise set.

## What was dropped from the original diff

The original PR also added an `InterfaceSettings.tsx` "OpenMouse Bridge" status card (checking/connected/disconnected heartbeat) with new i18n strings across all locales. That whole "Bridge coming soon" panel no longer exists on main — `src/bridge.ts`'s REST client now backs other, already-shipped features (application profiles, games, battery) with no dedicated settings-page UI — so re-adding a standalone connection-status widget was out of scope for a faithful, minimal port. `applyBridgeNativeSettings()` failures surface through the existing staged-change error path like any other apply failure.

## Verification
- `npm run check` (typecheck + build + tests) passes
- `npm run size` passes (JS 99% of budget, no change to BUDGET_BYTES needed)

https://claude.ai/code/session_01JfTcrhgBuFh8QiLvbtdJCX