### PR TITLE
News banner: place above sidebar/main, shrink height, add level icons

### DIFF
--- a/src/app/NewsBanner.tsx
+++ b/src/app/NewsBanner.tsx
@@ -1,7 +1,14 @@
+import { AlertTriangle, Info, OctagonAlert, type LucideIcon } from "lucide-react";
 import { useEffect, useState, type ReactNode } from "react";
-import { fetchNews, type NewsItem } from "../news";
+import { fetchNews, type NewsItem, type NewsLevel } from "../news";
 import { t } from "../i18n";
 import type { InterfaceLocale } from "../interface-preferences";
+
+const LEVEL_ICON: Record<NewsLevel, LucideIcon> = {
+  info: Info,
+  warning: AlertTriangle,
+  critical: OctagonAlert,
+};
 
 const DISMISSED_STORAGE_KEY = "openmouse.news.dismissed";
 const POLL_INTERVAL_MS = 10 * 60 * 1000;
@@ -62,9 +69,11 @@ export function NewsBanner({ locale }: { locale: InterfaceLocale }): ReactNode {
   ) : (
     <span className="news-banner-link">{news.message}</span>
   );
+  const Icon = LEVEL_ICON[news.level];
 
   return (
     <div className={`news-banner news-banner-${news.level}`} role="status">
+      <Icon className="news-banner-icon" size={15} strokeWidth={2.2} aria-hidden="true" />
       {body}
       <button
         type="button"

--- a/src/control.css
+++ b/src/control.css
@@ -608,7 +608,7 @@ button:focus-visible, a:focus-visible, input:focus-visible { outline: 2px solid 
 }
 .control-shell button:focus-visible, .control-shell select:focus-visible, .control-shell input:focus-visible { outline: 2px solid var(--ui-accent); outline-offset: 2px; }
 
-.control-shell { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 100vh; }
+.control-shell { display: grid; grid-template-columns: 260px minmax(0, 1fr); grid-template-rows: auto 1fr; min-height: 100vh; }
 .control-shell.sidebar-hidden { grid-template-columns: minmax(0, 1fr); }
 .control-shell.sidebar-hidden .sidebar { display: none; }
 
@@ -1079,15 +1079,15 @@ nav { display: grid; gap: .3rem; margin-top: 1.4rem; }
 
 .news-banner {
   display: flex;
-  grid-column: 1 / -1;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.55rem 1rem;
+  gap: 0.5rem;
+  padding: 0.3rem 0.85rem;
   border-bottom: 1px solid color-mix(in srgb, var(--warning) 35%, var(--line));
   background: color-mix(in srgb, var(--warning) 14%, var(--card));
   color: var(--bright);
-  font-size: 0.8rem;
+  font-size: 0.72rem;
   font-weight: 600;
+  line-height: 1.3;
 }
 .news-banner-critical {
   border-bottom-color: color-mix(in srgb, var(--destructive) 40%, var(--line));
@@ -1097,6 +1097,12 @@ nav { display: grid; gap: .3rem; margin-top: 1.4rem; }
   border-bottom-color: var(--line);
   background: var(--card);
 }
+.news-banner-icon {
+  flex: 0 0 auto;
+  color: var(--warning);
+}
+.news-banner-critical .news-banner-icon { color: var(--destructive); }
+.news-banner-info .news-banner-icon { color: var(--info); }
 .news-banner-link {
   min-width: 0;
   overflow: hidden;
@@ -1114,7 +1120,7 @@ nav { display: grid; gap: .3rem; margin-top: 1.4rem; }
   border-radius: 6px;
   background: transparent;
   color: inherit;
-  font-size: 1rem;
+  font-size: 0.95rem;
   line-height: 1;
   cursor: pointer;
   opacity: 0.7;
@@ -2094,10 +2100,11 @@ body { height: 100vh; overflow: hidden; }
 
 /* .control-shell is a two-column grid: 56px rail + content. The sidebar is
    grid child #1; full-desktop-main takes child #2 and holds the scroller. */
-.control-shell > .app-sidebar { grid-column: 1; grid-row: 1; }
+.control-shell > .news-banner { grid-column: 1 / -1; grid-row: 1; }
+.control-shell > .app-sidebar { grid-column: 1; grid-row: 2; }
 .control-shell > .full-desktop-main {
   grid-column: 2;
-  grid-row: 1;
+  grid-row: 2;
   position: relative;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Fixes the news banner rendering off-screen at the bottom (grid row conflict with sidebar/main), shrinks its height, and adds a lucide icon per severity level (info/warning/critical).