### PR TITLE
artwork: refuse a second image format for a device that already has one

### DIFF
--- a/functions/api/artwork/upload.js
+++ b/functions/api/artwork/upload.js
@@ -68,8 +68,13 @@ export async function onRequest({ request, env }) {
   const filename = `${vendorHex}:${productHex}.${ext}`;
   const objectKey = `crowd/${filename}`;
 
-  const existing = await env.ARTWORK_BUCKET.head(objectKey);
-  if (existing) {
+  // Checked by prefix, not by the exact key: the extension is part of the key
+  // (crowd/{vendor}:{product}.{ext}), so a .head() on this one key alone would
+  // miss an existing upload in the *other* format and let both land in the
+  // bucket for the same device — two objects the list endpoint can then only
+  // arbitrarily pick between.
+  const existing = await env.ARTWORK_BUCKET.list({ prefix: `crowd/${filename.replace(/\.[^.]+$/, "")}.` });
+  if (existing.objects.length > 0) {
     return json({ ok: true, message: "Artwork already exists." });
   }
 

--- a/src/ui/artwork-storage.ts
+++ b/src/ui/artwork-storage.ts
@@ -47,7 +47,13 @@ function saveCacheToStorage(entries: ArtworkEntry[]): void {
 
 function buildMap(entries: ArtworkEntry[]): Map<string, string> {
   const map = new Map<string, string>();
-  for (const entry of entries) {
+  // The upload endpoint now refuses a second format for a device that already
+  // has one, but the bucket may still carry pre-existing .png/.webp pairs
+  // from before that check existed. Sort so any leftover duplicate resolves
+  // to the same filename every time instead of whichever the API happened to
+  // list last — R2's list order isn't something this app controls.
+  const sorted = [...entries].sort((a, b) => a.filename.localeCompare(b.filename));
+  for (const entry of sorted) {
     map.set(getCacheKey(entry.vendorId, entry.productId), entry.filename);
   }
   return map;


### PR DESCRIPTION
Confirmed report from vladi: uploading a .webp alongside an existing .png for the same device creates two R2 objects that list.js/buildMap() collapse nondeterministically.

## Root cause
- `functions/api/artwork/upload.js`: the R2 object key includes the extension (`crowd/{vendor}:{product}.{ext}`), and the existing-artwork check only did `.head()` on that exact key — so a second format for an already-illustrated device sailed straight through.
- `functions/api/artwork/list.js`: lists both objects with the same vendorId/productId, different filenames.
- `src/ui/artwork-storage.ts` `buildMap()`: keys by vendorId:productId only (no extension), so the second entry it processes silently overwrites the first — and that order comes straight from R2's list response, which isn't something this app controls.

## Fix
- Upload now checks by *prefix* (any extension for that vendor:product) before allowing a new one, so a competing format gets rejected instead of quietly creating a duplicate.
- `buildMap()` sorts entries before building the map, so any duplicate already sitting in the bucket from before this fix resolves to the same filename on every load instead of flipping.

`npm run check`: 142/142 tests pass (no existing coverage for the Cloudflare Functions themselves).