### PR TITLE
Razer: name the Windows-reinstalled legacy HID driver in the error

### DIFF
--- a/src/device/controller.ts
+++ b/src/device/controller.ts
@@ -1951,12 +1951,36 @@ async function requestSupportedClient(): Promise<SupportedClient | null> {
     if (probed) return probed;
   }
 
+  // Seen repeatedly since a wave of Windows Update pushes reinstalled a legacy
+  // "Razer common" HID driver (reports as an old 10.0.x or 6.2.9600 driver in
+  // Device Manager) that binds ahead of the generic HID class driver and
+  // claims the mouse's vendor collection for itself. Chrome then never gets
+  // that collection offered at all -- only the boot-mouse/consumer-control
+  // leftovers -- so every Razer model breaks at once with no app change and
+  // no Synapse process running (resolves as "not a supported control
+  // interface" with zero usable candidates rather than a probe failure).
+  // Uninstalling the driver from Device Manager isn't enough on its own if
+  // Windows Update just reinstalls it on the next scan/reboot; the driver
+  // package has to be removed from the driver store (pnputil /delete-driver
+  // with /uninstall, matched against the oem*.inf reported by
+  // `pnputil /enum-drivers`) or driver updates blocked for that device.
+  const razerVendorCollectionSeen = razerCandidates.some((device) =>
+    device.collections.some((collection) => collection.usagePage === 0x01 && collection.usage === 0x02));
+  const windowsDriverHint = probedRazer && !razerVendorCollectionSeen
+    ? " This looks like a Windows Update-reinstalled legacy Razer HID driver claiming the mouse's "
+      + "control interface exclusively (check Device Manager for a 'Razer' entry under Human Interface "
+      + "Devices with an old driver date/version, then remove it from the driver store with "
+      + "`pnputil /delete-driver <oemN.inf> /uninstall /force` so Windows Update can't silently put it "
+      + "back) rather than something this app can fix."
+    : "";
+
   throw new Error(
     `Selected device is not a supported control interface (${details})`
     + (probedRazer ? ` [probed ${razerCandidates.length} Razer collection(s), none answered]` : "")
     + `. `
     + "Pick a vendor control interface (not a plain boot mouse). "
-    + "If this keeps failing, note the VID/PID from this message.",
+    + "If this keeps failing, note the VID/PID from this message."
+    + windowsDriverHint,
   );
 }
 


### PR DESCRIPTION
Follow-up to #258. Issue #253/#166's symptom (zero Razer vendor collections granted, no Synapse running) is a Windows Update-reinstalled legacy Razer HID driver claiming the control interface exclusively, not something the app's shape/probe logic can recover from. This surfaces that specific cause and the actual fix (pnputil driver-store removal, not just Device Manager uninstall) instead of the generic error.

Claude-Session: https://claude.ai/code/session_01XbYSu8D3cu3c7vbEyJbacn