### PR TITLE
feat(dareu): add A950 PRO Mg controls (resolves #246, #218)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -482,8 +482,7 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#28f2a88220bf7d63ba787dfb66f29272ae300751",
-      "integrity": "sha512-1N5Lg1K/1zcNBk71/dHK5U1yo2/rg7yP2lJfNv7xfjxgBegHlbrKRPsx6tPY7YfnOmdc8CWEer3KJqOVPMl/tQ==",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#75fa8329bb23ff9dba83c3f0953e1e394c0c86a1",
       "engines": {
         "node": ">=20"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -482,7 +482,7 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#75fa8329bb23ff9dba83c3f0953e1e394c0c86a1",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#27b9e607a16cd9740db7f41bca324ec16fa17a16",
       "engines": {
         "node": ">=20"
       }

--- a/public/devices/README.md
+++ b/public/devices/README.md
@@ -201,3 +201,10 @@ package:
   MCHOSE publishes only `A7V3Pro_*` renders and the four V3 models share a
   shell, so one image covers the family. **Needs a maintainer upload**, and
   carries the same unresolved licensing question.
+
+- `dareu-a950-pro-mg.png` — **needs a maintainer upload.** The mapping covers
+  the A950 PRO Mg mouse (`0x260d:0x1117`) and dedicated receiver
+  (`0x260d:0x1114`). Suggested source: the contributor-supplied transparent
+  render from Dareu's driver panel
+  (`https://driver.dareu.com/allinone/products/1117/TM271F.png?v=1.3.24`). It
+  is vendor product art; request licensing review before publishing it in R2.

--- a/src/app/OverviewPage.tsx
+++ b/src/app/OverviewPage.tsx
@@ -45,7 +45,7 @@ import {
   PulsarProCard,
   SignalCard,
   SleepCard,
-  TeevolutionDpiLightingCard,
+  DpiLightingCard,
 } from "./cards/AdvancedCards";
 import { cardAvailability } from "./cards/availability";
 import { TeevolutionProfileCard } from "./cards/teevolution/ProfileCard";
@@ -317,10 +317,18 @@ function OverviewEmpty({ snapshot, compact = false }: { snapshot: ControlSnapsho
 function OverviewContent({ snapshot }: { snapshot: ControlSnapshot }): ReactNode {
   const status = snapshot.status;
   if (!status) return <OverviewEmpty snapshot={snapshot} />;
+  const has = cardAvailability(snapshot);
+  const powerOverview = status.ui?.powerOverview === true;
   return (
     <>
       <DeviceShowcase snapshot={snapshot} />
       <DeviceInfoGrid snapshot={snapshot} />
+      {powerOverview && (has.teevolutionDpiLighting || has.sleep) ? (
+        <section id="power-overview-settings" className="settings-grid device-data" aria-label="Power settings">
+          {has.teevolutionDpiLighting ? <DpiLightingCard snapshot={snapshot} /> : null}
+          {has.sleep ? <SleepCard snapshot={snapshot} /> : null}
+        </section>
+      ) : null}
     </>
   );
 }
@@ -338,6 +346,7 @@ export function Workspace({
   const locale = snapshot.preferences.locale;
   const has = cardAvailability(snapshot);
   const show = (available: boolean, tabs: readonly WorkspaceTab[]): boolean => available && on(tab, tabs);
+  const powerOverview = status.ui?.powerOverview === true;
 
   const performance = [
     show(has.dpi, ["performance"]) ? <DpiCard key="dpi" snapshot={snapshot} /> : null,
@@ -349,7 +358,7 @@ export function Workspace({
   const advanced = [
     show(has.signal, ["advanced"]) ? <SignalCard key="signal" snapshot={snapshot} /> : null,
     show(has.debounce, ["buttons"]) ? <DebounceCard key="debounce" snapshot={snapshot} /> : null,
-    show(has.sleep, ["advanced"]) ? <SleepCard key="sleep" snapshot={snapshot} /> : null,
+    !powerOverview && show(has.sleep, ["advanced"]) ? <SleepCard key="sleep" snapshot={snapshot} /> : null,
     show(has.lightingAdvanced, ["advanced"])
       ? <LightingCard key="lighting" snapshot={snapshot} variant="advanced" /> : null,
     show(has.ninjutsoSensor, ["performance"])
@@ -383,8 +392,8 @@ export function Workspace({
   const lighting = [
     show(has.lighting, ["lighting"])
       ? <LightingCard key="lighting-tab" snapshot={snapshot} variant="tab" zones={lightingZones} /> : null,
-    show(has.teevolutionDpiLighting, ["lighting"])
-      ? <TeevolutionDpiLightingCard key="teevo" snapshot={snapshot} /> : null,
+    !powerOverview && show(has.teevolutionDpiLighting, ["lighting"])
+      ? <DpiLightingCard key="dpi-indicator" snapshot={snapshot} /> : null,
   ].filter((node) => node !== null);
 
   const showProfiles = show(has.profiles, ["profiles"]);
@@ -609,7 +618,7 @@ export function OverviewPage({
     let tempTabs = WORKSPACE_TAB_ORDER;
     const has = cardAvailability(snapshot);
     if (deviceStatus == null) return tempTabs;
-    if (!has.lighting && !has.teevolutionDpiLighting) tempTabs = tempTabs.filter((tab) => tab !== "lighting");
+    if (!has.lighting && (!has.teevolutionDpiLighting || deviceStatus.ui?.powerOverview === true)) tempTabs = tempTabs.filter((tab) => tab !== "lighting");
     if (
       !has.eggButtons
       && !has.razerButtons

--- a/src/app/cards/AdvancedCards.tsx
+++ b/src/app/cards/AdvancedCards.tsx
@@ -430,7 +430,7 @@ export function ProcessingCard({ snapshot }: { snapshot: ControlSnapshot }): Rea
   );
 }
 
-export function TeevolutionDpiLightingCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNode {
+export function DpiLightingCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNode {
   const status = snapshot.status;
   const profile = snapshot.capabilities?.teevolutionProfile;
   const hint = status?.ui?.dpiLighting;
@@ -442,14 +442,15 @@ export function TeevolutionDpiLightingCard({ snapshot }: { snapshot: ControlSnap
   const speedMax = hint?.speed.at(-1) ?? profile!.dpiLighting.speed.max;
   const locale = snapshot.preferences.locale;
   const lightMode = status.dpiLedMode ?? 0;
-  const staged = snapshot.pending.keys.some((key) => key.startsWith("teevolution-dpi-light-"));
+  const powerOverview = status.ui?.powerOverview === true;
+  const staged = snapshot.pending.keys.some((key) => key.startsWith("teevolution-dpi-light-") || key === "dpi-light-sleep");
   return (
     <article
       id="teevolution-dpi-lighting"
       className={`setting-card${staged ? " is-staged" : ""}`}
-      data-pending-key="teevolution-dpi-light-mode teevolution-dpi-light-brightness teevolution-dpi-light-speed"
+      data-pending-key="teevolution-dpi-light-mode teevolution-dpi-light-brightness teevolution-dpi-light-speed dpi-light-sleep"
     >
-      <div className="setting-heading compact"><div><p>LIGHTING</p><h2>{t(locale, "adv.dpiIndicator")}</h2></div></div>
+      <div className="setting-heading compact"><div><p>{powerOverview ? "POWER" : "LIGHTING"}</p><h2>{t(locale, "adv.dpiIndicator")}</h2></div></div>
       <label className="field-label">
         {t(locale, "adv.effect")}
         <select
@@ -476,7 +477,7 @@ export function TeevolutionDpiLightingCard({ snapshot }: { snapshot: ControlSnap
               max={brightnessMax}
               step={1}
               value={status.dpiLedBrightness ?? brightnessMin}
-              disabled={lightMode !== 1 || status.dpiLedBrightness == null}
+              disabled={lightMode === 0 || status.dpiLedBrightness == null}
               style={{
                 "--fill": `${((status.dpiLedBrightness ?? brightnessMin) - brightnessMin)
                   / Math.max(1, brightnessMax - brightnessMin) * 100}%`,
@@ -508,10 +509,27 @@ export function TeevolutionDpiLightingCard({ snapshot }: { snapshot: ControlSnap
           </span>
         </label>
       </div>
+      {hint?.sleepTimeouts?.length && status.dpiLedSleepTimeout != null ? (
+        <label className="field-label spaced">
+          {t(locale, "adv.autoSleep")}
+          <select
+            id="dpi-light-sleep-timeout"
+            value={status.dpiLedSleepTimeout}
+            onChange={(event) => control.applyDpiLightingSleepTimeout(Number(event.currentTarget.value))}
+          >
+            {hint.sleepTimeouts.map((seconds) => (
+              <option key={seconds} value={seconds}>{sleepLabel(seconds, locale)}</option>
+            ))}
+          </select>
+        </label>
+      ) : null}
       <small className="setting-note">{t(locale, "adv.dpiStageNote")}</small>
     </article>
   );
 }
+
+/** @deprecated Kept as an import alias for integrations built before generic DPI lighting. */
+export const TeevolutionDpiLightingCard = DpiLightingCard;
 
 export function NinjutsoSensorCard({ snapshot }: { snapshot: ControlSnapshot }): ReactNode {
   const status = snapshot.status;

--- a/src/app/cards/availability.test.ts
+++ b/src/app/cards/availability.test.ts
@@ -124,6 +124,26 @@ test("ATK exposes its processing and DPI-lighting cards from reported controls",
   assert.equal(has.teevolutionDpiLighting, true);
 });
 
+test("Dareu exposes its verified mouse and DPI-indicator sleep controls", () => {
+  const has = cardAvailability(snapshot({
+    status: {
+      brand: "Dareu",
+      ui: {
+        family: "dareu",
+        showAdvancedSection: true,
+        dpiLighting: {
+          modes: [0, 1, 2], brightness: [1, 2], speed: [1, 2], sleepTimeouts: [0, 60],
+        },
+      },
+      sleepTimeout: 180,
+      dpiLedSleepTimeout: 180,
+    },
+  }));
+  assert.equal(has.advancedHost, true);
+  assert.equal(has.sleep, true);
+  assert.equal(has.teevolutionDpiLighting, true);
+});
+
 test("ATK inspection cards require data actually read from the device", () => {
   const empty = cardAvailability(snapshot({ status: { brand: "VXE", ui: { family: "atk" } } }));
   assert.equal(empty.atkButtons, false);

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -149,6 +149,7 @@ import {
 import { SUPPORTED_HID_FILTERS } from "@openmouse/protocol/drivers/vendors";
 import { WLMouseHidClient } from "@openmouse/protocol/drivers/wlmouse/hid";
 import { MicrosoftHidClient } from "@openmouse/protocol/drivers/microsoft/hid";
+import { DareuHidClient } from "@openmouse/protocol/drivers/dareu/hid";
 import { IncottHidClient } from "@openmouse/protocol/drivers/incott/hid";
 import { parsePreviewMode, previewsEnabled, type PreviewMode } from "../preview-modes";
 import { sleepLabel } from "./options";
@@ -204,7 +205,7 @@ function activeAs<T>(...classes: ClientClass<T>[]): T | null {
 
 const DM_CLASSES = [WLMouseHidClient, LamzuHidClient, AtkHidClient, AtkBitmouseHidClient, NinjutsoHidClient] as const;
 const RAZER_CLASSES = [RazerHidClient, RazerViperMiniHidClient, RazerViperHidClient, RazerCobraHidClient] as const;
-const NEEDS_OPEN = [TeevolutionHidClient, VgnF2HidClient, KeychronNapeHidClient, KeychronM6HidClient, ModdoHidClient, ZaunkoenigHidClient, CorsairHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient, GloriousHidClient, GloriousClassicHidClient, MchoseHidClient, MchoseDockHidClient, MchoseV3HidClient, MicrosoftHidClient, IncottHidClient] as const;
+const NEEDS_OPEN = [TeevolutionHidClient, VgnF2HidClient, KeychronNapeHidClient, KeychronM6HidClient, ModdoHidClient, ZaunkoenigHidClient, CorsairHidClient, FantechHidClient, WallhackMouseHidClient, WallhackKeyboardHidClient, GloriousHidClient, GloriousClassicHidClient, MchoseHidClient, MchoseDockHidClient, MchoseV3HidClient, MicrosoftHidClient, DareuHidClient, IncottHidClient] as const;
 const PULSAR_CLASSES = [PulsarHidClient, PulsarProHidClient, PulsarXs1HidClient] as const;
 
 const logitechClient = (): LogitechHidppClient | null => activeAs(LogitechHidppClient);
@@ -218,8 +219,8 @@ const razerClient = (): RazerHidClient | RazerViperMiniHidClient | RazerViperHid
 const viperClient = (): RazerViperV4ProHidClient | null => activeAs(RazerViperV4ProHidClient);
 
 const teevolutionClient = (): TeevolutionHidClient | null => activeAs(TeevolutionHidClient);
-const dpiLightingClient = (): TeevolutionHidClient | AtkHidClient | null =>
-  activeAs<TeevolutionHidClient | AtkHidClient>(TeevolutionHidClient, AtkHidClient);
+const dpiLightingClient = (): TeevolutionHidClient | AtkHidClient | DareuHidClient | null =>
+  activeAs<TeevolutionHidClient | AtkHidClient | DareuHidClient>(TeevolutionHidClient, AtkHidClient, DareuHidClient);
 const finalmouseClient = (): FinalmouseHidClient | null => activeAs(FinalmouseHidClient);
 const orbitalClient = (): OrbitalHidClient | null => activeAs(OrbitalHidClient);
 const vgnClient = (): VgnF2HidClient | null => activeAs(VgnF2HidClient);
@@ -1709,7 +1710,6 @@ async function activateClientNow(client: SupportedClient): Promise<void> {
       lastSleepSeconds = status.sleepTimeout ?? keychron.getSleepOptions()[0] ?? 60;
     }
     deviceStatuses.set(client.device, status);
-    capabilities = readCapabilities();
     applyStatus(status);
     await readButtons();
     await loadNapeKeymap(status.napeLayer ?? editedNapeLayer ?? 1);
@@ -3278,9 +3278,12 @@ export function applyPulsarToggle(setting: PulsarToggleSetting, enabled: boolean
 }
 
 export function applyPulsarValue(setting: "debounce" | "sleep", value: number): void {
-  if (!(pulsarClient() ?? dmClient() ?? orbitalClient() ?? razerClient()
-    ?? viperClient() ?? teevolutionClient() ?? vgnClient() ?? keychronNapeClient() ?? keychronM6Client() ?? wallhackMouseClient()
-    ?? incottClient())) return;
+  const client = setting === "sleep"
+    ? activeSettingsClient()
+    : pulsarClient() ?? dmClient() ?? orbitalClient() ?? razerClient()
+      ?? viperClient() ?? teevolutionClient() ?? vgnClient() ?? keychronNapeClient() ?? keychronM6Client() ?? wallhackMouseClient()
+      ?? incottClient();
+  if (!client || (setting === "sleep" && !("setSleepTimeout" in client))) return;
   const asleep = value !== WLMOUSE_SLEEP_NEVER;
   stageChange({
     key: setting,
@@ -3547,6 +3550,9 @@ async function writeStagedTeevolutionDpiLighting(): Promise<void> {
 
 export function applyTeevolutionDpiLighting(setting: "mode" | "brightness" | "speed", value: number): void {
   if (!dpiLightingClient()) return;
+  const hint = latestDeviceStatus?.ui?.dpiLighting;
+  const allowed = setting === "mode" ? hint?.modes : setting === "brightness" ? hint?.brightness : hint?.speed;
+  if (allowed && !allowed.includes(value)) return;
   const names = { mode: "effect", brightness: "brightness", speed: "speed" } as const;
   const display = setting === "mode" ? (["Off", "Steady", "Breathing"][value] ?? `${value}`) : `${value}`;
   stageChange({
@@ -3561,6 +3567,24 @@ export function applyTeevolutionDpiLighting(setting: "mode" | "brightness" | "sp
       if (setting === "speed") status.dpiLedSpeed = value;
     },
     apply: writeStagedTeevolutionDpiLighting,
+  });
+}
+
+export function applyDpiLightingSleepTimeout(seconds: number): void {
+  const allowed = latestDeviceStatus?.ui?.dpiLighting?.sleepTimeouts;
+  if (!allowed?.includes(seconds)) return;
+  stageChange({
+    key: "dpi-light-sleep",
+    label: `DPI indicator sleep ${sleepLabel(seconds, interfacePreferences.locale)}`,
+    command: `Set DPI indicator sleep to ${sleepLabel(seconds, interfacePreferences.locale)}`,
+    progress: "Setting DPI indicator sleep…",
+    preview: (status) => { status.dpiLedSleepTimeout = seconds; },
+    apply: async () => {
+      const client = requireClientMethod("setDpiLedSleepTimeout", "DPI indicator sleep") as unknown as {
+        setDpiLedSleepTimeout(value: number): Promise<unknown>;
+      };
+      await client.setDpiLedSleepTimeout(seconds);
+    },
   });
 }
 

--- a/src/device/traits.ts
+++ b/src/device/traits.ts
@@ -62,6 +62,7 @@ const BY_FAMILY: Readonly<Record<string, Partial<DriverTraits>>> = {
   // "mchose-v3" is deliberately absent: that driver reads and cannot write, so
   // every card these flags open would render controls with nothing behind
   // them. Give it the same flags as `mchose` once it grows setters.
+  dareu: { advancedSection: true, sleep: true },
   // Incott supports a 0-30 ms debounce and a 1-900 s sleep timer over its own
   // vendor protocol, not the CompX direct-mode transport, so it takes the
   // plain flags rather than DIRECT_MODE (its advancedSection already comes

--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -85,6 +85,13 @@ test("Attack Shark R5 Ultra wired and wireless share the same artwork", () => {
   assert.equal(deviceImage(null, "Attack Shark R5 Ultra"), CDN + "attackshark-r5-ultra.png");
 });
 
+test("Dareu A950 PRO Mg wired and receiver paths share the requested artwork", () => {
+  const dareuArt = CDN + "dareu-a950-pro-mg.png";
+  assert.equal(deviceImage(dev(0x260d, 0x1117)), dareuArt);
+  assert.equal(deviceImage(dev(0x260d, 0x1114)), dareuArt);
+  assert.equal(deviceImage(null, "Dareu A950 PRO Mg"), dareuArt);
+});
+
 test("Attack Shark R2 resolves by name (PID 0x402D is shared with the M5 Pro)", () => {
   assert.equal(deviceImage(null, "Attack Shark R2"), CDN + "attackshark-r2.png");
   // The shared receiver PID must NOT resolve to the R2 render.

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -168,6 +168,9 @@ const DEVICE_IMAGES: ReadonlyMap<string, string> = new Map([
   // K-snake X11 wired / 2.4 GHz dongle share the same shell.
   ["a8a4:2255", "ksnake-x11.png"],
   ["a8a5:2255", "ksnake-x11.png"],
+  // A950 PRO Mg wired mouse and its dedicated 2.4 GHz receiver.
+  ["260d:1117", "dareu-a950-pro-mg.png"],
+  ["260d:1114", "dareu-a950-pro-mg.png"],
   // Microsoft Intellimouse
   ["045e:0823", "microsoft-classic-intellimouse.png"],
   ["045e:082a", "microsoft-pro-intellimouse.png"],
@@ -332,6 +335,7 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
   // an "A7 V3" name is not swallowed by a looser A7 match later.
   if (/\ba7\s*v3\b/i.test(displayName)) return "mchose-a7-v3.png";
   if (/\ba7\s*v2\b/i.test(displayName)) return "mchose-a7-v2.png";
+  if (/\ba950\s*pro\s*mg\b/i.test(displayName)) return "dareu-a950-pro-mg.png";
   if (/\b(finalmouse|starlight|ulx)\b/i.test(displayName)) return "finalmouse-ulx.png";
   if (/\borbital\b/i.test(displayName)) return "unknown-device.png";
   if (/\bmoddo/i.test(displayName)) return "unknown-device.png";


### PR DESCRIPTION
Resolves conflicts in #246 (itself a clean re-derivation of #218) and supersedes it. #246 lives on a contributor fork, so its actual PR branch couldn't be updated in place once other driver PRs (#248, #249, #250) landed on main and touched the same shared registration files.

Conflicts were additive in `src/device/controller.ts` (`NEEDS_OPEN` gained `DareuHidClient` alongside other recently-landed drivers) and `package-lock.json` (regenerated against latest `@openmouse/protocol`).

`npm run check`: 135/135 tests pass. Bundle size within budget (1,485.2 kB / 1,500 kB JS).

Claude-Session: https://claude.ai/code/session_01JfTcrhgBuFh8QiLvbtdJCX