### PR TITLE
Disable automatic Discord changelog posts

### DIFF
--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -1,10 +1,11 @@
 name: Discord Changelog
 
+# Disabled 2026-09-12: raw per-push/per-PR posts to #updates were too
+# technical for non-developers to follow (see Florian's feedback in
+# Discord). Replaced with a plain-English daily digest, planned for the
+# following Monday -- until then this workflow only runs on manual trigger.
 on:
-  push:
-    branches: [main]
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Raw per-push/per-PR commit dumps to #updates were too technical for non-developers to follow. Switches the workflow's trigger to manual (`workflow_dispatch`) only, so nothing posts automatically until a plain-English daily digest replaces it (planned for Monday).

No code changes, workflow-trigger only.