### PR TITLE
Restore the language picker in Settings

### DIFF
--- a/src/app/InterfaceSettings.tsx
+++ b/src/app/InterfaceSettings.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactNode } from "react";
 import * as control from "../device/controller";
 import type { ControlSnapshot } from "../device/types";
-import { t } from "../i18n";
+import { LOCALE_NAME_KEYS, t } from "../i18n";
 import { interfaceThemeSlug, type InterfaceTheme } from "../interface-preferences";
 import { DiscordIcon, DISCORD_URL, GitHubIcon, GITHUB_URL, TwitterIcon, TWITTER_URL } from "./social-links";
+import { Segmented } from "./ui";
 
 const THEME_ORDER: readonly InterfaceTheme[] = [
   "Matt",
@@ -160,6 +161,20 @@ export function InterfaceSettings({ snapshot }: { snapshot: ControlSnapshot }): 
             </button>
           ))}
         </fieldset>
+      </div>
+
+      <div className="setting-row">
+        <div className="setting-label">
+          <span className="setting-title">{t(locale, "set.languageTitle")}</span>
+          <span className="setting-description">{t(locale, "set.languageBody")}</span>
+        </div>
+        <Segmented
+          id="interface-locale"
+          ariaLabel={t(locale, "set.languageTitle")}
+          value={preferences.locale}
+          onChange={set("locale")}
+          options={LOCALE_NAME_KEYS.map(([value, nameKey]) => ({ value, label: t(locale, nameKey) }))}
+        />
       </div>
 
       {switchRow(


### PR DESCRIPTION
Reverts #229. The sidebar globe menu stayed as the other place to change language, but a user expected the option in Settings specifically and it wasn't there anymore — restoring the Settings row so it's available in both places.

`npm run check`: 142/142 tests pass.