### PR TITLE
artwork: key crowd uploads and lookups by device name only

### DIFF
--- a/functions/api/artwork/list.js
+++ b/functions/api/artwork/list.js
@@ -1,16 +1,10 @@
 /**
  * Lists all crowd-sourced artworks from the R2 bucket.
- * Returns a JSON array of artwork entries with vendorId, productId, and filename.
+ * Returns a JSON array of artwork entries with nameSlug and filename.
  *
  * GET /api/artwork/list
  *
- * Response: { artworks: Array<{ vendorId: number, productId: number, filename: string, nameSlug?: string }> }
- *
- * A device whose id is shared across different physical products (see
- * upload.js's SHARED_PID_KEYS) uploads under `{vid}:{pid}:{nameSlug}.{ext}`
- * instead of the plain `{vid}:{pid}.{ext}` every other device uses, so two
- * different models behind one id each get their own entry here rather than
- * one clobbering the other.
+ * Response: { artworks: Array<{ nameSlug: string, filename: string }> }
  */
 
 const json = (body, status = 200) => new Response(JSON.stringify(body), {
@@ -32,18 +26,9 @@ export async function onRequest({ env }) {
 
     for (const object of listed.objects) {
       const filename = object.key.replace("crowd/", "");
-      const named = filename.match(/^([0-9a-f]{4}):([0-9a-f]{4}):([a-z0-9-]+)\.(png|webp)$/i);
-      if (named) {
-        const vendorId = parseInt(named[1], 16);
-        const productId = parseInt(named[2], 16);
-        artworks.push({ vendorId, productId, filename, nameSlug: named[3].toLowerCase() });
-        continue;
-      }
-      const plain = filename.match(/^([0-9a-f]{4}):([0-9a-f]{4})\.(png|webp)$/i);
-      if (plain) {
-        const vendorId = parseInt(plain[1], 16);
-        const productId = parseInt(plain[2], 16);
-        artworks.push({ vendorId, productId, filename });
+      const match = filename.match(/^([a-z0-9-]+)\.(png|webp)$/i);
+      if (match) {
+        artworks.push({ nameSlug: match[1].toLowerCase(), filename });
       }
     }
 

--- a/functions/api/artwork/upload.js
+++ b/functions/api/artwork/upload.js
@@ -1,9 +1,15 @@
 /**
  * Uploads crowd-sourced artwork to the R2 bucket.
- * Validates that no artwork exists for the device before uploading.
+ * Validates that no artwork exists for this device name before uploading.
+ *
+ * Keyed purely by the device's own reported name — never by VID:PID. A USB
+ * id is not always unique to one physical product (several brands reuse the
+ * same receiver or ODM board), while the name is what's actually specific to
+ * the product connected. The panel already resolves its built-in art the
+ * same way (see src/ui/device-images.ts), so crowd art follows suit.
  *
  * POST /api/artwork/upload
- * Body: { vendorId: number, productId: number, displayName: string, dataUrl: string }
+ * Body: { displayName: string, dataUrl: string }
  *
  * Response: { ok: boolean, message?: string }
  */
@@ -16,29 +22,9 @@ const json = (body, status = 200) => new Response(JSON.stringify(body), {
   },
 });
 
-const VENDOR_RE = /^[0-9a-f]{4}$/i;
 // PNG/WebP only — JPEG can't carry an alpha channel, and this artwork is
 // composited over the device panel, so it needs a transparent background.
 const DATA_URL_RE = /^data:image\/(png|webp);base64,(.+)$/;
-
-// VID:PID pairs (and, for WLMouse, a whole vendor id) known to be genuinely
-// shared across different physical products — a receiver or ODM board reused
-// by several models. Kept in sync by hand with the same list in
-// src/ui/device-images.ts; duplicated here because these Functions run
-// outside that module's build. For these, the object key includes a slug of
-// the device's own reported name so two different models behind one shared
-// id each get their own upload instead of clobbering one another the way a
-// bare VID:PID key would.
-const SHARED_PID_KEYS = new Set([
-  "046d:c539", // Logitech Lightspeed receiver (G502 X, G703, G Pro Wireless, ...)
-  "3151:402d", // GearHub 2.4 GHz receiver (Attack Shark R2, Lingbao M5 Pro)
-  "3837:4030", "3837:4031", "3837:4032", "3837:4033", // MCHOSE A7 V3-generation receiver ids
-]);
-const SHARED_PID_VENDOR_IDS = new Set([0x36a7]); // WLMouse — no single shared receiver PID
-
-function isSharedPid(vendorId, productId, vendorHex, productHex) {
-  return SHARED_PID_VENDOR_IDS.has(vendorId) || SHARED_PID_KEYS.has(`${vendorHex}:${productHex}`);
-}
 
 function slugifyName(name) {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
@@ -64,14 +50,15 @@ export async function onRequest({ request, env }) {
     return json({ message: "Invalid request body." }, 400);
   }
 
-  const { vendorId, productId, displayName, dataUrl } = body;
-
-  if (typeof vendorId !== "number" || typeof productId !== "number") {
-    return json({ message: "Invalid vendorId or productId." }, 400);
-  }
+  const { displayName, dataUrl } = body;
 
   if (typeof displayName !== "string" || displayName.length > 100) {
     return json({ message: "Invalid displayName." }, 400);
+  }
+
+  const nameSlug = slugifyName(displayName);
+  if (!nameSlug) {
+    return json({ message: "This device has no usable name yet — reconnect it and try again once it's fully read." }, 400);
   }
 
   if (typeof dataUrl !== "string") {
@@ -86,29 +73,14 @@ export async function onRequest({ request, env }) {
   const ext = dataUrlMatch[1];
   const contentType = `image/${ext}`;
   const base64Data = dataUrlMatch[2];
-  const vendorHex = vendorId.toString(16).padStart(4, "0");
-  const productHex = productId.toString(16).padStart(4, "0");
-
-  const shared = isSharedPid(vendorId, productId, vendorHex, productHex);
-  let keyBase = `${vendorHex}:${productHex}`;
-  if (shared) {
-    const nameSlug = slugifyName(displayName);
-    if (!nameSlug) {
-      return json({ message: "This device's id is shared with other models — a device name is required to tell them apart." }, 400);
-    }
-    keyBase += `:${nameSlug}`;
-  }
-  const filename = `${keyBase}.${ext}`;
+  const filename = `${nameSlug}.${ext}`;
   const objectKey = `crowd/${filename}`;
 
   // Checked by prefix, not by the exact key: the extension is part of the key
-  // (crowd/{keyBase}.{ext}), so a .head() on this one key alone would miss an
-  // existing upload in the *other* format and let both land in the bucket for
-  // the same device — two objects the list endpoint can then only
-  // arbitrarily pick between. For a shared id, keyBase already includes the
-  // name slug, so this only matches the same model's other format, not a
-  // different model sharing the same raw VID:PID.
-  const existing = await env.ARTWORK_BUCKET.list({ prefix: `crowd/${keyBase}.` });
+  // (crowd/{nameSlug}.{ext}), so a .head() on this one key alone would miss
+  // an existing upload in the *other* format and let both land in the
+  // bucket for the same device.
+  const existing = await env.ARTWORK_BUCKET.list({ prefix: `crowd/${nameSlug}.` });
   if (existing.objects.length > 0) {
     return json({ ok: true, message: "Artwork already exists." });
   }
@@ -128,8 +100,6 @@ export async function onRequest({ request, env }) {
       },
       customMetadata: {
         displayName,
-        vendorId: vendorHex,
-        productId: productHex,
         uploadedAt: new Date().toISOString(),
       },
     });

--- a/src/app/ArtworkUploadDialog.tsx
+++ b/src/app/ArtworkUploadDialog.tsx
@@ -16,8 +16,6 @@ interface ArtworkUploadDialogProps {
   isOpen: boolean;
   onClose: () => void;
   locale: InterfaceLocale;
-  vendorId: number;
-  productId: number;
   displayName: string;
   onArtworkUploaded: () => void;
 }
@@ -26,8 +24,6 @@ export function ArtworkUploadDialog({
   isOpen,
   onClose,
   locale,
-  vendorId,
-  productId,
   displayName,
   onArtworkUploaded,
 }: ArtworkUploadDialogProps): ReactNode {
@@ -97,14 +93,14 @@ export function ArtworkUploadDialog({
     if (state.status !== "preview") return;
     setState({ status: "uploading", fileName: state.fileName, dataUrl: state.dataUrl });
 
-    const result = await uploadArtwork(vendorId, productId, displayName, state.dataUrl);
+    const result = await uploadArtwork(displayName, state.dataUrl);
     if (result.ok) {
       setState({ status: "done" });
       onArtworkUploaded();
     } else {
       setState({ status: "error", message: result.error ?? "Upload failed" });
     }
-  }, [state, vendorId, productId, displayName, onArtworkUploaded]);
+  }, [state, displayName, onArtworkUploaded]);
 
   const handleClose = useCallback(() => {
     if (state.status === "uploading") return;

--- a/src/app/OverviewPage.tsx
+++ b/src/app/OverviewPage.tsx
@@ -138,8 +138,6 @@ function DeviceShowcase({ snapshot }: { snapshot: ControlSnapshot }): ReactNode 
           isOpen={showUploadDialog}
           onClose={() => setShowUploadDialog(false)}
           locale={locale}
-          vendorId={activeDevice.vendorId}
-          productId={activeDevice.productId}
           displayName={status.name}
           onArtworkUploaded={() => {
             control.refreshArtwork();

--- a/src/ui/artwork-storage.ts
+++ b/src/ui/artwork-storage.ts
@@ -1,116 +1,10 @@
 /**
- * Crowd-sourced artwork storage layer.
- * Fetches artwork list from API and caches in localStorage for quick access.
+ * Crowd-sourced artwork upload. The read/cache side lives in device-images.ts
+ * (`loadCrowdArtworkCache`/`refreshCrowdArtworkCache`/`deviceImage`) — this
+ * module only submits a new upload and asks that cache to refresh.
  */
 
-const CACHE_KEY = "openmouse.crowd-artwork-cache";
-const CACHE_TTL = 5 * 60 * 1000;
-
-interface ArtworkEntry {
-  vendorId: number;
-  productId: number;
-  filename: string;
-}
-
-interface ArtworkCache {
-  entries: ArtworkEntry[];
-  fetchedAt: number;
-}
-
-let cachedEntries: Map<string, string> | null = null;
-
-function getCacheKey(vendorId: number, productId: number): string {
-  const hex = (v: number) => v.toString(16).padStart(4, "0");
-  return `${hex(vendorId)}:${hex(productId)}`;
-}
-
-function loadCacheFromStorage(): ArtworkCache | null {
-  try {
-    const raw = localStorage.getItem(CACHE_KEY);
-    if (!raw) return null;
-    const cache: ArtworkCache = JSON.parse(raw);
-    if (Date.now() - cache.fetchedAt > CACHE_TTL) return null;
-    return cache;
-  } catch {
-    return null;
-  }
-}
-
-function saveCacheToStorage(entries: ArtworkEntry[]): void {
-  const cache: ArtworkCache = { entries, fetchedAt: Date.now() };
-  try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
-  } catch {
-    // Storage full or blocked — silently continue
-  }
-}
-
-function buildMap(entries: ArtworkEntry[]): Map<string, string> {
-  const map = new Map<string, string>();
-  // The upload endpoint now refuses a second format for a device that already
-  // has one, but the bucket may still carry pre-existing .png/.webp pairs
-  // from before that check existed. Sort so any leftover duplicate resolves
-  // to the same filename every time instead of whichever the API happened to
-  // list last — R2's list order isn't something this app controls.
-  const sorted = [...entries].sort((a, b) => a.filename.localeCompare(b.filename));
-  for (const entry of sorted) {
-    map.set(getCacheKey(entry.vendorId, entry.productId), entry.filename);
-  }
-  return map;
-}
-
-async function fetchArtworkList(): Promise<Map<string, string>> {
-  try {
-    const response = await fetch("/api/artwork/list", {
-      headers: { Accept: "application/json" },
-    });
-    if (!response.ok) return new Map();
-    const text = await response.text();
-    if (!text) return new Map();
-    const data = JSON.parse(text);
-    if (!Array.isArray(data.artworks)) return new Map();
-    const entries: ArtworkEntry[] = data.artworks;
-    saveCacheToStorage(entries);
-    return buildMap(entries);
-  } catch {
-    return new Map();
-  }
-}
-
-export async function loadCrowdArtworkCache(): Promise<void> {
-  if (cachedEntries) return;
-  cachedEntries = await fetchArtworkList();
-}
-
-export async function getArtworkMap(): Promise<Map<string, string>> {
-  if (cachedEntries) return cachedEntries;
-
-  const cached = loadCacheFromStorage();
-  if (cached) {
-    cachedEntries = buildMap(cached.entries);
-    return cachedEntries;
-  }
-
-  cachedEntries = await fetchArtworkList();
-  return cachedEntries;
-}
-
-export function getCrowdArtworkFilename(vendorId: number, productId: number): string | null {
-  if (!cachedEntries) return null;
-  return cachedEntries.get(getCacheKey(vendorId, productId)) ?? null;
-}
-
-export function hasCrowdArtwork(vendorId: number, productId: number): boolean {
-  return getCrowdArtworkFilename(vendorId, productId) !== null;
-}
-
-export async function refreshArtworkCache(): Promise<void> {
-  cachedEntries = await fetchArtworkList();
-}
-
 export async function uploadArtwork(
-  vendorId: number,
-  productId: number,
   displayName: string,
   dataUrl: string,
 ): Promise<{ ok: boolean; error?: string }> {
@@ -118,7 +12,7 @@ export async function uploadArtwork(
     const response = await fetch("/api/artwork/upload", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ vendorId, productId, displayName, dataUrl }),
+      body: JSON.stringify({ displayName, dataUrl }),
     });
 
     const text = await response.text();
@@ -132,7 +26,6 @@ export async function uploadArtwork(
       return { ok: false, error: result.message ?? "Upload failed" };
     }
 
-    await refreshArtworkCache();
     return { ok: true };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : "Network error" };

--- a/src/ui/device-images.test.ts
+++ b/src/ui/device-images.test.ts
@@ -243,3 +243,55 @@ test("Incott G23V2Pro and Keychron M6 resolve by name", () => {
   assert.equal(deviceImage(null, "Esports G23V2Pro"), CDN + "incott-g23-v2-pro.png");
   assert.equal(deviceImage(null, "Keychron M6"), CDN + "keychron-m6.png");
 });
+
+test("every Incott family resolves its own render, base and Pro separately", () => {
+  // The driver reads the model from the device and appends "Pro" when the
+  // PAW3950 is fitted, so these are the names it actually reports.
+  assert.equal(deviceImage(null, "Ghero"), CDN + "incott-ghero.png");
+  assert.equal(deviceImage(null, "Ghero Pro"), CDN + "incott-ghero-pro.png");
+  assert.equal(deviceImage(null, "G23"), CDN + "incott-g23.png");
+  assert.equal(deviceImage(null, "G23 Pro"), CDN + "incott-g23-pro.png");
+  assert.equal(deviceImage(null, "G24"), CDN + "incott-g24.png");
+  assert.equal(deviceImage(null, "G24 Pro"), CDN + "incott-g24-pro.png");
+  assert.equal(deviceImage(null, "G23V2"), CDN + "incott-g23-v2.png");
+  assert.equal(deviceImage(null, "G23V2 Pro"), CDN + "incott-g23-v2-pro.png");
+  assert.equal(deviceImage(null, "Zero 29"), CDN + "incott-zero-29.png");
+  assert.equal(deviceImage(null, "Zero 29 Pro"), CDN + "incott-zero-29-pro.png");
+  assert.equal(deviceImage(null, "Zero 39"), CDN + "incott-zero-39.png");
+  assert.equal(deviceImage(null, "Zero 39 Pro"), CDN + "incott-zero-39-pro.png");
+});
+
+test("a looser Incott rule never swallows a tighter one", () => {
+  // G23V2 must not fall into the plain G23 render, and neither base model may
+  // be matched by its own Pro pattern or vice versa. Ordering is the only
+  // thing keeping these apart.
+  assert.notEqual(deviceImage(null, "G23V2"), CDN + "incott-g23.png");
+  assert.notEqual(deviceImage(null, "G23V2 Pro"), CDN + "incott-g23-pro.png");
+  assert.notEqual(deviceImage(null, "G23 Pro"), CDN + "incott-g23.png");
+  assert.notEqual(deviceImage(null, "Ghero Pro"), CDN + "incott-ghero.png");
+});
+
+test("the wired product string resolves the same render as the read model", () => {
+  // Wired with no identity read, the driver falls back to the tidied product
+  // string — "Esports G23V2Pro", no separators at all.
+  assert.equal(deviceImage(null, "Esports G23V2Pro"), CDN + "incott-g23-v2-pro.png");
+  assert.equal(deviceImage(null, "incott Esports G23V2Pro mouse"), CDN + "incott-g23-v2-pro.png");
+});
+
+test("Incott crowd art is keyed by model name like everything else", () => {
+  // All six families enumerate under the same two product ids, so a crowd
+  // upload keyed by name (not id) is what keeps one model's art from being
+  // served to every other model.
+  assert.equal(
+    deviceImage(dev(0x093a, 0x522c), "Ghero"),
+    CDN + "incott-ghero.png",
+    "no crowd art loaded in tests, so it falls through to the name rule",
+  );
+});
+
+test("Incott names do not collide with other brands' renders", () => {
+  // "G Pro" and the Logitech G-series numbers sit in the same cascade.
+  assert.equal(deviceImage(null, "G PRO WIRELESS"), CDN + "logitech-gpro-wireless.png");
+  assert.equal(deviceImage(null, "G203 LIGHTSYNC"), CDN + "logitech-g203.png");
+  assert.equal(deviceImage(null, "G303 SHROUD"), CDN + "logitech-g303.png");
+});

--- a/src/ui/device-images.ts
+++ b/src/ui/device-images.ts
@@ -24,46 +24,17 @@
  * the name-fallback regexes below.
  */
 
-function deviceKey(device: HIDDevice): string {
-  const hex = (value: number): string => value.toString(16).padStart(4, "0");
-  return `${hex(device.vendorId)}:${hex(device.productId)}`;
-}
-
-/**
- * VID:PID pairs known to be genuinely shared across different physical
- * products (a receiver or ODM board reused by several models), transcribed
- * from the name-fallback comments below rather than kept as a second source
- * of truth. Crowd-sourced artwork is keyed by VID:PID alone (see
- * `deviceImage`), so without this, uploading art for one model sharing one
- * of these ids would apply it to every other model behind the same id —
- * these are skipped so crowd art is only ever trusted for a PID that maps to
- * exactly one product.
- *
- * Add an entry here whenever a name-fallback regex is added below for the
- * same reason (a shared receiver/PID, not just an unmapped model).
- */
-const SHARED_PID_KEYS: ReadonlySet<string> = new Set([
-  "046d:c539", // Logitech Lightspeed receiver (G502 X, G703, G Pro Wireless, ...)
-  "3151:402d", // GearHub 2.4 GHz receiver (Attack Shark R2, Lingbao M5 Pro)
-  "3837:4030", "3837:4031", "3837:4032", "3837:4033", // MCHOSE A7 V3-generation receiver ids
-]);
-
-/** WLMouse has no single shared receiver PID — its whole vendor id is name-resolved. */
-const SHARED_PID_VENDOR_IDS: ReadonlySet<number> = new Set([0x36a7]);
-
-function isSharedPidDevice(device: HIDDevice): boolean {
-  return SHARED_PID_VENDOR_IDS.has(device.vendorId) || SHARED_PID_KEYS.has(deviceKey(device));
-}
-
 /** Matches upload.js's slug exactly — the two must agree for the lookup to ever hit. */
 function slugifyName(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
 /**
- * Crowd-sourced artwork cache. Populated asynchronously on app load from
- * `/api/artwork/list`. Once loaded, checked synchronously in
- * `resolveDeviceImageFilename` before the static map and name fallbacks.
+ * Crowd-sourced artwork cache, keyed by the same name slug as the built-in
+ * art below — never by VID:PID, for the same reason: an id is not always
+ * unique to one physical product. Populated asynchronously on app load from
+ * `/api/artwork/list`. Once loaded, checked synchronously in `deviceImage`
+ * before the name-fallback regexes.
  */
 let crowdArtworkCache: Map<string, string> | null = null;
 let crowdArtworkPromise: Promise<void> | null = null;
@@ -86,14 +57,8 @@ async function fetchCrowdArtworkMap(bypassHttpCache = false): Promise<Map<string
 
     const map = new Map<string, string>();
     for (const entry of data.artworks) {
-      if (typeof entry.vendorId === "number" && typeof entry.productId === "number" && typeof entry.filename === "string") {
-        const hex = (v: number) => v.toString(16).padStart(4, "0");
-        const pidKey = `${hex(entry.vendorId)}:${hex(entry.productId)}`;
-        // A shared-id upload carries a nameSlug (see upload.js/list.js) so it
-        // doesn't collide with a different model behind the same raw id —
-        // keyed separately here, looked up the same way in deviceImage().
-        const key = typeof entry.nameSlug === "string" && entry.nameSlug ? `${pidKey}:${entry.nameSlug}` : pidKey;
-        map.set(key, entry.filename);
+      if (typeof entry.nameSlug === "string" && entry.nameSlug && typeof entry.filename === "string") {
+        map.set(entry.nameSlug, entry.filename);
       }
     }
     return map;
@@ -127,10 +92,9 @@ export async function refreshCrowdArtworkCache(): Promise<void> {
   if (map) crowdArtworkCache = map;
 }
 
-export function hasCrowdArtwork(vendorId: number, productId: number): boolean {
+export function hasCrowdArtwork(displayName: string): boolean {
   if (!crowdArtworkCache) return false;
-  const hex = (v: number) => v.toString(16).padStart(4, "0");
-  return crowdArtworkCache.has(`${hex(vendorId)}:${hex(productId)}`);
+  return crowdArtworkCache.has(slugifyName(displayName));
 }
 
 function resolveDeviceImageFilename(_device: HIDDevice | null | undefined, displayName = ""): string {
@@ -227,8 +191,28 @@ function resolveDeviceImageFilename(_device: HIDDevice | null | undefined, displ
   if (/\bsora\s*v3\b/i.test(displayName)) return "ninjutso-sora-v3.png";
   if (/\bsora\s*v2\b/i.test(displayName)) return "ninjutso-sora-v2.png";
   if (/\bninjutso\b.*\bten\b/i.test(displayName)) return "ninjutso-ten.png";
-  // Incott reports its model as "Esports G23V2Pro" (see incott/index.ts).
+  // Incott: six model families, each sold in a base and a Pro version with
+  // a different shell finish, so all twelve get their own render. The driver
+  // reads the model from the device and appends "Pro" when the PAW3950 is
+  // fitted (see incott/index.ts), giving names like "Ghero", "G23V2 Pro" or
+  // "Zero 39". Wired with no identity read it falls back to the product
+  // string, "Esports G23V2Pro", which these same patterns match because
+  // every separator is optional.
+  //
+  // Each Pro pattern MUST precede its base model, and the G23V2 pair must
+  // precede the plain G23 pair, or the looser rule swallows the tighter one.
   if (/\bg23\s*v2\s*pro\b/i.test(displayName)) return "incott-g23-v2-pro.png";
+  if (/\bg23\s*v2\b/i.test(displayName)) return "incott-g23-v2.png";
+  if (/\bg23\s*pro\b/i.test(displayName)) return "incott-g23-pro.png";
+  if (/\bg23\b/i.test(displayName)) return "incott-g23.png";
+  if (/\bg24\s*pro\b/i.test(displayName)) return "incott-g24-pro.png";
+  if (/\bg24\b/i.test(displayName)) return "incott-g24.png";
+  if (/\bghero\s*pro\b/i.test(displayName)) return "incott-ghero-pro.png";
+  if (/\bghero\b/i.test(displayName)) return "incott-ghero.png";
+  if (/\bzero\s*29\s*pro\b/i.test(displayName)) return "incott-zero-29-pro.png";
+  if (/\bzero\s*29\b/i.test(displayName)) return "incott-zero-29.png";
+  if (/\bzero\s*39\s*pro\b/i.test(displayName)) return "incott-zero-39-pro.png";
+  if (/\bzero\s*39\b/i.test(displayName)) return "incott-zero-39.png";
   if (/\bkeychron\s*m6\b/i.test(displayName)) return "keychron-m6.png";
   if (/\b(finalmouse|starlight|ulx)\b/i.test(displayName)) return "finalmouse-ulx.png";
   if (/\borbital\b/i.test(displayName)) return "unknown-device.png";
@@ -257,18 +241,13 @@ function resolveDeviceImageFilename(_device: HIDDevice | null | undefined, displ
 const DEVICE_IMAGE_BASE_URL = "https://img.openmouse.app/";
 
 export function deviceImage(device: HIDDevice | null | undefined, displayName = ""): string {
-  // Crowd-sourced artwork takes priority. For a shared VID:PID, a bare
-  // vendorId:productId key would be whichever model someone happened to
-  // upload for and wrong for every other model behind the same id — so those
-  // devices are looked up by vendorId:productId:nameSlug instead (matching
-  // how upload.js keys them), and only served when the reported name
-  // actually matches. No name match falls through to
-  // resolveDeviceImageFilename's own name-based checks, same as it already
-  // does when there's no crowd art at all.
-  if (device && crowdArtworkCache) {
-    const shared = isSharedPidDevice(device);
-    const key = shared ? `${deviceKey(device)}:${slugifyName(displayName)}` : deviceKey(device);
-    const crowdFilename = crowdArtworkCache.get(key);
+  // Crowd-sourced artwork takes priority, looked up by the device's own name
+  // — never by VID:PID, since an id is not always unique to one physical
+  // product. No name (not yet connected/read) or no match falls through to
+  // resolveDeviceImageFilename's name-based checks, same as it already does
+  // when there's no crowd art at all.
+  if (crowdArtworkCache && displayName) {
+    const crowdFilename = crowdArtworkCache.get(slugifyName(displayName));
     if (crowdFilename) return DEVICE_IMAGE_BASE_URL + `crowd/${crowdFilename}`;
   }
   return DEVICE_IMAGE_BASE_URL + resolveDeviceImageFilename(device, displayName);
@@ -309,9 +288,6 @@ export const UNKNOWN_DEVICE_FILENAME = "unknown-device.png";
 
 export function isUnknownDevice(device: HIDDevice | null | undefined, displayName = ""): boolean {
   // If crowd art exists, it's not unknown
-  if (device && crowdArtworkCache) {
-    const crowdFilename = crowdArtworkCache.get(deviceKey(device));
-    if (crowdFilename) return false;
-  }
+  if (crowdArtworkCache && displayName && crowdArtworkCache.has(slugifyName(displayName))) return false;
   return resolveDeviceImageFilename(device, displayName) === UNKNOWN_DEVICE_FILENAME;
 }


### PR DESCRIPTION
Simplifies #259's shared-id list down to just always keying by name — a crowd upload only ever happens against an actively-connected device, so the name is always known at that moment, same as it already is for the built-in art (#261). No id list to remember to update for the next ambiguous device.

- `upload.js`: object key is `{nameSlug}.{ext}`, no vendorId/productId in the request at all.
- `list.js`: returns `nameSlug` + `filename`, nothing else.
- `device-images.ts`: crowd cache keyed by `nameSlug`; `deviceImage()` looks up by `slugifyName(displayName)` — no VID branching, no shared-id set to maintain.
- `artwork-storage.ts`: dropped its entire unused read-cache half (never called anywhere — the real cache lives in `device-images.ts`). Down to just `uploadArtwork(displayName, dataUrl)`.
- `ArtworkUploadDialog.tsx`/`OverviewPage.tsx`: dropped the now-unused vendorId/productId props.

Also folds in #262's Incott per-model image rules (base + Pro render for all six families) adapted to this scheme — that PR's own shared-id-list entry for Incott is no longer needed since the list itself is gone.

`npm run check`: 151/151 tests pass. Bundle size within budget.