### PR TITLE
device-images: resolve every Incott model, and key its crowd art by name

### DIFF
--- a/functions/api/artwork/upload.js
+++ b/functions/api/artwork/upload.js
@@ -33,6 +33,7 @@ const SHARED_PID_KEYS = new Set([
   "046d:c539", // Logitech Lightspeed receiver (G502 X, G703, G Pro Wireless, ...)
   "3151:402d", // GearHub 2.4 GHz receiver (Attack Shark R2, Lingbao M5 Pro)
   "3837:4030", "3837:4031", "3837:4032", "3837:4033", // MCHOSE A7 V3-generation receiver ids
+  "093a:522c", "093a:622c", // Incott dongle / wired ids, shared by all six families
 ]);
 const SHARED_PID_VENDOR_IDS = new Set([0x36a7]); // WLMouse — no single shared receiver PID
 

--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -243,3 +243,54 @@ test("Incott G23V2Pro and Keychron M6 resolve by name", () => {
   assert.equal(deviceImage(null, "Esports G23V2Pro"), CDN + "incott-g23-v2-pro.png");
   assert.equal(deviceImage(null, "Keychron M6"), CDN + "keychron-m6.png");
 });
+
+test("every Incott family resolves its own render, base and Pro separately", () => {
+  // The driver reads the model from the device and appends "Pro" when the
+  // PAW3950 is fitted, so these are the names it actually reports.
+  assert.equal(deviceImage(null, "Ghero"), CDN + "incott-ghero.png");
+  assert.equal(deviceImage(null, "Ghero Pro"), CDN + "incott-ghero-pro.png");
+  assert.equal(deviceImage(null, "G23"), CDN + "incott-g23.png");
+  assert.equal(deviceImage(null, "G23 Pro"), CDN + "incott-g23-pro.png");
+  assert.equal(deviceImage(null, "G24"), CDN + "incott-g24.png");
+  assert.equal(deviceImage(null, "G24 Pro"), CDN + "incott-g24-pro.png");
+  assert.equal(deviceImage(null, "G23V2"), CDN + "incott-g23-v2.png");
+  assert.equal(deviceImage(null, "G23V2 Pro"), CDN + "incott-g23-v2-pro.png");
+  assert.equal(deviceImage(null, "Zero 29"), CDN + "incott-zero-29.png");
+  assert.equal(deviceImage(null, "Zero 29 Pro"), CDN + "incott-zero-29-pro.png");
+  assert.equal(deviceImage(null, "Zero 39"), CDN + "incott-zero-39.png");
+  assert.equal(deviceImage(null, "Zero 39 Pro"), CDN + "incott-zero-39-pro.png");
+});
+
+test("a looser Incott rule never swallows a tighter one", () => {
+  // G23V2 must not fall into the plain G23 render, and neither base model may
+  // be matched by its own Pro pattern or vice versa. Ordering is the only
+  // thing keeping these apart.
+  assert.notEqual(deviceImage(null, "G23V2"), CDN + "incott-g23.png");
+  assert.notEqual(deviceImage(null, "G23V2 Pro"), CDN + "incott-g23-pro.png");
+  assert.notEqual(deviceImage(null, "G23 Pro"), CDN + "incott-g23.png");
+  assert.notEqual(deviceImage(null, "Ghero Pro"), CDN + "incott-ghero.png");
+});
+
+test("the wired product string resolves the same render as the read model", () => {
+  // Wired with no identity read, the driver falls back to the tidied product
+  // string — "Esports G23V2Pro", no separators at all.
+  assert.equal(deviceImage(null, "Esports G23V2Pro"), CDN + "incott-g23-v2-pro.png");
+  assert.equal(deviceImage(null, "incott Esports G23V2Pro mouse"), CDN + "incott-g23-v2-pro.png");
+});
+
+test("Incott crowd art is keyed by model name, not its shared product id", () => {
+  // All six families enumerate as 093a:522c / 093a:622c, so a bare VID:PID
+  // key would serve one model's upload to every other model.
+  assert.equal(
+    deviceImage(dev(0x093a, 0x522c), "Ghero"),
+    CDN + "incott-ghero.png",
+    "no crowd art loaded in tests, so it falls through to the name rule",
+  );
+});
+
+test("Incott names do not collide with other brands' renders", () => {
+  // "G Pro" and the Logitech G-series numbers sit in the same cascade.
+  assert.equal(deviceImage(null, "G PRO WIRELESS"), CDN + "logitech-gpro-wireless.png");
+  assert.equal(deviceImage(null, "G203 LIGHTSYNC"), CDN + "logitech-g203.png");
+  assert.equal(deviceImage(null, "G303 SHROUD"), CDN + "logitech-g303.png");
+});

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -46,6 +46,9 @@ const SHARED_PID_KEYS: ReadonlySet<string> = new Set([
   "046d:c539", // Logitech Lightspeed receiver (G502 X, G703, G Pro Wireless, ...)
   "3151:402d", // GearHub 2.4 GHz receiver (Attack Shark R2, Lingbao M5 Pro)
   "3837:4030", "3837:4031", "3837:4032", "3837:4033", // MCHOSE A7 V3-generation receiver ids
+  // Every Incott model family enumerates under these two ids — the 2.4 GHz
+  // dongle and the wired link — so crowd art has to be keyed by name here.
+  "093a:522c", "093a:622c",
 ]);
 
 /** WLMouse has no single shared receiver PID — its whole vendor id is name-resolved. */
