### PR TITLE
device: wire in the Razer control-interface probe fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -482,8 +482,8 @@
     },
     "node_modules/@openmouse/protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#3c2d3d5d3c0874c4252df690f8c39e1bd37410a8",
-      "integrity": "sha512-CbSKl9xStDl+EcuHuwu29CvINbdr9T8pXX/c0eNu3F7V1VkgFnFiDquceeTQZjjcxUvU8iOooF+fmrjfk+Zycw==",
+      "resolved": "git+ssh://git@github.com/OpenMouse-Project/mouse-protocol.git#c144f4476a0cccef2f32cedf24a34568c9163d79",
+      "integrity": "sha512-BkhssWjrXHfVU5/k3strpBbwNVV1PMlqYVqfC/CiCf96HnK/Sh+9k3FR0cprmBYgsCrtDunwYKxYyhlB09sHvw==",
       "engines": {
         "node": ">=20"
       }

--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -103,7 +103,7 @@ import { PulsarHidClient } from "@openmouse/protocol/drivers/pulsar/pulsar-hid";
 import { PulsarProHidClient } from "@openmouse/protocol/drivers/pulsar/pulsar-pro-hid";
 import { PulsarXs1HidClient } from "@openmouse/protocol/drivers/pulsar/pulsar-xs1-hid";
 import { OrbitalHidClient } from "@openmouse/protocol/drivers/orbital/hid";
-import { RazerHidClient } from "@openmouse/protocol/drivers/razer/hid";
+import { RazerHidClient, razerProbeControlInterface } from "@openmouse/protocol/drivers/razer/hid";
 import {
   RAZER_BUTTON_CONTROL_LABEL,
   RAZER_TOGGLE_CONTROL_INFO,
@@ -149,7 +149,7 @@ import {
   type KeychronNapeButtonAction,
   type KeychronNapeLayerKeymap,
 } from "@openmouse/protocol/keychron";
-import { SUPPORTED_HID_FILTERS } from "@openmouse/protocol/drivers/vendors";
+import { SUPPORTED_HID_FILTERS, VENDOR_ID } from "@openmouse/protocol/drivers/vendors";
 import { WLMouseHidClient } from "@openmouse/protocol/drivers/wlmouse/hid";
 import { MicrosoftHidClient } from "@openmouse/protocol/drivers/microsoft/hid";
 import { DareuHidClient } from "@openmouse/protocol/drivers/dareu/hid";
@@ -1936,8 +1936,25 @@ async function requestSupportedClient(): Promise<SupportedClient | null> {
       + "Synapse app, so this mouse needs a native client.",
     );
   }
+  // The shape check above assumes a Razer control channel is always a single
+  // Generic Desktop Mouse collection. That has held for every model verified
+  // so far, but what collections a browser/OS combination actually exposes
+  // over WebHID is decided below this app, by the platform — a mismatch there
+  // wouldn't show up as a code difference. Rather than guess a new shape,
+  // try the protocol itself against every Razer-vendor collection Chrome
+  // granted before giving up.
+  const razerCandidates = devices.filter((device) => device.vendorId === VENDOR_ID.razer);
+  let probedRazer = false;
+  if (razerCandidates.length > 0) {
+    probedRazer = true;
+    const probed = await razerProbeControlInterface(devices);
+    if (probed) return probed;
+  }
+
   throw new Error(
-    `Selected device is not a supported control interface (${details}). `
+    `Selected device is not a supported control interface (${details})`
+    + (probedRazer ? ` [probed ${razerCandidates.length} Razer collection(s), none answered]` : "")
+    + `. `
     + "Pick a vendor control interface (not a plain boot mouse). "
     + "If this keeps failing, note the VID/PID from this message.",
   );


### PR DESCRIPTION
Pulls in mouse-protocol#95 (razerProbeControlInterface + widened HyperSpeed filter, superseding openmouse#254's earlier lockfile bump for that generation).

When the normal shape-based detection finds no match among granted devices and at least one is Razer-vendor, `requestSupportedClient()` now tries the real protocol against every granted Razer collection before giving up. The final error also now says how many collections were probed and that none answered, so a future report of this same symptom is distinguishable from the probe simply never running.

`npm run check`: 142/142 tests pass. Bundle size within budget (1,486.8 kB / 1,500 kB JS).