### PR TITLE
Add top-of-site news banner backed by a CDN-fetched JSON file

### DIFF
--- a/public/news.json
+++ b/public/news.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-razer-mice",
+  "level": "warning",
+  "message": "We are aware of issues with Razer Mice within OpenMouse, we are investigating this issue.",
+  "url": ""
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,6 +8,7 @@ import { CaptureDialog } from "./CaptureDialog";
 import { FeedbackDialog } from "./FeedbackDialog";
 import { InterfaceSettings } from "./InterfaceSettings";
 import { MouseTestPage } from "./MouseTestPage";
+import { NewsBanner } from "./NewsBanner";
 import { PendingBar } from "./PendingBar";
 import { ShareProfileDialog } from "./ShareProfileDialog";
 import { WhatsNewDialog } from "./WhatsNewDialog";
@@ -96,6 +97,7 @@ export function App(): ReactNode {
       ].filter(Boolean).join(" ")}
       data-interface-theme={interfaceThemeSlug(preferences.theme)}
     >
+      <NewsBanner locale={locale} />
       <AppSidebar snapshot={snapshot} page={resolvedPage} onNavigate={navigate} onOpenFeedback={() => setFeedbackOpen(true)} onOpenWhatsNew={() => setWhatsNewOpen(true)} />
 
       <main className="full-desktop-main">

--- a/src/app/NewsBanner.tsx
+++ b/src/app/NewsBanner.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { fetchNews, type NewsItem } from "../news";
+import { t } from "../i18n";
+import type { InterfaceLocale } from "../interface-preferences";
+
+const DISMISSED_STORAGE_KEY = "openmouse.news.dismissed";
+const POLL_INTERVAL_MS = 10 * 60 * 1000;
+
+function dismissedId(): string | null {
+  try {
+    return window.localStorage.getItem(DISMISSED_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function rememberDismissed(id: string): void {
+  try {
+    window.localStorage.setItem(DISMISSED_STORAGE_KEY, id);
+  } catch {
+    /* private mode / storage disabled */
+  }
+}
+
+export function NewsBanner({ locale }: { locale: InterfaceLocale }): ReactNode {
+  const [news, setNews] = useState<NewsItem | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    async function load(): Promise<void> {
+      try {
+        const item = await fetchNews(controller.signal);
+        if (!cancelled) setNews(item && item.id !== dismissedId() ? item : null);
+      } catch {
+        // The CDN being unreachable should never break the app; just skip
+        // the banner for this cycle and try again on the next poll.
+      }
+    }
+
+    void load();
+    const interval = window.setInterval(load, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      controller.abort();
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  if (!news) return null;
+
+  function dismiss(): void {
+    rememberDismissed(news!.id);
+    setNews(null);
+  }
+
+  const body = news.url ? (
+    <a className="news-banner-link" href={news.url} target="_blank" rel="noreferrer">
+      {news.message}
+    </a>
+  ) : (
+    <span className="news-banner-link">{news.message}</span>
+  );
+
+  return (
+    <div className={`news-banner news-banner-${news.level}`} role="status">
+      {body}
+      <button
+        type="button"
+        className="news-banner-dismiss"
+        onClick={dismiss}
+        aria-label={t(locale, "common.close")}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/src/control.css
+++ b/src/control.css
@@ -1077,6 +1077,50 @@ nav { display: grid; gap: .3rem; margin-top: 1.4rem; }
 }
 .control-shell.reduce-interface-motion .apply-bar { transition: none; }
 
+.news-banner {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 1rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--warning) 35%, var(--line));
+  background: color-mix(in srgb, var(--warning) 14%, var(--card));
+  color: var(--bright);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+.news-banner-critical {
+  border-bottom-color: color-mix(in srgb, var(--destructive) 40%, var(--line));
+  background: color-mix(in srgb, var(--destructive) 16%, var(--card));
+}
+.news-banner-info {
+  border-bottom-color: var(--line);
+  background: var(--card);
+}
+.news-banner-link {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: inherit;
+  text-decoration: none;
+}
+.news-banner a.news-banner-link:hover { text-decoration: underline; }
+.news-banner-dismiss {
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding: 0.1rem 0.4rem;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.7;
+}
+.news-banner-dismiss:hover { opacity: 1; background: color-mix(in srgb, currentColor 12%, transparent); }
+
 @keyframes pending-bar-pulse { 0%, 100% { box-shadow: 0 0 0 3px var(--ui-accent-soft); } 50% { box-shadow: 0 0 0 6px transparent; } }
 
 @media (min-width: 900px) {

--- a/src/news.ts
+++ b/src/news.ts
@@ -1,0 +1,37 @@
+/** Site-wide news banner. The message itself lives outside this repo's
+    build — it is fetched from a CDN mirror of `public/news.json` so an
+    announcement (an outage, a known-issue notice) can go out instantly
+    without shipping a new app build. See `public/news.json` for the source
+    file and how to publish an instant update. */
+
+export type NewsLevel = "info" | "warning" | "critical";
+
+export interface NewsItem {
+  id: string;
+  level: NewsLevel;
+  message: string;
+  url?: string;
+}
+
+interface NewsResponse {
+  id?: unknown;
+  level?: unknown;
+  message?: unknown;
+  url?: unknown;
+}
+
+const NEWS_URL = "https://cdn.jsdelivr.net/gh/OpenMouse-Project/openmouse@main/public/news.json";
+
+const LEVELS: NewsLevel[] = ["info", "warning", "critical"];
+
+export async function fetchNews(signal?: AbortSignal): Promise<NewsItem | null> {
+  const response = await fetch(NEWS_URL, { signal, cache: "no-store" });
+  if (!response.ok) throw new Error(`News CDN returned HTTP ${response.status}.`);
+  const body = await response.json() as NewsResponse;
+  const id = typeof body.id === "string" ? body.id.trim() : "";
+  const message = typeof body.message === "string" ? body.message.trim() : "";
+  if (!id || !message) return null;
+  const level: NewsLevel = LEVELS.includes(body.level as NewsLevel) ? (body.level as NewsLevel) : "info";
+  const url = typeof body.url === "string" && body.url.trim() ? body.url.trim() : undefined;
+  return { id, level, message, url };
+}


### PR DESCRIPTION
Adds a dismissible banner at the top of the app that fetches its message from `public/news.json` via jsdelivr's GitHub CDN mirror, so an announcement (outage, known issue, etc.) can go out instantly by editing that file and purging the CDN cache — no app rebuild needed.

Seeded with a notice about known Razer mice issues.

