### PR TITLE
artwork: key shared-id crowd uploads by device name, not just VID:PID

### DIFF
--- a/functions/api/artwork/list.js
+++ b/functions/api/artwork/list.js
@@ -4,7 +4,13 @@
  *
  * GET /api/artwork/list
  *
- * Response: { artworks: Array<{ vendorId: number, productId: number, filename: string }> }
+ * Response: { artworks: Array<{ vendorId: number, productId: number, filename: string, nameSlug?: string }> }
+ *
+ * A device whose id is shared across different physical products (see
+ * upload.js's SHARED_PID_KEYS) uploads under `{vid}:{pid}:{nameSlug}.{ext}`
+ * instead of the plain `{vid}:{pid}.{ext}` every other device uses, so two
+ * different models behind one id each get their own entry here rather than
+ * one clobbering the other.
  */
 
 const json = (body, status = 200) => new Response(JSON.stringify(body), {
@@ -26,10 +32,17 @@ export async function onRequest({ env }) {
 
     for (const object of listed.objects) {
       const filename = object.key.replace("crowd/", "");
-      const match = filename.match(/^([0-9a-f]{4}):([0-9a-f]{4})\.(png|webp)$/i);
-      if (match) {
-        const vendorId = parseInt(match[1], 16);
-        const productId = parseInt(match[2], 16);
+      const named = filename.match(/^([0-9a-f]{4}):([0-9a-f]{4}):([a-z0-9-]+)\.(png|webp)$/i);
+      if (named) {
+        const vendorId = parseInt(named[1], 16);
+        const productId = parseInt(named[2], 16);
+        artworks.push({ vendorId, productId, filename, nameSlug: named[3].toLowerCase() });
+        continue;
+      }
+      const plain = filename.match(/^([0-9a-f]{4}):([0-9a-f]{4})\.(png|webp)$/i);
+      if (plain) {
+        const vendorId = parseInt(plain[1], 16);
+        const productId = parseInt(plain[2], 16);
         artworks.push({ vendorId, productId, filename });
       }
     }

--- a/functions/api/artwork/upload.js
+++ b/functions/api/artwork/upload.js
@@ -21,6 +21,29 @@ const VENDOR_RE = /^[0-9a-f]{4}$/i;
 // composited over the device panel, so it needs a transparent background.
 const DATA_URL_RE = /^data:image\/(png|webp);base64,(.+)$/;
 
+// VID:PID pairs (and, for WLMouse, a whole vendor id) known to be genuinely
+// shared across different physical products — a receiver or ODM board reused
+// by several models. Kept in sync by hand with the same list in
+// src/ui/device-images.ts; duplicated here because these Functions run
+// outside that module's build. For these, the object key includes a slug of
+// the device's own reported name so two different models behind one shared
+// id each get their own upload instead of clobbering one another the way a
+// bare VID:PID key would.
+const SHARED_PID_KEYS = new Set([
+  "046d:c539", // Logitech Lightspeed receiver (G502 X, G703, G Pro Wireless, ...)
+  "3151:402d", // GearHub 2.4 GHz receiver (Attack Shark R2, Lingbao M5 Pro)
+  "3837:4030", "3837:4031", "3837:4032", "3837:4033", // MCHOSE A7 V3-generation receiver ids
+]);
+const SHARED_PID_VENDOR_IDS = new Set([0x36a7]); // WLMouse — no single shared receiver PID
+
+function isSharedPid(vendorId, productId, vendorHex, productHex) {
+  return SHARED_PID_VENDOR_IDS.has(vendorId) || SHARED_PID_KEYS.has(`${vendorHex}:${productHex}`);
+}
+
+function slugifyName(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
 export async function onRequest({ request, env }) {
   if (request.method !== "POST") {
     return json({ message: "Method not allowed." }, 405);
@@ -65,15 +88,27 @@ export async function onRequest({ request, env }) {
   const base64Data = dataUrlMatch[2];
   const vendorHex = vendorId.toString(16).padStart(4, "0");
   const productHex = productId.toString(16).padStart(4, "0");
-  const filename = `${vendorHex}:${productHex}.${ext}`;
+
+  const shared = isSharedPid(vendorId, productId, vendorHex, productHex);
+  let keyBase = `${vendorHex}:${productHex}`;
+  if (shared) {
+    const nameSlug = slugifyName(displayName);
+    if (!nameSlug) {
+      return json({ message: "This device's id is shared with other models — a device name is required to tell them apart." }, 400);
+    }
+    keyBase += `:${nameSlug}`;
+  }
+  const filename = `${keyBase}.${ext}`;
   const objectKey = `crowd/${filename}`;
 
   // Checked by prefix, not by the exact key: the extension is part of the key
-  // (crowd/{vendor}:{product}.{ext}), so a .head() on this one key alone would
-  // miss an existing upload in the *other* format and let both land in the
-  // bucket for the same device — two objects the list endpoint can then only
-  // arbitrarily pick between.
-  const existing = await env.ARTWORK_BUCKET.list({ prefix: `crowd/${filename.replace(/\.[^.]+$/, "")}.` });
+  // (crowd/{keyBase}.{ext}), so a .head() on this one key alone would miss an
+  // existing upload in the *other* format and let both land in the bucket for
+  // the same device — two objects the list endpoint can then only
+  // arbitrarily pick between. For a shared id, keyBase already includes the
+  // name slug, so this only matches the same model's other format, not a
+  // different model sharing the same raw VID:PID.
+  const existing = await env.ARTWORK_BUCKET.list({ prefix: `crowd/${keyBase}.` });
   if (existing.objects.length > 0) {
     return json({ ok: true, message: "Artwork already exists." });
   }

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -216,6 +216,11 @@ function isSharedPidDevice(device: HIDDevice): boolean {
   return SHARED_PID_VENDOR_IDS.has(device.vendorId) || SHARED_PID_KEYS.has(deviceKey(device));
 }
 
+/** Matches upload.js's slug exactly — the two must agree for the lookup to ever hit. */
+function slugifyName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
 /**
  * Crowd-sourced artwork cache. Populated asynchronously on app load from
  * `/api/artwork/list`. Once loaded, checked synchronously in
@@ -244,7 +249,12 @@ async function fetchCrowdArtworkMap(bypassHttpCache = false): Promise<Map<string
     for (const entry of data.artworks) {
       if (typeof entry.vendorId === "number" && typeof entry.productId === "number" && typeof entry.filename === "string") {
         const hex = (v: number) => v.toString(16).padStart(4, "0");
-        map.set(`${hex(entry.vendorId)}:${hex(entry.productId)}`, entry.filename);
+        const pidKey = `${hex(entry.vendorId)}:${hex(entry.productId)}`;
+        // A shared-id upload carries a nameSlug (see upload.js/list.js) so it
+        // doesn't collide with a different model behind the same raw id —
+        // keyed separately here, looked up the same way in deviceImage().
+        const key = typeof entry.nameSlug === "string" && entry.nameSlug ? `${pidKey}:${entry.nameSlug}` : pidKey;
+        map.set(key, entry.filename);
       }
     }
     return map;
@@ -389,13 +399,18 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
 const DEVICE_IMAGE_BASE_URL = "https://img.openmouse.app/";
 
 export function deviceImage(device: HIDDevice | null | undefined, displayName = ""): string {
-  // Crowd-sourced artwork takes priority — except for a shared VID:PID, where
-  // it's keyed to whichever model someone happened to upload for and would be
-  // wrong for every other model behind the same id. Those fall through to
-  // resolveDeviceImageFilename's name-based checks instead, same as the
-  // static map already does for them.
-  if (device && crowdArtworkCache && !isSharedPidDevice(device)) {
-    const crowdFilename = crowdArtworkCache.get(deviceKey(device));
+  // Crowd-sourced artwork takes priority. For a shared VID:PID, a bare
+  // vendorId:productId key would be whichever model someone happened to
+  // upload for and wrong for every other model behind the same id — so those
+  // devices are looked up by vendorId:productId:nameSlug instead (matching
+  // how upload.js keys them), and only served when the reported name
+  // actually matches. No name match falls through to
+  // resolveDeviceImageFilename's own name-based checks, same as it already
+  // does when there's no crowd art at all.
+  if (device && crowdArtworkCache) {
+    const shared = isSharedPidDevice(device);
+    const key = shared ? `${deviceKey(device)}:${slugifyName(displayName)}` : deviceKey(device);
+    const crowdFilename = crowdArtworkCache.get(key);
     if (crowdFilename) return DEVICE_IMAGE_BASE_URL + `crowd/${crowdFilename}`;
   }
   return DEVICE_IMAGE_BASE_URL + resolveDeviceImageFilename(device, displayName);


### PR DESCRIPTION
Follow-up to #257. That fix stopped a shared VID:PID from showing the wrong model's crowd art, but at the cost of never showing crowd art for those devices at all — an upload would silently go nowhere.

## What changes
- `upload.js`: a device on the known shared-id list now keys its object as `{vid}:{pid}:{nameSlug}.{ext}` instead of `{vid}:{pid}.{ext}`, so two different models behind one id get separate objects instead of one clobbering the other's existence check. A device with no readable name gets a clear rejection instead of a silently-unshowable upload.
- `list.js`: parses both filename shapes, returns `nameSlug` when present.
- `device-images.ts`: looks up a shared device's crowd art by `vid:pid:nameSlug` (same slug algorithm, kept in sync by hand with upload.js since Functions run outside this module's build) — a name match shows that model's art, no match falls through to the existing name-based resolution.

`npm run check`: 142/142 tests pass. Both Functions files pass `node --check`.