### PR TITLE
traits: open the advanced cards for the MCHOSE A7 V3

### DIFF
--- a/src/device/traits.ts
+++ b/src/device/traits.ts
@@ -60,9 +60,10 @@ const BY_FAMILY: Readonly<Record<string, Partial<DriverTraits>>> = {
   // it is not a direct-mode (CompX) driver, so it takes the plain flags.
   mchose: { advancedSection: true, sleep: true, debounce: true },
   "mchose-a5-gen1": { advancedSection: true, sleep: true, debounce: true },
-  // "mchose-v3" is deliberately absent: that driver reads and cannot write, so
-  // every card these flags open would render controls with nothing behind
-  // them. Give it the same flags as `mchose` once it grows setters.
+  // The A7 V3 generation now writes its settings block, so it takes the same
+  // flags as the V2 above. Like it, this is not a direct-mode (CompX) driver:
+  // it publishes its own sleep and debounce option lists.
+  "mchose-v3": { advancedSection: true, sleep: true, debounce: true },
   dareu: { advancedSection: true, sleep: true },
   // Incott supports a 0-30 ms debounce and a 1-900 s sleep timer over its own
   // vendor protocol, not the CompX direct-mode transport, so it takes the


### PR DESCRIPTION
One line, plus the comment it replaces.

> **Depends on [OpenMouse-Project/mouse-protocol#101](https://github.com/OpenMouse-Project/mouse-protocol/pull/101).** Until that lands the V3 driver has no setters, and these flags would open cards with nothing behind them — which is exactly what the comment being removed here said.

The V3 driver now writes its settings block, so `mchose-v3` takes the same flags as the `mchose` entry above it, for the same reason: it is not a direct-mode (CompX) driver and publishes its own sleep and debounce option lists.

Worth knowing before merging: the protocol PR's writes are built to the shape MCHOSE's own software uses and the framing under them is hardware-proven, but **no write has been sent to a real V3 yet**. The driver's status note says so where a user will see it. If you would rather wait for a tester, hold this one with it.

`npm test` (151), `tsc` and `vite build` pass against a local build of the protocol branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
