### PR TITLE
device-images: resolve all built-in artwork by name instead of VID:PID

### DIFF
--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -5,39 +5,35 @@ import { deviceImage } from "./device-images.ts";
 
 const CDN = "https://img.openmouse.app/";
 
-const hid = (productId: number): HIDDevice => ({ vendorId: 0x046d, productId } as HIDDevice);
+const dev = (vendorId: number, productId: number): HIDDevice => ({ vendorId, productId } as HIDDevice);
 
-test("G502 family USB interfaces use their matching normalized artwork", () => {
-  assert.equal(deviceImage(hid(0xc07d)), CDN + "logitech-g502.png");
-  assert.equal(deviceImage(hid(0xc095)), CDN + "logitech-g502-x-plus.png");
-  assert.equal(deviceImage(hid(0xc098)), CDN + "logitech-g502-x.png");
-  assert.equal(deviceImage(hid(0xc099)), CDN + "logitech-g502-x.png");
+test("G502 family resolves entirely by name", () => {
+  assert.equal(deviceImage(null, "G502"), CDN + "logitech-g502.png");
+  assert.equal(deviceImage(null, "G502 X PLUS"), CDN + "logitech-g502-x-plus.png");
+  assert.equal(deviceImage(null, "G502 X"), CDN + "logitech-g502-x.png");
 });
 
-test("G703 wired PIDs and Lightspeed name fallback use the G703 render", () => {
-  assert.equal(deviceImage(hid(0xc087)), CDN + "logitech-g703.png");
-  assert.equal(deviceImage(hid(0xc090)), CDN + "logitech-g703.png");
-  assert.equal(deviceImage(hid(0xc539), "G703 HERO"), CDN + "logitech-g703.png");
+test("G703 name resolves the G703 render regardless of transport", () => {
+  assert.equal(deviceImage(null, "G703 HERO"), CDN + "logitech-g703.png");
   assert.equal(deviceImage(null, "G703 Wired/Wireless Gaming Mouse"), CDN + "logitech-g703.png");
 });
 
 test("G502 X receiver artwork follows the paired mouse name", () => {
-  assert.equal(deviceImage(hid(0xc547), "G502 X PLUS"), CDN + "logitech-g502-x-plus.png");
-  assert.equal(deviceImage(hid(0xc547), "G502 X"), CDN + "logitech-g502-x.png");
+  assert.equal(deviceImage(dev(0x046d, 0xc547), "G502 X PLUS"), CDN + "logitech-g502-x-plus.png");
+  assert.equal(deviceImage(dev(0x046d, 0xc547), "G502 X"), CDN + "logitech-g502-x.png");
 });
 
-test("PRO X 2 Superstrike uses its own artwork over USB and shared receivers", () => {
-  assert.equal(deviceImage(hid(0xc0a8)), CDN + "logitech-pro-x2-superstrike.png");
-  assert.equal(deviceImage(hid(0xc547), "PRO X 2 Superstrike"), CDN + "logitech-pro-x2-superstrike.png");
+test("PRO X 2 Superstrike resolves by name over any shared receiver", () => {
+  assert.equal(deviceImage(dev(0x046d, 0xc547), "PRO X 2 Superstrike"), CDN + "logitech-pro-x2-superstrike.png");
   assert.equal(deviceImage(null, "Logitech PRO X2 SUPERSTRIKE"), CDN + "logitech-pro-x2-superstrike.png");
 });
 
-test("Razer Orochi V2 uses its own render over its Atheris receiver", () => {
-  assert.equal(deviceImage({ vendorId: 0x1532, productId: 0x0094 } as HIDDevice), CDN + "razer-orochi-v2.png");
+test("Razer Orochi V2 resolves by name", () => {
+  assert.equal(deviceImage(dev(0x1532, 0x0094), "Razer Orochi V2"), CDN + "razer-orochi-v2.png");
 });
 
 test("Corsair NIGHTSWORD RGB falls back to the placeholder until art exists", () => {
-  assert.equal(deviceImage({ vendorId: 0x1b1c, productId: 0x1b5c } as HIDDevice, "Corsair NIGHTSWORD RGB"), CDN + "unknown-device.png");
+  assert.equal(deviceImage(dev(0x1b1c, 0x1b5c), "Corsair NIGHTSWORD RGB"), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "CORSAIR NIGHTSWORD RGB Gaming Mouse"), CDN + "unknown-device.png");
 });
 
@@ -61,16 +57,7 @@ test("Pulsar 4K receiver artwork follows the reported mouse name", () => {
   assert.equal(deviceImage(null, "Pulsar X2 V2 Pro"), CDN + "pulsar-x2-v2.png");
 });
 
-test("VXE R1 family transports and names share one shell render", () => {
-  const vxe = (vendorId: number, productId: number): HIDDevice =>
-    ({ vendorId, productId } as HIDDevice);
-
-  assert.equal(deviceImage(vxe(0x3554, 0xf58a)), CDN + "vxe-r1-series.png");
-  assert.equal(deviceImage(vxe(0x3554, 0xf58c)), CDN + "vxe-r1-series.png");
-  assert.equal(deviceImage(vxe(0x3554, 0xf58e)), CDN + "vxe-r1-series.png");
-  assert.equal(deviceImage(vxe(0x3554, 0xf58f)), CDN + "vxe-r1-series.png");
-  assert.equal(deviceImage(vxe(0x373b, 0x1085)), CDN + "vxe-r1-series.png");
-
+test("VXE R1 family resolves by name across every generation", () => {
   assert.equal(deviceImage(null, "VXE R1"), CDN + "vxe-r1-series.png");
   assert.equal(deviceImage(null, "VXE R1 SE"), CDN + "vxe-r1-series.png");
   assert.equal(deviceImage(null, "VXE R1 SE+"), CDN + "vxe-r1-series.png");
@@ -78,35 +65,29 @@ test("VXE R1 family transports and names share one shell render", () => {
   assert.equal(deviceImage(null, "VXE R1 Pro Max"), CDN + "vxe-r1-series.png");
 });
 
-test("Attack Shark R5 Ultra wired and wireless share the same artwork", () => {
-  const hid373e = (productId: number): HIDDevice => ({ vendorId: 0x373e, productId } as HIDDevice);
-  assert.equal(deviceImage(hid373e(0x0046)), CDN + "attackshark-r5-ultra.png");
-  assert.equal(deviceImage(hid373e(0x0047)), CDN + "attackshark-r5-ultra.png");
+test("Attack Shark R5 Ultra resolves by name", () => {
   assert.equal(deviceImage(null, "Attack Shark R5 Ultra"), CDN + "attackshark-r5-ultra.png");
 });
 
-test("Dareu A950 PRO Mg wired and receiver paths share the requested artwork", () => {
-  const dareuArt = CDN + "dareu-a950-pro-mg.png";
-  assert.equal(deviceImage(dev(0x260d, 0x1117)), dareuArt);
-  assert.equal(deviceImage(dev(0x260d, 0x1114)), dareuArt);
-  assert.equal(deviceImage(null, "Dareu A950 PRO Mg"), dareuArt);
+test("ATK ZERO resolves by name", () => {
+  assert.equal(deviceImage(null, "ATK ZERO"), CDN + "atk-zero.png");
+});
+
+test("Dareu A950 PRO Mg resolves by name", () => {
+  assert.equal(deviceImage(null, "Dareu A950 PRO Mg"), CDN + "dareu-a950-pro-mg.png");
 });
 
 test("Attack Shark R2 resolves by name (PID 0x402D is shared with the M5 Pro)", () => {
   assert.equal(deviceImage(null, "Attack Shark R2"), CDN + "attackshark-r2.png");
   // The shared receiver PID must NOT resolve to the R2 render.
   assert.equal(
-    deviceImage({ vendorId: 0x3151, productId: 0x402d } as HIDDevice, "Lingbao M5 Pro"),
+    deviceImage(dev(0x3151, 0x402d), "Lingbao M5 Pro"),
     CDN + "unknown-device.png",
   );
 });
 
-test("OP1we wired and wireless share the same artwork, distinct from OP1 8K", () => {
-  const hid3367 = (productId: number): HIDDevice => ({ vendorId: 0x3367, productId } as HIDDevice);
-  assert.equal(deviceImage(hid3367(0x1961)), CDN + "endgame-gear-op1we.png");
-  assert.equal(deviceImage(hid3367(0x1962)), CDN + "endgame-gear-op1we.png");
+test("OP1we and OP1 8K resolve to distinct renders by name", () => {
   assert.equal(deviceImage(null, "OP1we"), CDN + "endgame-gear-op1we.png");
-  assert.equal(deviceImage(hid3367(0x1964)), CDN + "endgame-gear-op1-8k.png");
   assert.equal(deviceImage(null, "OP1 8K"), CDN + "endgame-gear-op1-8k.png");
 });
 
@@ -115,30 +96,20 @@ test("Pulsar receiver falls back to the generic Pulsar render (no dongle art)", 
   assert.equal(deviceImage(device, "Pulsar PRO Dongle"), CDN + "pulsar-x2-v2.png");
 });
 
-const dev = (vendorId: number, productId: number): HIDDevice => ({ vendorId, productId } as HIDDevice);
-
-test("G203/G102 family shares the G203 render by PID and name", () => {
-  assert.equal(deviceImage(dev(0x046d, 0xc084)), CDN + "logitech-g203.png"); // G203 Prodigy
-  assert.equal(deviceImage(dev(0x046d, 0xc092)), CDN + "logitech-g203.png"); // G203 Lightsync
-  assert.equal(deviceImage(dev(0x046d, 0xc089)), CDN + "logitech-g203.png"); // G102 Lightsync
+test("G203/G102 family shares the G203 render by name", () => {
   assert.equal(deviceImage(null, "G203 LIGHTSYNC"), CDN + "logitech-g203.png");
   assert.equal(deviceImage(null, "Logitech G102 LIGHTSYNC"), CDN + "logitech-g203.png");
 });
 
-test("G402 / G303 / G403 / G903 resolve by PID and name", () => {
-  assert.equal(deviceImage(dev(0x046d, 0xc07e)), CDN + "logitech-g402.png");
+test("G402 / G303 / G403 / G903 resolve by name", () => {
   assert.equal(deviceImage(null, "G402 Hyperion Fury"), CDN + "logitech-g402.png");
-  assert.equal(deviceImage(dev(0x046d, 0xc080)), CDN + "logitech-g303.png");
   assert.equal(deviceImage(null, "G303 Shroud Edition"), CDN + "logitech-g303.png");
-  assert.equal(deviceImage(dev(0x046d, 0xc08f)), CDN + "logitech-g403.png");
   assert.equal(deviceImage(null, "G403 HERO"), CDN + "logitech-g403.png");
-  assert.equal(deviceImage(dev(0x046d, 0xc08e)), CDN + "logitech-g903.png");
   assert.equal(deviceImage(null, "G903 HERO"), CDN + "logitech-g903.png");
 });
 
 test("G Pro family uses the classic shell; G Pro Wireless and G Pro 2 get their own renders", () => {
-  assert.equal(deviceImage(dev(0x046d, 0xc085)), CDN + "logitech-g-pro.png"); // G Pro (2017)
-  assert.equal(deviceImage(dev(0x046d, 0xc08c)), CDN + "logitech-g-pro.png"); // G Pro Hero
+  assert.equal(deviceImage(null, "G Pro"), CDN + "logitech-g-pro.png"); // G Pro (2017) / Hero
   // G Pro Wireless shares its Lightspeed receiver PID (0xc539) with other
   // models (e.g. G703), so it can only be resolved by its reported name.
   assert.equal(deviceImage(null, "G Pro Wireless Gaming Mouse"), CDN + "logitech-gpro-wireless.png");
@@ -146,8 +117,7 @@ test("G Pro family uses the classic shell; G Pro Wireless and G Pro 2 get their 
   // The Superlight must keep its own render, not the classic G Pro shell.
   assert.equal(deviceImage(null, "G Pro X Superlight"), CDN + "logitech-pro-x-superlight-2c.png");
   // The original Superlight (PID 0xc094) reports its own HID++ device name as
-  // "PRO X Wireless", not "Superlight", so it needs a direct PID match rather
-  // than the name-based fallback above — confirmed against real hardware.
+  // "PRO X Wireless", not "Superlight" — confirmed against real hardware.
   assert.equal(deviceImage(dev(0x046d, 0xc094), "PRO X Wireless"), CDN + "logitech-pro-x-superlight-2c.png");
 });
 
@@ -163,36 +133,35 @@ test("MX Anywhere 3 and MX Ergo S resolve by name over their shared Bolt receive
 });
 
 test("DeathAdder V2 family shares the V2 render; V4 Pro gets its own", () => {
-  assert.equal(deviceImage(dev(0x1532, 0x0084)), CDN + "razer-deathadder-v2.png"); // V2 wired
-  assert.equal(deviceImage(dev(0x1532, 0x007c)), CDN + "razer-deathadder-v2.png"); // V2 Pro
-  assert.equal(deviceImage(dev(0x1532, 0x007d)), CDN + "razer-deathadder-v2.png");
-  assert.equal(deviceImage(dev(0x1532, 0x006e)), CDN + "razer-deathadder-v2.png"); // Essential
   assert.equal(deviceImage(null, "DeathAdder V2"), CDN + "razer-deathadder-v2.png");
   assert.equal(deviceImage(null, "DeathAdder V2 Pro"), CDN + "razer-deathadder-v2.png");
   assert.equal(deviceImage(null, "DeathAdder Essential"), CDN + "razer-deathadder-v2.png");
-  assert.equal(deviceImage(dev(0x1532, 0x00be)), CDN + "razer-deathadder-v4-pro.png");
-  assert.equal(deviceImage(dev(0x1532, 0x00ef)), CDN + "razer-deathadder-v4-pro.png"); // Carbon
   assert.equal(deviceImage(null, "DeathAdder V4 Pro"), CDN + "razer-deathadder-v4-pro.png");
+  assert.equal(deviceImage(null, "DeathAdder V4 Pro Carbon Fiber Edition"), CDN + "razer-deathadder-v4-pro.png");
   // Test-needed V3 Pro and V2 X HyperSpeed must NOT pick up V3/V2 artwork.
   assert.equal(deviceImage(null, "DeathAdder V3 Pro"), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "DeathAdder V2 X HyperSpeed"), CDN + "unknown-device.png");
 });
 
-test("DeathAdder V3 wired resolves by name (PID not pinned)", () => {
+test("DeathAdder V3 wired resolves by name", () => {
   assert.equal(deviceImage(null, "DeathAdder V3"), CDN + "razer-deathadder-v3.png");
 });
 
-test("Viper V3 HyperSpeed and Viper V4 Pro use their own renders", () => {
-  assert.equal(deviceImage(dev(0x1532, 0x00b8)), CDN + "razer-viper-v3-hyperspeed.png");
+test("Viper family resolves each generation to its own render", () => {
+  assert.equal(deviceImage(null, "Viper V2 Pro"), CDN + "razer-viper-v2-pro.png");
+  assert.equal(deviceImage(null, "Viper V3 Pro"), CDN + "razer-viper-v3-pro.png");
+  // Viper V3 Pro SE must NOT fall into the plain V3 Pro render — no art of
+  // its own yet, so it resolves to the placeholder.
+  assert.equal(deviceImage(null, "Viper V3 Pro SE"), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "Viper V3 HyperSpeed"), CDN + "razer-viper-v3-hyperspeed.png");
-  assert.equal(deviceImage(dev(0x1532, 0x00e5)), CDN + "razer-viper-v4-pro.png");
-  assert.equal(deviceImage(dev(0x1532, 0x00e6)), CDN + "razer-viper-v4-pro.png");
   assert.equal(deviceImage(null, "Viper V4 Pro"), CDN + "razer-viper-v4-pro.png");
+  // The plain original Viper resolves last among the viper checks.
+  assert.equal(deviceImage(null, "Viper"), CDN + "razer-viper.webp");
+  // Viper Ultimate has no render of its own; must not borrow the plain Viper's.
+  assert.equal(deviceImage(null, "Viper Ultimate"), CDN + "unknown-device.png");
 });
 
 test("Endgame Gear XM2 8K and XM2w resolve to their own renders", () => {
-  assert.equal(deviceImage(dev(0x3367, 0x1966)), CDN + "endgame-gear-xm2-8k.png");
-  assert.equal(deviceImage(dev(0x3367, 0x1980)), CDN + "endgame-gear-xm2-8k.png");
   assert.equal(deviceImage(null, "XM2 8K"), CDN + "endgame-gear-xm2-8k.png");
   assert.equal(deviceImage(null, "XM2w 4K"), CDN + "endgame-gear-xm2w.png");
   // XM2w must not be caught by the OP1 render.
@@ -200,28 +169,18 @@ test("Endgame Gear XM2 8K and XM2w resolve to their own renders", () => {
 });
 
 test("WLMouse Beast X / Beast Mini / Beast X Pro have no render and fall back to unknown", () => {
-  assert.equal(deviceImage(dev(0x36a7, 0xa883)), CDN + "unknown-device.png");
-  assert.equal(deviceImage(dev(0x36a7, 0xa884)), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "WLMouse Beast X"), CDN + "unknown-device.png");
-  assert.equal(deviceImage(dev(0x36a7, 0xa886)), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "WLMouse Beast Mini"), CDN + "unknown-device.png");
-  assert.equal(deviceImage(dev(0x36a7, 0xa870)), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "WLMouse Beast X Pro"), CDN + "unknown-device.png");
-  // Sword X keeps its render (not skipped).
-  assert.equal(deviceImage(dev(0x36a7, 0xa878)), CDN + "wlmouse-sword-x.png");
+  // Sword X keeps its render.
   assert.equal(deviceImage(null, "WLMouse Sword X"), CDN + "wlmouse-sword-x.png");
 });
 
 test("VGN Dragonfly F2 Master+, Lamzu Maya X, ATK F1 V2, Orbital and moddo resolve", () => {
-  assert.equal(deviceImage(dev(0x3554, 0xfb56)), CDN + "vgn-dragonfly-f2.png");
-  assert.equal(deviceImage(dev(0x3554, 0xfb57)), CDN + "vgn-dragonfly-f2.png");
   assert.equal(deviceImage(null, "Dragonfly F2 Master+"), CDN + "vgn-dragonfly-f2.png");
-  assert.equal(deviceImage(dev(0x373e, 0x001c)), CDN + "lamzu-maya-x.png");
-  assert.equal(deviceImage(dev(0x373e, 0x001e)), CDN + "lamzu-maya-x.png");
   assert.equal(deviceImage(null, "Lamzu Maya X"), CDN + "lamzu-maya-x.png");
   assert.equal(deviceImage(null, "ATK F1 V2 Ultra Max"), CDN + "atk-f1-v2-ultra-max.png");
   // Orbital has no product render yet; it resolves to the generic placeholder.
-  assert.equal(deviceImage(dev(0x1915, 0x080c)), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "Orbital Ghost"), CDN + "unknown-device.png");
   // moddo has no product render yet; it resolves to the generic placeholder.
   assert.equal(deviceImage(null, "moddoMOUSE"), CDN + "unknown-device.png");
@@ -234,7 +193,6 @@ test("Finalmouse Starlight-12 / ULX resolves by name", () => {
 
 test("test-needed and unsupported models are not given new artwork", () => {
   assert.equal(deviceImage(null, "Razer Basilisk V3"), CDN + "unknown-device.png");
-  assert.equal(deviceImage(null, "Razer Viper Ultimate"), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "Attack Shark X3"), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "Endgame Gear OP1w 4K v2"), CDN + "unknown-device.png");
   assert.equal(deviceImage(null, "VGN Dragonfly R1 Pro"), CDN + "unknown-device.png");
@@ -249,11 +207,7 @@ test("a mouse behind a shared WLMouse receiver resolves by name", () => {
   assert.equal(deviceImage(receiver, "WLmouse Beast Mini"), CDN + "unknown-device.png");
 });
 
-test("K-snake X11 wired and dongle share the same artwork", () => {
-  const wired = { vendorId: 0xa8a4, productId: 0x2255 } as HIDDevice;
-  const dongle = { vendorId: 0xa8a5, productId: 0x2255 } as HIDDevice;
-  assert.equal(deviceImage(wired), CDN + "ksnake-x11.png");
-  assert.equal(deviceImage(dongle), CDN + "ksnake-x11.png");
+test("K-snake X11 resolves by name regardless of transport", () => {
   assert.equal(deviceImage(null, "K-snake X11"), CDN + "ksnake-x11.png");
 });
 
@@ -263,16 +217,13 @@ test("Attack Shark X11 does not inherit K-snake artwork", () => {
 });
 
 test("the MCHOSE A7 V3 family gets its own render, not the V2's", () => {
-  const mchose = (productId: number): HIDDevice =>
-    ({ vendorId: 0x3837, productId } as HIDDevice);
+  assert.equal(deviceImage(null, "MCHOSE A7 V3"), CDN + "mchose-a7-v3.png");
+  assert.equal(deviceImage(null, "MCHOSE A7 V2"), CDN + "mchose-a7-v2.png");
 
-  for (const productId of [0x4030, 0x4031, 0x4032, 0x4033]) {
-    assert.equal(deviceImage(mchose(productId)), CDN + "mchose-a7-v3.png");
-  }
-  assert.equal(deviceImage(mchose(0x4021)), CDN + "mchose-a7-v2.png");
-
-  // The V3 receivers are shared with the K5, R7 and A5 V3, so mapping them to
-  // an A7 render would put the wrong mouse on screen for those owners.
+  // The V3 receivers are shared with the K5, R7 and A5 V3, so a device
+  // behind one with no matching name falls to the placeholder rather than
+  // guessing it's an A7.
+  const mchose = (productId: number): HIDDevice => ({ vendorId: 0x3837, productId } as HIDDevice);
   assert.equal(deviceImage(mchose(0x1014)), CDN + "unknown-device.png");
   assert.equal(deviceImage(mchose(0x1018)), CDN + "unknown-device.png");
 });
@@ -280,4 +231,15 @@ test("the MCHOSE A7 V3 family gets its own render, not the V2's", () => {
 test("an A7 V3 name is not swallowed by the A7 V2 fallback", () => {
   assert.equal(deviceImage(null, "MCHOSE A7 V3 Ultra+"), CDN + "mchose-a7-v3.png");
   assert.equal(deviceImage(null, "MCHOSE A7 V2 Ultra+"), CDN + "mchose-a7-v2.png");
+});
+
+test("Ninjutso Sora V2/V3 and TEN family resolve by name", () => {
+  assert.equal(deviceImage(null, "Ninjutso Sora V2"), CDN + "ninjutso-sora-v2.png");
+  assert.equal(deviceImage(null, "Ninjutso Sora V3"), CDN + "ninjutso-sora-v3.png");
+  assert.equal(deviceImage(null, "Ninjutso TEN / TEN AIR"), CDN + "ninjutso-ten.png");
+});
+
+test("Incott G23V2Pro and Keychron M6 resolve by name", () => {
+  assert.equal(deviceImage(null, "Esports G23V2Pro"), CDN + "incott-g23-v2-pro.png");
+  assert.equal(deviceImage(null, "Keychron M6"), CDN + "keychron-m6.png");
 });

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -1,189 +1,28 @@
 /**
- * Top-down product art for the persistent device panel, keyed by the identifiers WebHID already reports so that
- * drivers stay free of asset paths and no new UI hint is needed.
+ * Top-down product art for the persistent device panel.
+ *
+ * Resolved entirely by the device's own reported name (see
+ * `resolveDeviceImageFilename`), not by VID:PID — a USB id is not always
+ * unique to one product (see `SHARED_PID_KEYS`/`SHARED_PID_VENDOR_IDS`
+ * below), and matching by name is the one identifier that's actually
+ * specific to the physical product in every case, not just the shared ones.
+ * The trade-off: a device's image can only resolve once its real name is
+ * known (after a full connect and read), where a VID:PID map would have
+ * resolved instantly from the raw `productName` string alone. Until then —
+ * or if a model has no name rule yet — it shows the generic placeholder.
  *
  * Files are hosted in the `openmouse-devices` Cloudflare R2 bucket (public
  * access via its r2.dev URL, see `DEVICE_IMAGE_BASE_URL` below) rather than
- * committed to the repo, so this map holds bare filenames only. A key whose
- * file is missing in the bucket therefore fails at load rather than at build
- * time, so the panel drops the thumbnail on that error and keeps the layout
- * it had before any art existed. See `public/devices/README.md` for how to
- * upload new art.
+ * committed to the repo, so only bare filenames appear below. A filename
+ * whose file is missing in the bucket therefore fails at load rather than at
+ * build time, so the panel drops the thumbnail on that error and keeps the
+ * layout it had before any art existed. See `public/devices/README.md` for
+ * how to upload new art.
  *
  * Crowd-sourced artworks are fetched from `/api/artwork/list` and cached
  * locally. Once a device has crowd-sourced artwork, it takes priority over
- * the static map and name-fallback regexes below.
+ * the name-fallback regexes below.
  */
-
-const DEVICE_IMAGES: ReadonlyMap<string, string> = new Map([
-  ["046d:c07d", "logitech-g502.png"],
-  ["046d:c095", "logitech-g502-x-plus.png"],
-  ["046d:c098", "logitech-g502-x.png"],
-  ["046d:c099", "logitech-g502-x.png"],
-  ["046d:c0a8", "logitech-pro-x2-superstrike.png"],
-  // Note: 0xc539 is NOT mapped here — it's Logitech's shared Lightspeed
-  // receiver PID, reused across G703, G Pro Wireless, and others, so it must
-  // be disambiguated by name (see the name-fallback checks below) rather
-  // than pinned to one render.
-  // The original G Pro X Superlight reports as "PRO X Wireless" over HID++,
-  // not "Superlight", so the name-based fallback below never matches it.
-  // Same shell as the Superlight 2c closely enough to reuse its render.
-  ["046d:c094", "logitech-pro-x-superlight-2c.png"],
-  // Original G703 (0xc087) and G703 HERO wired (0xc090) share the same shell.
-  ["046d:c087", "logitech-g703.png"],
-  ["046d:c090", "logitech-g703.png"],
-  // M3K and M2K use the supplied M3K product artwork.
-  ["0483:a462", "zaunkoenig-m3k.png"],
-  ["0483:a3cf", "zaunkoenig-m3k.png"],
-  // Wired and receiver are separate product ids for the same mouse.
-  ["1532:00a5", "razer-viper-v2-pro.png"],
-  ["1532:00a6", "razer-viper-v2-pro.png"],
-  ["1532:00c0", "razer-viper-v3-pro.png"],
-  ["1532:00c1", "razer-viper-v3-pro.png"],
-  ["1532:008a", "razer-viper-mini.webp"],
-  ["1532:0078", "razer-viper.webp"],
-  ["1532:00a3", "razer-cobra.webp"],
-  ["1532:0094", "razer-orochi-v2.png"],
-  // MCHOSE A7 V2 family. Pro, Pro+, Ultra and Ultra+ are one shell with
-  // different sensors — MCHOSE itself only publishes `A7V2Pro_*` renders — so
-  // every model id and every link (receiver, Bluetooth, 8K receiver) maps to
-  // the same art.
-  ["3837:4018", "mchose-a7-v2.png"],
-  ["3837:4019", "mchose-a7-v2.png"],
-  ["3837:4021", "mchose-a7-v2.png"],
-  ["3837:4023", "mchose-a7-v2.png"],
-  ["3837:100a", "mchose-a7-v2.png"],
-  ["3837:100b", "mchose-a7-v2.png"],
-  ["3837:1020", "mchose-a7-v2.png"],
-  // MCHOSE A7 V3 family — a different shell and a different protocol from the
-  // V2 above. Its two receiver ids are shared with the other V3-generation
-  // models, so they are deliberately not mapped: a K5 or R7 behind the same
-  // dongle would get an A7 render.
-  ["3837:4030", "mchose-a7-v3.png"],
-  ["3837:4031", "mchose-a7-v3.png"],
-  ["3837:4032", "mchose-a7-v3.png"],
-  ["3837:4033", "mchose-a7-v3.png"],
-  // CRDRAKO KO-ONE wired and receiver transports share the same shell.
-  ["373e:006a", "crdrako-ko-one.png"],
-  ["373e:006b", "crdrako-ko-one.png"],
-  // Attack Shark R5 Ultra wired and wireless transports share the same shell.
-  // ATK ZERO wired and its 8K receiver are the same shell.
-  ["373b:1154", "atk-zero.png"],
-  ["373b:1155", "atk-zero.png"],
-  ["373e:0046", "attackshark-r5-ultra.png"],
-  ["373e:0047", "attackshark-r5-ultra.png"],
-  // OP1 8K, Purple Frost, and v2. XM2 models use different shells.
-  ["3367:1964", "endgame-gear-op1-8k.png"],
-  ["3367:1976", "endgame-gear-op1-8k.png"],
-  ["3367:1978", "endgame-gear-op1-8k.png"],
-  // OP1we
-  ["3367:1961", "endgame-gear-op1we.png"],
-  ["3367:1962", "endgame-gear-op1we.png"],
-  // NinjaForce exposes separate wired and receiver ids for Sora V2, Sora V3,
-  // and the TEN family. Receiver variants show the paired mouse artwork.
-  ["1915:ae11", "ninjutso-sora-v2.png"],
-  ["1915:ae12", "ninjutso-sora-v2.png"],
-  ["1915:ae13", "ninjutso-sora-v2.png"],
-  ["1915:ae14", "ninjutso-sora-v2.png"],
-  ["1915:ae15", "ninjutso-sora-v2.png"],
-  ["1915:ae16", "ninjutso-sora-v2.png"],
-  ["1915:ae1c", "ninjutso-sora-v2.png"],
-  ["1915:ae8a", "ninjutso-sora-v2.png"],
-  ["1915:ae8c", "ninjutso-sora-v2.png"],
-  // Incott G23V2Pro: the dongle (0x522c) and the wired transport (0x622c)
-  // are the same mouse, so they share one render.
-  ["093a:522c", "incott-g23-v2-pro.png"],
-  ["093a:622c", "incott-g23-v2-pro.png"],
-  ["093a:e010", "ninjutso-sora-v3.png"],
-  ["093a:eb02", "ninjutso-sora-v3.png"],
-  ["093a:e020", "ninjutso-ten.png"],
-  ["093a:ea01", "ninjutso-ten.png"],
-  ["093a:eb01", "ninjutso-ten.png"],
-  // WLMouse Beast G receiver / wired transports share the same shell.
-  ["36a7:a860", "wlmouse-beast-g.png"],
-  ["36a7:a861", "wlmouse-beast-g.png"],
-  // Beast Max wired / 4K8K receiver transports share the same shell.
-  ["36a7:a881", "wlmouse-beast-max.png"],
-  ["36a7:a880", "wlmouse-beast-max.png"],
-  // VXE R1 family. R1, R1 SE/SE+, R1 Pro, and R1 Pro Max share the same shell.
-  // Known wired / receiver transports therefore reuse one family render.
-  ["3554:f58a", "vxe-r1-series.png"],
-  ["3554:f58c", "vxe-r1-series.png"],
-  ["3554:f58e", "vxe-r1-series.png"],
-  ["3554:f58f", "vxe-r1-series.png"],
-  ["373b:1085", "vxe-r1-series.png"],
-  // Teevolution Terra Pro wired / receiver Compx transports.
-  ["3554:f520", "teevolution-terra-pro.png"],
-  ["3554:f522", "teevolution-terra-pro.png"],
-  ["3554:f523", "teevolution-terra-pro.png"],
-  ["3554:f5bb", "teevolution-terra-pro.png"],
-  // WALLHACK M-001 wireless mouse (real config id and in-app demo id).
-  ["3879:1110", "wallhack-m-001.png"],
-  ["3879:0807", "wallhack-m-001.png"],
-  // WALLHACK K-001 analog keyboard (both enumerated vendor ids).
-  ["3879:0806", "wallhack-k-001.png"],
-  ["1caa:0806", "wallhack-k-001.png"],
-  // Logitech G203 family. G203 LIGHTSYNC / PRODIGY and G102 share the same shell.
-  ["046d:c084", "logitech-g203.png"],
-  ["046d:c089", "logitech-g203.png"],
-  ["046d:c092", "logitech-g203.png"],
-  ["046d:c07e", "logitech-g402.png"],
-  ["046d:c080", "logitech-g303.png"],
-  ["046d:c08f", "logitech-g403.png"],
-  ["046d:c08e", "logitech-g903.png"],
-  // G Pro (2017), G Pro Hero, and G Pro Wireless share the same classic shell.
-  ["046d:c085", "logitech-g-pro.png"],
-  ["046d:c08c", "logitech-g-pro.png"],
-  // Endgame Gear XM2 8K wired.
-  ["3367:1966", "endgame-gear-xm2-8k.png"],
-  ["3367:1980", "endgame-gear-xm2-8k.png"],
-  // WLMouse Beast X / Beast Mini / Beast X Pro have no product render yet;
-  // they resolve to the generic placeholder via the name fallbacks below.
-  // Sword X wired / receiver transports keep their render.
-  ["36a7:a878", "wlmouse-sword-x.png"],
-  ["36a7:a879", "wlmouse-sword-x.png"],
-  // VGN Dragonfly F2 Master+ wired / receiver transports.
-  ["3554:fb56", "vgn-dragonfly-f2.png"],
-  ["3554:fb57", "vgn-dragonfly-f2.png"],
-  // Lamzu Maya X wired / wireless / 8K transports.
-  ["373e:001c", "lamzu-maya-x.png"],
-  ["373e:001d", "lamzu-maya-x.png"],
-  ["373e:001e", "lamzu-maya-x.png"],
-  // Orbital Ghost / Pathfinder V2 has no product render yet; resolves to the
-  // generic placeholder via the name fallback below.
-  ["1532:006e", "razer-deathadder-v2.png"],
-  ["1532:0071", "razer-deathadder-v2.png"],
-  ["1532:007c", "razer-deathadder-v2.png"],
-  ["1532:007d", "razer-deathadder-v2.png"],
-  ["1532:0084", "razer-deathadder-v2.png"],
-  ["1532:0098", "razer-deathadder-v2.png"],
-  // DeathAdder V4 Pro and its Carbon Fiber SKU share the same shell.
-  ["1532:00be", "razer-deathadder-v4-pro.png"],
-  ["1532:00bf", "razer-deathadder-v4-pro.png"],
-  ["1532:00ef", "razer-deathadder-v4-pro.png"],
-  ["1532:00f0", "razer-deathadder-v4-pro.png"],
-  ["1532:00b8", "razer-viper-v3-hyperspeed.png"],
-  ["1532:00e5", "razer-viper-v4-pro.png"],
-  ["1532:00e6", "razer-viper-v4-pro.png"],
-  // K-snake X11 wired / 2.4 GHz dongle share the same shell.
-  ["a8a4:2255", "ksnake-x11.png"],
-  ["a8a5:2255", "ksnake-x11.png"],
-  // A950 PRO Mg wired mouse and its dedicated 2.4 GHz receiver.
-  ["260d:1117", "dareu-a950-pro-mg.png"],
-  ["260d:1114", "dareu-a950-pro-mg.png"],
-  // Microsoft Intellimouse
-  ["045e:0823", "microsoft-classic-intellimouse.png"],
-  ["045e:082a", "microsoft-pro-intellimouse.png"],
-  // HyperX Pulsefire Haste: Kingston-era wired (0x0951:0x1727) and HP-era
-  // wired / wired-mode / wireless dongle transports share one shell.
-  ["0951:1727", "hyperx-pulsefire-haste.png"],
-  ["03f0:0f8f", "hyperx-pulsefire-haste.png"],
-  ["03f0:048e", "hyperx-pulsefire-haste.png"],
-  ["03f0:028e", "hyperx-pulsefire-haste.png"],
-  // Keychron M6 (1K, PixArt 3395) wired and its Link-KM receiver share one shell.
-  ["3434:d060", "keychron-m6.png"],
-  ["3434:d029", "keychron-m6.png"],
-]);
 
 function deviceKey(device: HIDDevice): string {
   const hex = (value: number): string => value.toString(16).padStart(4, "0");
@@ -294,23 +133,28 @@ export function hasCrowdArtwork(vendorId: number, productId: number): boolean {
   return crowdArtworkCache.has(`${hex(vendorId)}:${hex(productId)}`);
 }
 
-function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displayName = ""): string {
-  const mapped = device ? DEVICE_IMAGES.get(deviceKey(device)) ?? null : null;
-  if (mapped) return mapped;
-
+function resolveDeviceImageFilename(_device: HIDDevice | null | undefined, displayName = ""): string {
   // Lightspeed receivers are shared product IDs, so paired G502 X variants
   // must use the friendly name read from the mouse itself.
   if (/g502\s*x\s*plus/i.test(displayName)) return "logitech-g502-x-plus.png";
   if (/g502\s*x/i.test(displayName)) return "logitech-g502-x.png";
   if (/\bg502\b/i.test(displayName)) return "logitech-g502.png";
   if (/\bg703\b/i.test(displayName)) return "logitech-g703.png";
+  // The original G Pro X Superlight reports as "PRO X Wireless" over HID++,
+  // not "Superlight" — matched on the wireless name instead, reusing the
+  // Superlight 2c's render (close enough a shell). The `superlight` check a
+  // few lines down covers every other Superlight generation.
+  if (/\bpro\s*x\s*wireless\b/i.test(displayName)) return "logitech-pro-x-superlight-2c.png";
   if (/mx\s*master\s*4/i.test(displayName)) return "unknown-device.png";
   if (/superstrike/i.test(displayName)) return "logitech-pro-x2-superstrike.png";
   if (/superlight/i.test(displayName)) return "logitech-pro-x-superlight-2c.png";
   if (/op1we/i.test(displayName)) return "endgame-gear-op1we.png";
   if (/\bop1\b/i.test(displayName)) return "endgame-gear-op1-8k.png";
   if (/\bviper\s*v2\s*pro\b/i.test(displayName)) return "razer-viper-v2-pro.png";
+  // "Viper V3 Pro SE" must not fall into the plain V3 Pro render.
+  if (/\bviper\s*v3\s*pro\b(?!\s*se)/i.test(displayName)) return "razer-viper-v3-pro.png";
   if (/\bviper\s*mini\b/i.test(displayName)) return "razer-viper-mini.webp";
+  if (/\borochi\s*v2\b/i.test(displayName)) return "razer-orochi-v2.png";
   if (/\bcobra\b/i.test(displayName)) return "razer-cobra.webp";
   if (/\bnape\s*pro\b/i.test(displayName)) return "unknown-device.png";
   if (/\bko-one\b/i.test(displayName)) return "crdrako-ko-one.png";
@@ -318,6 +162,7 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
     return "vxe-r1-series.png";
   }
   if (/\br5\s*ultra\b/i.test(displayName)) return "attackshark-r5-ultra.png";
+  if (/\batk\s*zero\b/i.test(displayName)) return "atk-zero.png";
   // R2 shares PID 0x402D with the Lingbao M5 Pro, so it can only be told apart
   // by the name the gearhub driver reads back from the device id.
   if (/\battack\s*shark\s*r2\b/i.test(displayName)) return "attackshark-r2.png";
@@ -352,6 +197,11 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
   if (/\bdeathadder\s*essential\b/i.test(displayName)) return "razer-deathadder-v2.png";
   if (/\bviper\s*v3\s*hyperspeed\b/i.test(displayName)) return "razer-viper-v3-hyperspeed.png";
   if (/\bviper\s*v4\b/i.test(displayName)) return "razer-viper-v4-pro.png";
+  // Catches the plain original Viper. Every other Viper generation is matched
+  // above, so this must run last among the viper checks — excluding every
+  // variant with no render of its own, so it falls to the placeholder rather
+  // than borrowing this one.
+  if (/\bviper\b(?!\s*(ultimate|8khz|mini|v2|v3|v4))/i.test(displayName)) return "razer-viper.webp";
   if (/\bxm2\s*8k\b/i.test(displayName)) return "endgame-gear-xm2-8k.png";
   if (/\bxm2w\b/i.test(displayName)) return "endgame-gear-xm2w.png";
   // WLMouse receivers are shared across models — the 1K dongle enumerates under
@@ -372,6 +222,14 @@ function resolveDeviceImageFilename(device: HIDDevice | null | undefined, displa
   if (/\ba7\s*v3\b/i.test(displayName)) return "mchose-a7-v3.png";
   if (/\ba7\s*v2\b/i.test(displayName)) return "mchose-a7-v2.png";
   if (/\ba950\s*pro\s*mg\b/i.test(displayName)) return "dareu-a950-pro-mg.png";
+  // NinjaForce/Ninjutso family — V3 first so "Sora V3" isn't swallowed by a
+  // looser V2 or "Ten" match.
+  if (/\bsora\s*v3\b/i.test(displayName)) return "ninjutso-sora-v3.png";
+  if (/\bsora\s*v2\b/i.test(displayName)) return "ninjutso-sora-v2.png";
+  if (/\bninjutso\b.*\bten\b/i.test(displayName)) return "ninjutso-ten.png";
+  // Incott reports its model as "Esports G23V2Pro" (see incott/index.ts).
+  if (/\bg23\s*v2\s*pro\b/i.test(displayName)) return "incott-g23-v2-pro.png";
+  if (/\bkeychron\s*m6\b/i.test(displayName)) return "keychron-m6.png";
   if (/\b(finalmouse|starlight|ulx)\b/i.test(displayName)) return "finalmouse-ulx.png";
   if (/\borbital\b/i.test(displayName)) return "unknown-device.png";
   if (/\bmoddo/i.test(displayName)) return "unknown-device.png";
@@ -424,10 +282,10 @@ export function deviceImage(device: HIDDevice | null | undefined, displayName = 
  */
 // Every filename here is checked against the R2 bucket directly (curl -o
 // /dev/null -w '%{http_code}') before landing on this list — several
-// filenames mapped in DEVICE_IMAGES above 404 because the art was never
-// uploaded (attackshark-r2.png, mchose-a7-v2.png, atk-zero.png, and the
-// Microsoft IntelliMouse renders among them), which silently fails on the
-// device panel but breaks a showcase that's shown unconditionally.
+// filenames resolveDeviceImageFilename can return above 404 because the art
+// was never uploaded (attackshark-r2.png, mchose-a7-v2.png, atk-zero.png,
+// and the Microsoft IntelliMouse renders among them), which silently fails
+// on the device panel but breaks a showcase that's shown unconditionally.
 const SHOWCASE_DEVICE_FILENAMES: readonly string[] = [
   "logitech-g502-x-plus.png",
   "razer-viper-v3-pro.png",


### PR DESCRIPTION
Removes the `DEVICE_IMAGES` static VID:PID map entirely. Every device's built-in image now resolves through the same name-regex cascade the already-ambiguous devices used.

## Trade-off (deliberate, per discussion)
A USB id is not always unique to one physical product, but a device's real name only becomes known after a full connect+read — before that, only the raw `productName` string is available, which is often generic or blank for a lot of hardware. So: a device that resolved instantly from its VID:PID before this change now shows the placeholder until it's actually read, in exchange for never being able to show the wrong model's art for a shared id.

## What's new
Added name rules for every model the removed map covered that didn't already have an equivalent regex — transcribed from each driver's own reported model string: Viper V3 Pro, plain Viper, Orochi V2, ATK ZERO, Ninjutso Sora V2/V3 + TEN, Incott G23V2Pro, Keychron M6.

## Not affected
Crowd-sourced artwork uploads — keyed by `vendorId:productId` (or `vendorId:productId:name` for the shared-id cases from #259), independent of this map. Both id and name are always known at upload time since uploading only happens against an actively-connected device.

Rewrote `device-images.test.ts` throughout — every previously-PID-only assertion now supplies the name the real driver reports, or (where the point was "no name means no match") keeps expecting the placeholder.

`npm run check`: 145/145 tests pass. Bundle size within budget (slightly smaller, in fact).