### PR TITLE
chore(deps): bump @openmouse/protocol to pick up the Razer picker fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -482,7 +482,8 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#27b9e607a16cd9740db7f41bca324ec16fa17a16",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#3c2d3d5d3c0874c4252df690f8c39e1bd37410a8",
+      "integrity": "sha512-CbSKl9xStDl+EcuHuwu29CvINbdr9T8pXX/c0eNu3F7V1VkgFnFiDquceeTQZjjcxUvU8iOooF+fmrjfk+Zycw==",
       "engines": {
         "node": ">=20"
       }


### PR DESCRIPTION
Pulls in mouse-protocol#92, which narrows the WebHID picker filter for every HyperSpeed-generation Razer model (DeathAdder V2 Pro, Basilisk V3 Pro, DeathAdder V3/V4 Pro, DeathAdder V3 HyperSpeed, Viper/Viper Mini/Ultimate) instead of leaving them on the whole-device catch-all, which offered every top-level collection as an identical, unlabeled checkbox and let users silently grant the wrong one.

Root-caused from a user's `navigator.hid.getDevices()` dump on Windows vs macOS for a DeathAdder V3 HyperSpeed — see mouse-protocol#92 for the full writeup.

`npm run check`: 142/142 tests pass. Bundle size within budget.

Claude-Session: https://claude.ai/code/session_01JfTcrhgBuFh8QiLvbtdJCX