@@ -227,8 +230,28 @@ function resolveDeviceImageFilename(_device: HIDDevice | null | undefined, displ
   if (/\bsora\s*v3\b/i.test(displayName)) return "ninjutso-sora-v3.png";
   if (/\bsora\s*v2\b/i.test(displayName)) return "ninjutso-sora-v2.png";
   if (/\bninjutso\b.*\bten\b/i.test(displayName)) return "ninjutso-ten.png";
-  // Incott reports its model as "Esports G23V2Pro" (see incott/index.ts).
+  // Incott: six model families, each sold in a base and a Pro version with
+  // a different shell finish, so all twelve get their own render. The driver
+  // reads the model from the device and appends "Pro" when the PAW3950 is
+  // fitted (see incott/index.ts), giving names like "Ghero", "G23V2 Pro" or
+  // "Zero 39". Wired with no identity read it falls back to the product
+  // string, "Esports G23V2Pro", which these same patterns match because
+  // every separator is optional.
+  //
+  // Each Pro pattern MUST precede its base model, and the G23V2 pair must
+  // precede the plain G23 pair, or the looser rule swallows the tighter one.
   if (/\bg23\s*v2\s*pro\b/i.test(displayName)) return "incott-g23-v2-pro.png";
+  if (/\bg23\s*v2\b/i.test(displayName)) return "incott-g23-v2.png";
+  if (/\bg23\s*pro\b/i.test(displayName)) return "incott-g23-pro.png";
+  if (/\bg23\b/i.test(displayName)) return "incott-g23.png";
+  if (/\bg24\s*pro\b/i.test(displayName)) return "incott-g24-pro.png";
+  if (/\bg24\b/i.test(displayName)) return "incott-g24.png";
+  if (/\bghero\s*pro\b/i.test(displayName)) return "incott-ghero-pro.png";
+  if (/\bghero\b/i.test(displayName)) return "incott-ghero.png";
+  if (/\bzero\s*29\s*pro\b/i.test(displayName)) return "incott-zero-29-pro.png";
+  if (/\bzero\s*29\b/i.test(displayName)) return "incott-zero-29.png";
+  if (/\bzero\s*39\s*pro\b/i.test(displayName)) return "incott-zero-39-pro.png";
+  if (/\bzero\s*39\b/i.test(displayName)) return "incott-zero-39.png";
   if (/\bkeychron\s*m6\b/i.test(displayName)) return "keychron-m6.png";
   if (/\b(finalmouse|starlight|ulx)\b/i.test(displayName)) return "finalmouse-ulx.png";
   if (/\borbital\b/i.test(displayName)) return "unknown-device.png";


### PR DESCRIPTION
Follows #261's move to name-based resolution. Only "G23V2 Pro" had a rule; the other eleven Incott variants fell through to the placeholder.

Incott has six model families (Ghero, G23, G24, G23V2, Zero 29, Zero 39), each sold in a base and a Pro version with a different shell finish. Only "G23V2 Pro" had a rule, so the other eleven fell through to the generic placeholder.

The driver reads the model from the device itself and appends "Pro" when the PAW3950 is fitted, so the names these match are the ones it actually reports. Wired with no identity read it falls back to the product string, "Esports G23V2Pro" — matched by the same patterns, since every separator is optional.

Every Pro pattern precedes its base model and the G23V2 pair precedes the plain G23 pair, since ordering is the only thing keeping a looser rule from swallowing a tighter one. Tests pin both directions.

Also adds 093a:522c and 093a:622c to SHARED_PID_KEYS, in device-images.ts and upload.js alike. All six families enumerate under those two ids — the 2.4 GHz dongle and the wired link — so crowd art keyed by bare VID:PID would serve whichever model was uploaded first to every other model behind the same id. The two sets have to agree or uploads and lookups key differently.

None of the twelve renders exist in the bucket yet, which fails at image load rather than at build, so this lands safely ahead of the art.